### PR TITLE
ci: switch docs deployment to official GitHub Pages Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,28 +9,45 @@ on:
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 jobs:
-  deploy-docs:
-    name: Deploy docs
+  build:
+    name: Build docs
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
-      - name: Checkout main
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
-      - name: Install mkdocs
+      - name: Install mkdocs-material
         run: pip install mkdocs-material
 
       - name: Build with mkdocs
         run: cd website && mkdocs build
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: website/site/
+          path: website/site/
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Replaces `peaceiris/actions-gh-pages` with `actions/upload-pages-artifact` + `actions/deploy-pages`
- Splits the single job into **build** + **deploy** jobs; deploy is pinned to the `github-pages` environment
- Uses top-level `permissions: pages: write, id-token: write` (required by `deploy-pages`)
- Adds `concurrency` guard so parallel workflow runs don't race

## Why

The `peaceiris` action just pushes to the `gh-pages` branch — it creates no GitHub Environment, so no "Deployments" section appears in the repo sidebar. The official `actions/deploy-pages` creates the `github-pages` Environment, which makes the live site URL appear under **Deployments** in the sidebar (the same way it shows on other Grafana plugin repos).

**Note:** Pages source has already been switched to `workflow` build type via the API — this PR must be merged before the next docs deployment will succeed.

## Test plan

- [ ] Merge and confirm the "Build Documentation" workflow completes successfully
- [ ] "Deployments → github-pages" section appears in the repo sidebar
- [ ] Live site at `https://allamiro.github.io/grafana-network-weathermap-ng/` still loads correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch docs deployment from `peaceiris/actions-gh-pages` to the official `actions/upload-pages-artifact` + `actions/deploy-pages`. This creates the `github-pages` environment and shows the live URL under Deployments.

- **Refactors**
  - Split workflow into `build` and `deploy` jobs; `deploy` targets the `github-pages` environment and exposes the page URL.
  - Added top-level permissions: `contents: read`, `pages: write`, `id-token: write`.
  - Upload built site from `website/site/` using `actions/upload-pages-artifact@v3`.
  - Added `concurrency` guard to prevent parallel deploy races.

- **Migration**
  - Pages source is already set to workflow; merge to enable the next deploy.
  - After merge, confirm Deployments → `github-pages` appears and the site at https://allamiro.github.io/grafana-network-weathermap-ng/ still loads.

<sup>Written for commit 0162612b176c8e2833d4a6d281280a87a2a22c56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

