### PR TITLE
chore(release): v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.1.3](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.1.3) (2026-06-09)
+
+### Chores
+
+* replace `nodejs.org` badge link in `README.md` with `CONTRIBUTING.md` link
+* upgrade `testing/exporter` Go dependencies to resolve `govulncheck` CVEs (GO-2022-0322, GO-2026-5037, GO-2026-5039)
+
 ## [1.1.2](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.1.2) (2026-06-09)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Final submission-ready release. Bumps version to 1.1.3 with CHANGELOG entry for PR #100 cleanup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.1.3 with a version bump and CHANGELOG update. Includes a README badge link fix and Go dependency upgrades in `testing/exporter` to resolve govulncheck CVEs (GO-2022-0322, GO-2026-5037, GO-2026-5039).

<sup>Written for commit b03b8e6e2114630f83c3490f1ec89eaae403867d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

