### PR TITLE
feat: add manual trigger to docs deploy workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'website/**'
       - '.github/workflows/docs.yml'
+  workflow_dispatch:
 
 jobs:
   deploy-docs:


### PR DESCRIPTION
Adds `workflow_dispatch` so the GitHub Pages docs build can be triggered manually from the Actions tab without needing to push a website file change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables manual runs for the docs deploy workflow by adding `workflow_dispatch` to `.github/workflows/docs.yml`. This lets us trigger a GitHub Pages build from the Actions tab without committing website changes.

<sup>Written for commit aff0ef83b898d9c8f0b436335f561701819e38ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/82?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

