### PR TITLE
fix: repair release workflow — sign step if condition causes validation failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }}
 
     steps:
       - uses: actions/checkout@v4
@@ -30,8 +32,8 @@ jobs:
         run: npm run build
 
       - name: Sign plugin
+        if: ${{ env.GRAFANA_API_KEY != '' }}
         run: npm run sign
-        if: ${{ secrets.GRAFANA_API_KEY != '' }}
         env:
           GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }}
 


### PR DESCRIPTION
## Problem

The release workflow has been broken since the initial commit. Every branch push logged a 0-second **workflow file issue** failure, and — critically — the workflow **never triggered on tag pushes**, so no release was ever built automatically.

Root cause: the sign step used `if: ${{ secrets.GRAFANA_API_KEY != '' }}`. GitHub Actions evaluates `secrets` context during static workflow validation for non-tag pushes, which fails because secrets are not available at that phase.

## Fix

Move `GRAFANA_API_KEY` to a job-level `env` block (where it is set from the secret once at runtime), then reference it in the step `if` via `env` context:

```yaml
jobs:
  release:
    env:
      GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }}
    steps:
      - name: Sign plugin
        if: ${{ env.GRAFANA_API_KEY != '' }}
        run: npm run sign
        env:
          GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }}
```

This makes the `if` expression safe to evaluate at validation time (env vars are known), while the sign step still only executes when the secret is actually configured.

## Testing
After merge, push a new tag matching `v*.*.*` to verify the release workflow triggers and completes.

Closes #29

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix release workflow by moving `GRAFANA_API_KEY` to a job-level env and checking it via `env` in the sign step. This removes validation errors on branch pushes and restores tag-triggered releases.

<sup>Written for commit 091e37fde8b7c0ac9d0dac8650f196f59c72b58d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

