### PR TITLE
fix: link strokes disappear due to -Infinity coordinates and direct mutation

### DIFF
--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -174,6 +174,8 @@ test('Check edit mode display', () => {
   fireEvent.wheel(container.querySelector('#nw-testing_')!, { deltaY: 1 });
   expect(testProps.options.weathermap.settings.panel.zoomScale).not.toEqual(0);
 
+  // Re-render with updated options so the component sees the new zoomScale
+  rerender(<WeathermapPanel {...testProps} />);
   fireEvent.wheel(container.querySelector('#nw-testing_')!, { deltaY: -1 });
   expect(testProps.options.weathermap.settings.panel.zoomScale).toEqual(0);
 

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -178,13 +178,14 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
         ? nearestMultiple(d.y, wm.settings.panel.grid.size)
         : y;
 
-    // The maximum link width on this anchor point
-    const maxLinkWidth = Math.max(
-      ...wm.links
-        .filter((l) => l.nodes[0].id === d.id || l.nodes[1].id === d.id)
-        .filter((l) => side.anchor === l.sides.A.anchor || l.sides.Z.anchor === side.anchor)
-        .map((l) => l.stroke)
-    );
+    // The maximum link width on this anchor point.
+    // Math.max(...[]) returns -Infinity for empty arrays, which corrupts
+    // coordinates — default to 0 so positions stay finite.
+    const anchorStrokes = wm.links
+      .filter((l) => l.nodes[0].id === d.id || l.nodes[1].id === d.id)
+      .filter((l) => side.anchor === l.sides.A.anchor || l.sides.Z.anchor === side.anchor)
+      .map((l) => l.stroke);
+    const maxLinkWidth = anchorStrokes.length > 0 ? Math.max(...anchorStrokes) : 0;
 
     // Change x values for left/right anchors
     if (side.anchor === Anchor.Left || side.anchor === Anchor.Right) {
@@ -441,15 +442,15 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
       return;
     }
 
-    let zoomed: Weathermap = wm;
-
-    if (e.deltaY > 0) {
-      zoomed.settings.panel.zoomScale += 1;
-    } else {
-      zoomed.settings.panel.zoomScale -= 1;
-    }
+    const delta = e.deltaY > 0 ? 1 : -1;
     onOptionsChange({
-      weathermap: zoomed,
+      weathermap: {
+        ...wm,
+        settings: {
+          ...wm.settings,
+          panel: { ...wm.settings.panel, zoomScale: wm.settings.panel.zoomScale + delta },
+        },
+      },
     });
   };
 


### PR DESCRIPTION
## Summary

Fixes #45 — bandwidth/stroke lines randomly disappear on links
Fixes #50 — link strokes disappear after panel re-render

**Root cause 1 — `-Infinity` link coordinates (primary cause)**

`getMultiLinkPosition` used `Math.max(...array)` where `array` could be empty when a node has no links on a specific anchor (e.g. Center anchor with no links, or after a reconfiguration). `Math.max(...[])` evaluates as `Math.max()` which returns `-Infinity`. This `-Infinity` then propagated into `x` / `y` coordinate arithmetic, producing `-Infinity` for `lineStartA.x`, etc. SVG silently ignores elements with non-finite coordinates, making the stroke invisible. Reloading recreated the state and happened to avoid the empty-array case.

**Fix:** Compute the strokes array first; if it's empty, default `maxLinkWidth` to `0` instead of spreading into `Math.max`.

**Root cause 2 — direct mutation of `wm` in zoom handler**

`let zoomed = wm` is a reference alias, not a copy. Mutating `zoomed.settings.panel.zoomScale` mutated the live `options.weathermap` object in-place, bypassing React's change detection. This could cause subsequent `useEffect` hooks (which diff by reference) to not fire, leaving `links` state geometry stale while the SVG `viewBox` updated.

**Fix:** Use object spread to produce a proper new object graph before calling `onOptionsChange`.

## Changed file
- `src/WeathermapPanel.tsx` — `getMultiLinkPosition` and `zoom` handler

## Test plan
- [ ] Create a map with nodes that have links on only some anchors — confirm all strokes remain visible
- [ ] Zoom in/out with mouse wheel — confirm strokes remain visible throughout
- [ ] Change time range — confirm strokes remain visible after data refresh
- [ ] Confirm build passes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes disappearing link strokes by preventing -Infinity coordinates and avoiding in-place state mutation during zoom. Updates `WeathermapPanel.test.tsx` to rerender between zoom events to reflect the new immutable zoom updates.

- **Bug Fixes**
  - `getMultiLinkPosition`: handle empty stroke arrays; default `maxLinkWidth` to 0 so coordinates stay finite.
  - Zoom handler: create a new `weathermap` via spread instead of mutating `wm`, so React detects changes and recalculates link geometry.

<sup>Written for commit fe5d27e2515b8908822782bf199ad3a9ac204e19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

