### PR TITLE
fix: use actions/attest-build-provenance for provenance attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,13 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
-      - name: Build and sign plugin
-        uses: grafana/plugin-actions/build-plugin@build-plugin/v1.2.0
-        with:
-          policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
-          attestation: 'true'
+      - name: Run tests
+        run: npm run test:ci
+
+      - name: Build plugin
+        run: npm run build
 
       - name: Get plugin metadata
         id: metadata
@@ -62,6 +62,11 @@ jobs:
           zip ${{ steps.metadata.outputs.archive }} ${{ steps.metadata.outputs.plugin-id }} -r
           md5sum ${{ steps.metadata.outputs.archive }} > ${{ steps.metadata.outputs.archive-checksum }}
           echo "checksum=$(cut -d' ' -f1 < ${{ steps.metadata.outputs.archive-checksum }})" >> "$GITHUB_OUTPUT"
+
+      - name: Generate provenance attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ steps.metadata.outputs.archive }}
 
       - name: Extract release notes
         id: changelog


### PR DESCRIPTION
`grafana/plugin-actions/build-plugin` requires an approved publisher account on grafana.com to self-sign — community plugins pending review cannot use this. The signing step was failing with `Error signing manifest.`

This replaces the `build-plugin` action with the original manual build flow, adding `actions/attest-build-provenance@v2` explicitly after packaging. This directly fixes the `no-provenance-attestation` validator warning without requiring plugin signing (which Grafana handles during review).

The `.npmrc` from PR #110 means `npm ci` now handles peer deps cleanly without `--legacy-peer-deps` flag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the release workflow to a manual build and add `actions/attest-build-provenance@v2` for provenance attestation. This fixes the failed signing step for community plugins and clears the `no-provenance-attestation` warning.

- **Bug Fixes**
  - Replaced `grafana/plugin-actions/build-plugin` with manual `npm run build` and `actions/attest-build-provenance@v2` on the packaged archive.
  - Use `npm ci` (no `--legacy-peer-deps`) and run `npm run test:ci` before building.

<sup>Written for commit 02692c6c1bbef4a4965c1e03bae0a5b06a5afc59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

