### PR TITLE
fix(#54): stable series name resolution for intermittent n/a links

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -377,5 +377,5 @@ export function getValueField(frame: DataFrame): Field {
 }
 
 export const getDataFrameName = (frame: DataFrame, allFrames: DataFrame[]): string => {
-  return getFieldDisplayName(getValueField(frame), frame);
+  return getFieldDisplayName(getValueField(frame), frame, allFrames);
 };


### PR DESCRIPTION
## Root cause

`getDataFrameName` called `getFieldDisplayName(field, frame)` without the third `allFrames` argument.

Grafana's `getFieldDisplayName` needs all frames to disambiguate multiple series sharing the same field name (e.g. a Prometheus wildcard query returning multiple label sets like `{instance="host1"}` and `{instance="host2"}`). Without it:
- Two series get identical display names
- Which one wins depends on array order — which Grafana does not guarantee between refreshes
- So a link that matched correctly on one refresh shows `n/a` on the next when frame order flips

## Fix

Pass `allFrames` as the third argument to `getFieldDisplayName`. When a field name is unique across all frames the output is identical to before. When duplicates exist Grafana appends the label set to produce a stable unique name.

Closes #54

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes intermittent "n/a" links by making series name resolution stable (fixes #54). `getDataFrameName` now passes `allFrames` to `getFieldDisplayName`, so duplicate field names get unique, consistent labels across refreshes.

<sup>Written for commit 3e2385fddc945270599104bcd89cd6ad234f47f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

