### PR TITLE
fix: add .npmrc for build-plugin peer-dep compatibility

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
The `grafana/plugin-actions/build-plugin` action runs `npm install` without `--legacy-peer-deps`, which fails due to `eslint-plugin-react-hooks@^4.6.0` conflicting with `@grafana/eslint-config@9.0.0` (requires `>=7.0.0`).

Adding `.npmrc` with `legacy-peer-deps=true` makes every npm invocation (including inside the action) use legacy peer dep resolution — unblocking the release workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a repo-level `.npmrc` with `legacy-peer-deps=true` so `npm install` uses legacy peer dep resolution in `grafana/plugin-actions/build-plugin` and locally. This fixes CI install failures from a peer-dependency conflict between `eslint-plugin-react-hooks@^4.6.0` and `@grafana/eslint-config@9.0.0`, unblocking the release workflow.

<sup>Written for commit 844364572ff02e44354fac0f6dc3afce489c06a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

