### PR TITLE
fix: remove hardcoded line-height 0px causing color scale label overlap

### DIFF
--- a/src/components/ColorScale.tsx
+++ b/src/components/ColorScale.tsx
@@ -121,7 +121,8 @@ const getStyles = () => {
       margin-right: 5px;
     `,
     colorLabel: css`
-      line-height: 0px;
+      line-height: normal;
+      white-space: nowrap;
     `,
   };
 };


### PR DESCRIPTION
## Summary

Fixes #44

 had `line-height: 0px` hardcoded on the `.colorLabel` class. This collapsed all threshold labels onto the same baseline, causing them to visually overlap when thresholds were close together.

**Root cause:** `line-height: 0px` eliminates vertical spacing from the text's line box, so adjacent labels at different thresholds stack on top of each other.

**Fix:** Set `line-height: normal` (inherits from the theme) and add `white-space: nowrap` to prevent label text from wrapping mid-percentage-range.

## Changed file
- `src/components/ColorScale.tsx` line 123–125

## Test plan
- [ ] Add a color scale with 4+ thresholds close together (e.g. 20%, 30%, 40%, 50%)
- [ ] Confirm each threshold label renders on its own line without overlapping
- [ ] Confirm build passes (`npm run build`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix overlapping color scale labels by replacing `line-height: 0px` with `line-height: normal` and adding `white-space: nowrap` in `src/components/ColorScale.tsx`. Labels now keep their own line and don’t wrap mid-value, even when thresholds are close.

<sup>Written for commit 410155277fc2aa25ff364a7e966c31359735ff39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

