### PR TITLE
chore(release): v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.2.0](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.2.0) (2026-06-09)
+
+### Bug Fixes
+
+* **query-matching**: links intermittently showed `n/a` despite valid query data — `getDataFrameName` was not passing `allFrames` to `getFieldDisplayName`, so Grafana could not disambiguate multiple series sharing the same field name; frame ordering (non-deterministic between refreshes) determined which series matched ([#54](https://github.com/allamiro/grafana-network-weathermap-ng/issues/54), PR [#102](https://github.com/allamiro/grafana-network-weathermap-ng/pull/102))
+* **performance**: panel editor lag and slow re-render on large weathermaps — `generateDrawnLink` rebuilt the full data-frame value array from scratch for every link, O(links × frames) per refresh; replaced with a `useMemo`-cached `Map<name, value>` computed once per data change, reducing to O(frames) total ([#47](https://github.com/allamiro/grafana-network-weathermap-ng/issues/47), [#48](https://github.com/allamiro/grafana-network-weathermap-ng/issues/48), PR [#103](https://github.com/allamiro/grafana-network-weathermap-ng/pull/103))
+* **tooltip-graph**: mini graph in link tooltip showed flat line or incorrect time axis — two root causes: (1) `let copy = frame` was a reference copy that permanently mutated field configs in `data.series`; (2) `tweakScale`/`tweakAxis` ran on the time field as well as value fields, distorting the x-axis range and applying the bps formatter to time labels ([#55](https://github.com/allamiro/grafana-network-weathermap-ng/issues/55), PR [#104](https://github.com/allamiro/grafana-network-weathermap-ng/pull/104))
+
 ## [1.1.3](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.1.3) (2026-06-09)
 
 ### Chores

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
## What's in v1.2.0

All four remaining open bugs fixed, validated, and merged.

| Issue | Fix | PR |
|---|---|---|
| #54 intermittent n/a links | Pass `allFrames` to `getFieldDisplayName` for stable series name resolution | #102 |
| #47 slow panel editor | `useMemo` data-frame map — O(frames) once instead of O(links × frames) per render | #103 |
| #48 slow rendering on large maps | Same fix as #47 | #103 |
| #55 tooltip graph flat / wrong time axis | Fix field mutation (spread copy) + guard `tweakScale`/`tweakAxis` to numeric fields only | #104 |

All issues auto-closed. All fix branches deleted. CI green on every merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.2.0 fixes unstable link labels, speeds up the editor and large-map renders, and corrects tooltip graphs. Improves reliability and responsiveness across the panel.

- **Bug Fixes**
  - Stable link labels: pass `allFrames` to `getFieldDisplayName` to disambiguate series (#54).
  - Faster renders: memoized `Map<name, value>` reduces work to O(frames) per data change; speeds up editor and large maps (#47, #48).
  - Correct tooltip graph: avoid field mutation and apply scale/axis tweaks only to numeric fields; fixes flat lines and wrong time axis (#55).

<sup>Written for commit 8531493b2558385f3b103a313cda54484bbe6ed7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

