### PR TITLE
fix: re-enable JSON export in ExportForm

### DIFF
--- a/src/forms/ExportForm.tsx
+++ b/src/forms/ExportForm.tsx
@@ -45,15 +45,10 @@ export const ExportForm = ({ value, onChange }: Props) => {
     generateDownloadLink(svgUrl, `network-weathermap-${new Date().toISOString()}.svg`);
   };
 
-  // const handleJSONExport = () => {
-  //   let weathermap: any = Object.assign({}, value);
-  //   weathermap.links = weathermap.links.map((link: Link) => {
-  //     return [link.nodes[0].id, link.nodes[1].id];
-  //   });
-
-  //   const data = 'data:text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(weathermap));
-  //   generateDownloadLink(data, 'network-weathermap.json');
-  // };
+  const handleJSONExport = () => {
+    const data = 'data:text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(value, null, 2));
+    generateDownloadLink(data, `network-weathermap-${new Date().toISOString()}.json`);
+  };
 
   if (value) {
     return (
@@ -62,9 +57,9 @@ export const ExportForm = ({ value, onChange }: Props) => {
           <Button onClick={handleSVGExport} className={styles.exportButton}>
             Export SVG
           </Button>
-          {/* <Button onClick={handleJSONExport} className={styles.exportJSONButton}>
+          <Button onClick={handleJSONExport} className={styles.exportJSONButton}>
             Export JSON
-          </Button> */}
+          </Button>
         </InlineFieldRow>
       </React.Fragment>
     );


### PR DESCRIPTION
## Summary

Fixes #52

The `handleJSONExport` function and its button were both commented out in `ExportForm.tsx`, making JSON export silently unavailable.

**Root cause:** The original code was disabled, likely because the lossy implementation (stripping links to bare node ID pairs) was incomplete and would produce unusable exports.

**Fix:** Restored the button and replaced the handler with a clean full-config export: `JSON.stringify(value, null, 2)` serializes the complete `Weathermap` object, including all node positions, link configs, thresholds, and settings. The filename includes an ISO timestamp to avoid collisions.

## Changed file
- `src/forms/ExportForm.tsx`

## Test plan
- [ ] Open a panel with a configured weathermap
- [ ] Open panel editor → Export tab
- [ ] Confirm both **Export SVG** and **Export JSON** buttons are visible
- [ ] Click **Export JSON** — confirm a `.json` file downloads containing the full weathermap config
- [ ] Confirm build passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enables JSON export in `ExportForm` and replaces the lossy handler with a full-config export. The Export JSON button is visible again and downloads pretty-printed `Weathermap` JSON with an ISO timestamped filename. Fixes #52.

<sup>Written for commit 3a373259e90319036e5a42891de267b11d4b4ebc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

