### PR TITLE
fix: support non-standard datasources by using first numeric field

### DIFF
--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -31,6 +31,7 @@ import {
   CURRENT_VERSION,
   handleVersionedStateUpdates,
   getDataFrameName,
+  getValueField,
 } from 'utils';
 import MapNode from './components/MapNode';
 import ColorScale from 'components/ColorScale';
@@ -256,7 +257,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
         return;
       }
       try {
-        const fieldValues = frame.fields[1].values;
+        const fieldValues = getValueField(frame).values;
         let resolvedValue: number;
         if (useAvg && fieldValues.length > 0) {
           let sum = 0;

--- a/src/forms/LinkForm.tsx
+++ b/src/forms/LinkForm.tsx
@@ -16,7 +16,7 @@ import { SelectableValue, StandardEditorProps } from '@grafana/data';
 import { v4 as uuidv4 } from 'uuid';
 import { Weathermap, Node, Link, Anchor, LinkSide } from 'types';
 import { FormDivider } from './FormDivider';
-import { getDataFrameName } from 'utils';
+import { getDataFrameName, getValueField } from 'utils';
 
 interface Settings {
   placeholder: string;
@@ -198,7 +198,7 @@ export const LinkForm = (props: Props) => {
         seenNames.add(name);
         // Build a concise label: "refId: fieldName" so the dropdown stays
         // readable even when Grafana appends full label sets to the display name.
-        const fieldName = d.fields[1].name || name;
+        const fieldName = getValueField(d).name || name;
         const label = d.refId ? `${d.refId}: ${fieldName}` : fieldName;
         dataWithIds.push({ value: name, label });
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { DataFrame, GrafanaTheme2, getFieldDisplayName } from '@grafana/data';
+import { DataFrame, Field, FieldType, GrafanaTheme2, getFieldDisplayName } from '@grafana/data';
 import merge from 'lodash.merge';
 import { Anchor, DrawnNode, Link, Node, Weathermap } from 'types';
 import { v4 as uuidv4 } from 'uuid';
@@ -361,6 +361,23 @@ export function handleVersionedStateUpdates(wm: Weathermap, theme: GrafanaTheme2
   return wm;
 }
 
+/**
+ * Returns the first numeric field in a data frame, falling back to fields[1].
+ * Non-standard datasources (Check MK, etc.) may not put the value at index 1 —
+ * they may omit the time field, reorder fields, or return table-style frames.
+ */
+export function getValueField(frame: DataFrame): Field {
+  const numeric = frame.fields.find((f) => f.type === FieldType.number);
+  if (numeric) {
+    return numeric;
+  }
+  // Fallback: use fields[1] for time-series frames (time at 0, value at 1)
+  if (frame.fields.length >= 2) {
+    return frame.fields[1];
+  }
+  throw new Error(`No value field found in frame "${frame.name}"`);
+}
+
 export const getDataFrameName = (frame: DataFrame, allFrames: DataFrame[]): string => {
-  return getFieldDisplayName(frame.fields[1], frame);
+  return getFieldDisplayName(getValueField(frame), frame);
 };


### PR DESCRIPTION
## Summary

Fixes #53

The plugin hardcoded `frame.fields[1]` to read metric values from every data frame, assuming all sources follow the standard Grafana time-series layout (`fields[0]` = time, `fields[1]` = value). Datasources like Check MK, table queries, and other non-standard sources may:

- Omit the time field entirely (value is at `fields[0]`)
- Return additional metadata fields before the value field
- Return table-style frames with arbitrary field ordering

This caused all links using those datasources to display `n/a` even when data was returned.

**Fix:** Added `getValueField(frame)` helper in `utils.ts` that searches for the first `FieldType.number` field in the frame, with a fallback to `fields[1]` for standard time-series frames. Used in all three locations that previously hardcoded index 1:

| File | Change |
|---|---|
| `utils.ts` — `getDataFrameName` | Uses `getValueField` for display name (determines stored query ID) |
| `WeathermapPanel.tsx` — `generateDrawnLink` | Uses `getValueField` for value extraction |
| `forms/LinkForm.tsx` — dropdown label | Uses `getValueField` for field name display |

## Test plan
- [ ] Configure a link with a standard Prometheus/InfluxDB query — confirm values still display correctly
- [ ] Configure a link with a Check MK or table datasource — confirm values now display instead of n/a
- [ ] Confirm build and all tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes value extraction for non-standard datasources by selecting the first numeric field instead of assuming the value is at fields[1]. Restores correct link values for Check MK and table-style queries that previously showed n/a.

- **Bug Fixes**
  - Added getValueField(frame): finds the first numeric field (`FieldType.number`), falls back to fields[1], throws if none found.
  - Applied in utils.ts (getDataFrameName), WeathermapPanel.tsx (value extraction), and forms/LinkForm.tsx (dropdown labels).
  - Keeps standard Prometheus/InfluxDB behavior unchanged.

<sup>Written for commit 5b8bff3b060621841b8eb7805c4b5dadd0ff4322. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

