### PR TITLE
fix(#55): correct tooltip graph scaling and time range alignment

### DIFF
--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef, useMemo } from 'react';
-import { DataFrame, Field, getTimeZone, getValueFormat, PanelProps } from '@grafana/data';
+import { DataFrame, Field, FieldType, getTimeZone, getValueFormat, PanelProps } from '@grafana/data';
 import {
   Anchor,
   DrawnLink,
@@ -629,18 +629,26 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                   timeRange={timeRange}
                   timeZone={getTimeZone()}
                   frames={filteredGraphQueries.map((frame: DataFrame) => {
-                    let copy = frame;
-                    let isInboundQuery = getDataFrameName(frame, data.series) === hoveredLink.link.sides.Z.query;
-                    copy.fields = copy.fields.map((v) => {
-                      v.config.custom = {
-                        fillOpacity: 10,
-                        lineColor: isInboundQuery
-                          ? wm.settings.tooltip.inboundColor
-                          : wm.settings.tooltip.outboundColor,
-                      };
-                      return v;
-                    });
-                    return copy;
+                    const isInboundQuery = getDataFrameName(frame, data.series) === hoveredLink.link.sides.Z.query;
+                    const lineColor = isInboundQuery
+                      ? wm.settings.tooltip.inboundColor
+                      : wm.settings.tooltip.outboundColor;
+                    // Spread each field to avoid mutating the original frame stored in data.series.
+                    // Mutating originals causes stale colors on subsequent renders.
+                    return {
+                      ...frame,
+                      fields: frame.fields.map((f) => ({
+                        ...f,
+                        config: {
+                          ...f.config,
+                          custom: {
+                            ...f.config.custom,
+                            fillOpacity: 10,
+                            lineColor,
+                          },
+                        },
+                      })),
+                    };
                   })}
                   legend={{
                     calcs: [],
@@ -650,6 +658,10 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                     showLegend: false,
                   }}
                   tweakScale={(opts, forField: Field) => {
+                    // Only adjust the value (y) axis — not the time axis.
+                    if (forField.type !== FieldType.number) {
+                      return opts;
+                    }
                     opts.softMin = 0;
                     if (
                       wm.settings.tooltip.scaleToBandwidth &&
@@ -660,6 +672,10 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                     return opts;
                   }}
                   tweakAxis={(opts, forField: Field) => {
+                    // Only format the value (y) axis — leave the time axis alone.
+                    if (forField.type !== FieldType.number) {
+                      return opts;
+                    }
                     opts.formatValue = getlinkGraphFormatter(
                       hoveredLink.link.units
                         ? hoveredLink.link.units


### PR DESCRIPTION
## Root cause — two independent bugs

### 1. Field mutation (caused stale / wrong colors)

`let copy = frame` creates a reference copy, not a new object. `copy.fields = copy.fields.map((v) => { v.config.custom = {...}; return v; })` mutated the original field objects inside `data.series`. On the next tooltip render those fields already had the previous hover's color values; hovering a different link would show the previous link's inbound/outbound colors.

**Fix:** spread both the frame and each field:
```js
return { ...frame, fields: frame.fields.map((f) => ({ ...f, config: { ...f.config, custom: { ...f.config.custom, fillOpacity: 10, lineColor } } })) };
```

### 2. tweakScale / tweakAxis applied to the time field (caused flat line / wrong time axis)

Both callbacks ran unconditionally for every field including the time field. Setting `softMin`/`softMax` on the time scale compressed/expanded the x-axis range; applying the bps formatter to time produced garbage time labels. The graph appeared as a flat line or showed completely wrong time labels.

**Fix:** guard both callbacks with `forField.type !== FieldType.number` so they only affect the value (y) axis.

Closes #55

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the tooltip mini-graph. Colors now update correctly per hover, and the time axis range and labels stay accurate.

- **Bug Fixes**
  - Avoided mutating original frames/fields by returning a new frame with spread fields and per-hover `custom` color config.
  - Limited `tweakScale` and `tweakAxis` to numeric fields only, leaving the time axis untouched to prevent x-axis distortion and bad labels.

<sup>Written for commit 789a31048b38e1912e347509bfb274371d7b4f84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

