### PR TITLE
chore(release): v1.1.2 — validator fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.1.2](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.1.2) (2026-06-09)
+
+### Bug Fixes
+
+* **security**: add `noopener,noreferrer` to all `window.open()` calls — prevents tab-nabbing vulnerability on dashboard link clicks ([#98](https://github.com/allamiro/grafana-network-weathermap-ng/pull/98))
+* **api**: replace direct `window.location` access with `locationService.getSearch()` from `@grafana/runtime` ([#98](https://github.com/allamiro/grafana-network-weathermap-ng/pull/98))
+
+### Chores
+
+* remove debug `console.log` calls from `utils.ts` and `WeathermapBuilder.tsx`
+* move developer setup docs to `CONTRIBUTING.md`; fix relative LICENSE link in `README.md`
+
 ## [1.1.1](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.1.1) (2026-06-09)
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Bumps version to 1.1.2. All code changes are in PR #98 (merged). This adds the CHANGELOG entry and version bump.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the v1.1.2 release by bumping `package.json` and adding a CHANGELOG entry with validator-related fixes. This documents security hardening for external links (adds `noopener,noreferrer` to all `window.open()` calls) and replaces direct `window.location` access with `locationService.getSearch()` from `@grafana/runtime`.

<sup>Written for commit 51e8cc242f86364ba058c34eb683b3698e39463f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/99?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

