### PR TITLE
chore(release): v1.1.1 — security patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.1.1](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.1.1) (2026-06-09)
+
+### Security
+
+* resolve all npm audit CVEs — 0 vulnerabilities remaining ([#96](https://github.com/allamiro/grafana-network-weathermap-ng/pull/96))
+  * `form-data` critical — resolved via `npm audit fix`
+  * `protobufjs` critical — resolved via `npm audit fix`
+  * `serialize-javascript` high (build-time) — pinned to 7.0.5 via npm overrides
+  * `dompurify` high (Grafana peer dep) — pinned to 3.4.8 via npm overrides
+  * `js-cookie` high (Grafana peer dep) — pinned to 3.0.8 via npm overrides
+  * `uuid` moderate — bumped direct dep to ^11.1.1; scoped override for @grafana/ui
+
 ## [1.1.0](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.1.0) (2026-06-09)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
## Summary

Security patch release. Bumps version to `1.1.1` and documents the CVE fixes in CHANGELOG.

- Bumps `package.json` version `1.1.0` → `1.1.1`
- Adds `## [1.1.1]` section to `CHANGELOG.md`

All actual code changes are in PR #96 (already merged to main).

## Test plan

- [ ] CI green
- [ ] After merge: add `GRAFANA_API_KEY` secret, then tag `v1.1.1` to trigger signed release

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the v1.1.1 security patch release by bumping the version and documenting the CVE fixes. No code changes in this PR.

Updates `package.json` to `1.1.1` and adds the `1.1.1` entry to `CHANGELOG.md` summarizing the resolved npm audit vulnerabilities.

<sup>Written for commit f53c9d34f8ccc87d85d16dd93766810f2c7944b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/97?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

