### PR TITLE
fix: tooltip appears at wrong position relative to cursor

### DIFF
--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -586,9 +586,12 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
           <div
             className={css`
               position: absolute;
-              top: ${hoveredLink.mouseY}px;
-              left: ${hoveredLink.mouseX}px;
-              transform: translate(0%, -100%);
+              top: ${hoveredLink.mouseY - 10}px;
+              left: ${hoveredLink.mouseX + 14}px;
+              transform: translate(
+                ${hoveredLink.mouseX > width2 * 0.65 ? '-100%' : '0%'},
+                ${hoveredLink.mouseY < 120 ? '0%' : '-100%'}
+              );
               pointer-events: none;
               background-color: ${wm.settings.tooltip.backgroundColor};
               color: ${wm.settings.tooltip.textColor} !important;


### PR DESCRIPTION
## Summary

Fixes #43

The link hover tooltip was positioned with `top: mouseY, left: mouseX, transform: translate(0%, -100%)` which placed its bottom-left corner exactly at the cursor hotspot. This caused the tooltip to:
- Cover the link being hovered (cursor sits under the tooltip)
- Overflow the top of the panel when hovering links near the top edge
- Overflow the right edge of the panel when hovering links on the right side

**Fix:**
- Offset 14px right and 10px above the cursor so the tooltip always clears the cursor arrow and the hovered link
- When the cursor is in the right 65% of the panel, flip the tooltip to the left (`translate(-100%, ...)`) so it never overflows the right edge
- When the cursor is within 120px of the top edge, flip the tooltip downward (`translate(..., 0%)`) so it never overflows above the panel

## Changed file
- `src/WeathermapPanel.tsx` — tooltip positioning in the JSX render

## Test plan
- [ ] Hover a link in the center of the panel — tooltip appears to the upper-right of the cursor
- [ ] Hover a link near the right edge — tooltip flips left, stays within panel bounds
- [ ] Hover a link near the top edge — tooltip appears below the cursor, stays within panel bounds
- [ ] Confirm tooltip text is readable and not obscured by the cursor

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tooltip positioning so it no longer covers the hovered link and always stays within the panel. Adds cursor-relative offsets and edge-aware flipping.

- **Bug Fixes**
  - Offset tooltip 14px right and 10px up from the cursor.
  - Flip left when the cursor is in the right 65% of the panel to prevent right overflow.
  - Flip down when the cursor is within 120px of the top to prevent top overflow.

<sup>Written for commit 554b82511bc9235ec481fe6fe0a3aa25c4fab22e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

