### PR TITLE
fix(validator): resolve all Grafana plugin validator errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing
+
+Thank you for your interest in contributing to the Network Weathermap plugin.
+
+## Prerequisites
+
+- Node.js 20+
+- npm 9+
+- Docker (for the local Grafana environment)
+
+## Setup
+
+```bash
+git clone https://github.com/allamiro/grafana-network-weathermap-ng.git
+cd grafana-network-weathermap-ng
+npm install --legacy-peer-deps
+```
+
+## Development
+
+```bash
+# Start webpack in watch mode
+npm run dev
+
+# In a separate terminal, start Grafana with the plugin loaded
+npm run server
+```
+
+Grafana will be available at `http://localhost:3000` (admin / admin).
+
+## Commands
+
+| Command | Description |
+|---|---|
+| `npm run dev` | Start webpack in watch mode |
+| `npm run build` | Production build |
+| `npm run test:ci` | Run unit tests |
+| `npm run e2e` | Run Playwright E2E tests |
+| `npm run lint` | ESLint check |
+| `npm run typecheck` | TypeScript type check |
+
+## Docker environment
+
+A fully provisioned local environment is provided via Docker Compose:
+
+```bash
+docker-compose up --build
+```
+
+This starts Grafana at `http://localhost:3000` with the plugin pre-loaded and sample dashboards provisioned from the `provisioning/` directory.
+
+## Submitting changes
+
+1. Open an issue first to discuss significant changes
+2. Fork the repo and create a branch from `main`
+3. Make your changes and add tests where applicable
+4. Ensure `npm run test:ci` and `npm run typecheck` pass
+5. Open a pull request referencing the issue number
+
+## Reporting bugs
+
+Use the [bug report template](https://github.com/allamiro/grafana-network-weathermap-ng/issues/new?template=bug_report.md).
+
+## License
+
+By contributing you agree that your contributions will be licensed under the Apache-2.0 license.

--- a/README.md
+++ b/README.md
@@ -80,39 +80,7 @@ systemctl restart grafana-server
 
 ## Development
 
-### Setup
-
-```bash
-# Install dependencies
-npm install --legacy-peer-deps
-
-# Start development server (watches for changes)
-npm run dev
-
-# In a separate terminal, start Grafana with the plugin loaded
-npm run server
-```
-
-### Commands
-
-| Command | Description |
-|---|---|
-| `npm run dev` | Start webpack in watch mode |
-| `npm run build` | Production build |
-| `npm run test:ci` | Run unit tests |
-| `npm run e2e` | Run Playwright E2E tests |
-| `npm run lint` | ESLint check |
-| `npm run typecheck` | TypeScript type check |
-
-### Docker
-
-A `docker-compose.yaml` is provided for a fully provisioned local environment:
-
-```bash
-docker-compose up --build
-```
-
-This starts Grafana at `http://localhost:3000` with the plugin pre-loaded and sample dashboards provisioned from the `provisioning/` directory.
+For local setup, build commands, Docker environment, and contribution guidelines, see [CONTRIBUTING.md](https://github.com/allamiro/grafana-network-weathermap-ng/blob/main/CONTRIBUTING.md).
 
 ---
 
@@ -151,4 +119,4 @@ Contributions are welcome. Please open an issue first to discuss significant cha
 
 ## License
 
-Apache-2.0 — see [LICENSE](LICENSE) for details.
+Apache-2.0 — see [LICENSE](https://github.com/allamiro/grafana-network-weathermap-ng/blob/main/LICENSE) for details.

--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { getDefaultRelativeTimeRange, getTimeZone, LoadingState, PanelProps } from '@grafana/data';
+import { locationService } from '@grafana/runtime';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { WeathermapPanel } from 'WeathermapPanel';
 import { SimpleOptions } from 'types';
@@ -158,10 +159,8 @@ test('Check edit mode display', () => {
     testProps.options = options;
   };
 
-  Object.defineProperty(window, 'location', {
-    writable: true,
-    value: new URL('https://www.example.com/?editPanel=1'),
-  });
+  const getSearchSpy = jest.spyOn(locationService, 'getSearch').mockReturnValue(new URLSearchParams('editPanel=1'));
+
   // Render the panel
   const { container, rerender } = render(<WeathermapPanel {...testProps} />);
 
@@ -179,11 +178,9 @@ test('Check edit mode display', () => {
   fireEvent.wheel(container.querySelector('#nw-testing_')!, { deltaY: -1 });
   expect(testProps.options.weathermap.settings.panel.zoomScale).toEqual(0);
 
-  Object.defineProperty(window, 'location', {
-    writable: true,
-    value: new URL('https://www.example.com/'),
-  });
+  getSearchSpy.mockReturnValue(new URLSearchParams(''));
   rerender(<WeathermapPanel {...testProps} />);
   fireEvent.wheel(container.querySelector('#nw-testing')!, { deltaY: -1 });
   expect(testProps.options.weathermap.settings.panel.zoomScale).toEqual(0);
+  getSearchSpy.mockRestore();
 });

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -22,6 +22,7 @@ import {
   useStyles2,
   useTheme2,
 } from '@grafana/ui';
+import { locationService } from '@grafana/runtime';
 import {
   measureText,
   getSolidFromAlphaColor,
@@ -77,7 +78,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
   }
 
   // Check for editing-related feature set
-  const isEditMode = window.location.search.includes('editPanel');
+  const isEditMode = locationService.getSearch().has('editPanel');
 
   const [draggedNode, setDraggedNode] = useState(null as unknown as DrawnNode);
   const [selectedNodes, setSelectedNodes] = useState([] as DrawnNode[]);
@@ -896,7 +897,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                       onMouseOut={handleLinkHoverLoss}
                       onClick={() => {
                         if (d.sides.A.dashboardLink.length > 0) {
-                          window.open(d.sides.A.dashboardLink, '_blank');
+                          window.open(d.sides.A.dashboardLink, '_blank', 'noopener,noreferrer');
                         }
                       }}
                       style={d.sides.A.dashboardLink.length > 0 ? { cursor: 'pointer' } : {}}
@@ -932,7 +933,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                           onMouseOut={handleLinkHoverLoss}
                           onClick={() => {
                             if (d.sides.A.dashboardLink.length > 0) {
-                              window.open(d.sides.A.dashboardLink, '_blank');
+                              window.open(d.sides.A.dashboardLink, '_blank', 'noopener,noreferrer');
                             }
                           }}
                           style={d.sides.A.dashboardLink.length > 0 ? { cursor: 'pointer' } : {}}
@@ -950,7 +951,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                           onMouseOut={handleLinkHoverLoss}
                           onClick={() => {
                             if (d.sides.Z.dashboardLink.length > 0) {
-                              window.open(d.sides.Z.dashboardLink, '_blank');
+                              window.open(d.sides.Z.dashboardLink, '_blank', 'noopener,noreferrer');
                             }
                           }}
                           style={d.sides.Z.dashboardLink.length > 0 ? { cursor: 'pointer' } : {}}
@@ -971,7 +972,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                           onMouseOut={handleLinkHoverLoss}
                           onClick={() => {
                             if (d.sides.Z.dashboardLink.length > 0) {
-                              window.open(d.sides.Z.dashboardLink, '_blank');
+                              window.open(d.sides.Z.dashboardLink, '_blank', 'noopener,noreferrer');
                             }
                           }}
                           style={d.sides.Z.dashboardLink.length > 0 ? { cursor: 'pointer' } : {}}
@@ -1169,7 +1170,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                           return v;
                         });
                       } else if (!isEditMode && tempNodes[i].dashboardLink) {
-                        window.open(tempNodes[i].dashboardLink, '_blank');
+                        window.open(tempNodes[i].dashboardLink, '_blank', 'noopener,noreferrer');
                       }
                       // Force an update
                       onOptionsChange(options);

--- a/src/forms/WeathermapBuilder.tsx
+++ b/src/forms/WeathermapBuilder.tsx
@@ -95,7 +95,6 @@ export const WeathermapBuilder = (props: Props) => {
   };
 
   if (!props.value) {
-    console.log('Initializing weathermap plugin.');
     props.onChange(defaultValue);
   } else if (!props.value.version || props.value.version !== CURRENT_VERSION) {
     // State versioning and merging to deal with missing properties.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -347,7 +347,6 @@ export function handleVersionedStateUpdates(wm: Weathermap, theme: GrafanaTheme2
   wm.nodes = wm.nodes.map((n) => merge(generateBasicNode('Node A', [200, 300], theme), n));
   wm.links = wm.links.map((l) => merge(generateBasicLink(), l));
   if (!(wm.scale instanceof Array)) {
-    console.log(wm.scale);
     const oldScale = wm.scale as unknown as Record<string, string>;
     wm.scale = Object.keys(oldScale).map((key: string) => {
       return {
@@ -357,7 +356,6 @@ export function handleVersionedStateUpdates(wm: Weathermap, theme: GrafanaTheme2
     });
   }
   wm = merge(modelWeathermap, wm);
-  console.log('updated weathermap state version', wm);
   return wm;
 }
 


### PR DESCRIPTION
## Summary

Fixes all **errors** and **warnings** reported by the Grafana plugin validator (`grafana/plugin-validator-cli`) that would block Marketplace submission.

## Errors fixed (blocking)

| Issue | File | Fix |
|---|---|---|
| Relative link to `LICENSE` | `README.md` | Changed to absolute `https://github.com/...` URL |
| `window.open()` without `noopener,noreferrer` (5 call sites) | `WeathermapPanel.tsx` L899, L935, L953, L974, L1172 | Added `noopener,noreferrer` feature string |
| Direct `window.location` access | `WeathermapPanel.tsx` L80 | Replaced with `locationService.getSearch()` from `@grafana/runtime` |

## Warnings fixed

| Issue | File | Fix |
|---|---|---|
| `console.log` in plugin code | `utils.ts` L350, L360 | Removed debug logs |
| `console.log` in plugin code | `WeathermapBuilder.tsx` L98 | Removed debug log |
| Developer jargon (`nodejs`, npm commands) in `README.md` | `README.md` | Moved Development section to new `CONTRIBUTING.md`; README links to it |

## Test plan

- [x] `npm run test:ci` — 10/10 tests pass (zoom edit-mode test updated to mock `locationService` instead of `window.location`)
- [ ] CI green on this PR
- [ ] After merge: release v1.1.2, run validator again, confirm 0 errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes all `grafana/plugin-validator-cli` errors and warnings to unblock Grafana Marketplace submission. Hardens external links, removes unsafe window access, cleans up logs, and moves dev docs.

- **Bug Fixes**
  - Use `locationService.getSearch()` from `@grafana/runtime` instead of `window.location`; updated tests to mock it.
  - Add `noopener,noreferrer` to all `window.open` calls.
  - Remove `console.log` usage from plugin code.

- **Docs**
  - Move development/setup content to CONTRIBUTING.md; README links to it.
  - Switch LICENSE link in README to an absolute GitHub URL.

<sup>Written for commit e1a8e398172dba3e08361219aa5b3d3b0bc0e450. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

