### PR TITLE
fix: guard against NaN and negative values from rate/increase queries

### DIFF
--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -259,12 +259,28 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
         let resolvedValue: number;
         if (useAvg && fieldValues.length > 0) {
           let sum = 0;
+          let count = 0;
           for (let vi = 0; vi < fieldValues.length; vi++) {
-            sum += fieldValues[vi];
+            const v = fieldValues[vi];
+            if (v !== null && !isNaN(v)) {
+              sum += Math.max(0, v);
+              count++;
+            }
           }
-          resolvedValue = sum / fieldValues.length;
+          resolvedValue = count > 0 ? sum / count : 0;
         } else {
-          resolvedValue = fieldValues[fieldValues.length - 1];
+          // Walk back to find the last non-NaN value; rate() produces NaN on
+          // the first sample and increase() can produce negative values on
+          // counter resets — treat both as 0.
+          let lastValid = 0;
+          for (let vi = fieldValues.length - 1; vi >= 0; vi--) {
+            const v = fieldValues[vi];
+            if (v !== null && !isNaN(v)) {
+              lastValid = Math.max(0, v);
+              break;
+            }
+          }
+          resolvedValue = lastValid;
         }
         dataFrameWithIds.push({
           value: resolvedValue,


### PR DESCRIPTION
## Summary

Fixes #51

`rate()` returns `NaN` on the first sample because there is no prior data point to calculate a rate from. `increase()` returns negative values on Prometheus counter resets. Both produced incorrect display values (NaN or wrong numbers) on weathermap links.

**Last-value mode** — previously took `fieldValues[fieldValues.length - 1]` directly, which could be `NaN`. Now walks backwards to find the last non-null, non-NaN value. Negative values (counter reset artifacts) are clamped to `0`.

**Average mode** — previously included NaN in the sum/count calculation, producing NaN for the average. Now skips null/NaN values entirely, divides only over valid sample count, and clamps negatives to `0`.

## Changed file
- `src/WeathermapPanel.tsx` — value extraction in `buildLink`

## Test plan
- [ ] Create a Prometheus `rate()` query; confirm links show `0` instead of `NaN` on first panel load
- [ ] Create a Prometheus `increase()` query on a counter that resets; confirm no negative values appear on links
- [ ] Confirm normal queries (gauge/counter without reset) still display correct values
- [ ] Confirm build passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents NaN and negative values from `rate()`/`increase()` from breaking weathermap link values. Last-value and average modes now ignore invalid samples and clamp negatives to 0 for stable display.

- **Bug Fixes**
  - Last-value mode: walks backward to the last valid value; skips null/NaN; clamps negatives to 0; falls back to 0 if none found.
  - Average mode: excludes null/NaN from sum and count; divides by valid count only; clamps negatives to 0; returns 0 if no valid samples.

<sup>Written for commit c2dc2d4447f3c240bd170eb3efbb41a2c2ad39de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

