### PR TITLE
chore(release): bump version to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.3.0](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.3.0) (2026-06-10)
+
+### Chores
+
+* **ci**: switch release workflow to `grafana/plugin-actions/build-plugin` with provenance attestation (`attestation: true`) and `GRAFANA_ACCESS_POLICY_TOKEN`; drop deprecated `GRAFANA_API_KEY`; fixes `no-provenance-attestation` Grafana validator warning
+* **plugin.json**: add sponsor link; fixes `sponsorshiplink` Grafana validator warning
+* **testing/exporter**: upgrade `golang.org/x/sys` to `v0.44.0`; fixes `GO-2026-5024` (`govulncheck` module-level finding, Windows integer overflow)
+
 ## [1.2.0](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.2.0) (2026-06-09)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Release v1.3.0 — fixes Grafana Marketplace validator warnings.

## Changes (from PR #108)

- `release.yml`: provenance attestation via `grafana/plugin-actions/build-plugin`
- `plugin.json`: sponsor link added
- `testing/exporter`: `golang.org/x/sys` upgraded to fix GO-2026-5024

## Checklist

- [ ] CI passes
- [ ] Merge to main
- [ ] Tag `v1.3.0` to trigger release workflow
- [ ] Verify signed + attested ZIP is attached to the GitHub release
- [ ] Resubmit ZIP to Grafana Marketplace

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.3.0 fixes Grafana Marketplace validator warnings and updates a vulnerable dependency. Adds provenance attestation to the release workflow and a sponsor link in `plugin.json`.

- **Bug Fixes**
  - Switch release workflow to `grafana/plugin-actions/build-plugin` with provenance attestation; resolves “no-provenance-attestation”.
  - Add sponsor link in `plugin.json`; resolves “sponsorshiplink”.

- **Dependencies**
  - Upgrade `golang.org/x/sys` to v0.44.0 to address `GO-2026-5024`.

<sup>Written for commit d18339424217f8d51d8b5d21e237ed058697d400. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

