### PR TITLE
fix: correct hardcoded plugin ID in icon path and update docs links

### DIFF
--- a/src/forms/NodeForm.tsx
+++ b/src/forms/NodeForm.tsx
@@ -117,7 +117,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
       };
     } else {
       weathermap.nodes[i].nodeIcon!.src =
-        icon === 'custom_icon' ? '' : 'public/plugins/knightss27-weathermap-panel/icons/' + icon + '.svg';
+        icon === 'custom_icon' ? '' : 'public/plugins/tamirsuliman-weathermap-panel/icons/' + icon + '.svg';
       weathermap.nodes[i].nodeIcon!.name = icon;
 
       if (weathermap.nodes[i].nodeIcon!.size.width === 0) {

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -1,19 +1,19 @@
 # FAQ
 
 - Q: I am using the Zabbix datasource and the only option in the query selection dropdown is "wide"?
-    - In the Zabbix datasource settings, please try turning off the "data alignment" property, you may also get this to work for a specific query by disabling data alignment under the query's "Options" section. Taken from [Issue #28](https://github.com/knightss27/grafana-network-weathermap/issues/28).
+    - In the Zabbix datasource settings, please try turning off the "data alignment" property, you may also get this to work for a specific query by disabling data alignment under the query's "Options" section.
 
 - Q: I am using the Zabbix datasource and can only select one of my queries (but it is labeled properly)?
-    - Try selecting multiple Zabbix "Items" through one Grafana query by using Regex in the "Item" area of the query editor. Taken from [Issue #38](https://github.com/knightss27/grafana-network-weathermap/issues/38).
+    - Try selecting multiple Zabbix "Items" through one Grafana query by using Regex in the "Item" area of the query editor.
 
 - Q: I am unable to select one of my data queries, even though it shows up in the query selection dropdown. What's happening?
     - See the note on: [Adding Data](/#adding-data).
 
 - Q: Can I upload an image as a background? Will this be added as a feature?
-    - Yes you can now! For node icons as well. You simple have to host the image somewhere and can insert the URL into the image box under the panel customization.
+    - Yes you can now! For node icons as well. You simply have to host the image somewhere and can insert the URL into the image box under the panel customization.
 
 - Q: Plugin is throwing `toReturn.source is undefined`?
-    - Just reload or force reload the page. I have yet to properly track down this bug, but rest assured it seems to only occur directly after saving and applying your changes and can be easily fixed.
+    - Just reload or force reload the page. This seems to only occur directly after saving and applying changes and can be fixed with a page reload.
 
 
-Other problems and you're somehow on this page before Github? [Leave a new issue!](https://github.com/knightss27/grafana-network-weathermap/issues)
+Other problems? [Leave a new issue!](https://github.com/allamiro/grafana-network-weathermap-ng/issues)


### PR DESCRIPTION
## Changes

### Bug fix — broken node icons (critical)

`src/forms/NodeForm.tsx` had the original plugin's ID hardcoded in the Grafana static asset path:

```ts
// Before (broken)
'public/plugins/knightss27-weathermap-panel/icons/' + icon + '.svg'

// After (correct)
'public/plugins/tamirsuliman-weathermap-panel/icons/' + icon + '.svg'
```

Any node configured with a built-in icon would silently fail with a 404 because Grafana serves plugin assets under `public/plugins/<plugin-id>/`. This has been broken since the plugin was renamed.

### Docs — FAQ link cleanup

`website/docs/faq.md` linked to issues in the original archived repo. Updated to point to this repo's issue tracker and removed the specific old issue references (the answers still stand, the linked issues no longer accept comments).

## Issues closed

Closes #40

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken built-in node icons by updating the Grafana plugin asset path to the current plugin ID. Also updates FAQ links to point to this repo.

- **Bug Fixes**
  - In `src/forms/NodeForm.tsx`, replaced `public/plugins/knightss27-weathermap-panel/...` with `public/plugins/tamirsuliman-weathermap-panel/...` to restore icon loading and prevent 404s.

- **Docs**
  - Updated `website/docs/faq.md` to link to this repo’s issues, removed references to archived issues, and made small copy edits.

<sup>Written for commit 679f2193da249efda3bc08673e5cb4df3bef688b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/41?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

