### PR TITLE
fix: lower minimum Grafana dependency to >=11.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.3.1](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.3.1) (2026-06-10)
+
+### Bug Fixes
+
+* **plugin.json**: lower minimum Grafana dependency from `>=12.0.0` to `>=11.0.0` — levitate API compatibility checks pass for Grafana 11.0.0 and above; the `>=12.0.0` restriction was overly conservative
+
 ## [1.3.0](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.3.0) (2026-06-10)
 
 ### Chores

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -37,7 +37,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": ">=12.0.0",
+    "grafanaDependency": ">=11.0.0",
     "plugins": []
   }
 }

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -6,7 +6,7 @@
     - This is a continuation fork. The original plugin was archived in 2023. This fork (`tamirsuliman-weathermap-panel`) is modernized for Grafana 12+ and actively maintained. Config exported from the original plugin is compatible.
 
 - **Q: What is the minimum Grafana version?**
-    - Grafana **12.0.0**. The plugin depends on `@grafana/*` SDK v11 APIs that are not available in earlier versions.
+    - Grafana **11.0.0**. The plugin uses `@grafana/*` SDK v11 APIs. API compatibility is verified against Grafana 11.x and 12.x in CI.
 
 ## Data / Queries
 

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -1,4 +1,4 @@
-<center><img src="/assets/logo.svg" alt="Network Weathermap NG Logo" width="200" style="background: lightgrey; padding: 2rem; border-radius: 1rem; box-shadow: #aaa 0.5rem 0.5rem 1rem;"/></center>
+<center><img src="assets/logo.svg" alt="Network Weathermap NG Logo" width="200" style="background: lightgrey; padding: 2rem; border-radius: 1rem; box-shadow: #aaa 0.5rem 0.5rem 1rem;"/></center>
 
 <center>
 # Grafana Network Weathermap NG

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -5,7 +5,7 @@
 </center>
 
 <center>
-A modernized, actively maintained network weathermap panel plugin for Grafana 12+.<br>
+A modernized, actively maintained network weathermap panel plugin for Grafana 11+.<br>
 Maintained by <a href="https://github.com/allamiro">Tamir Suliman</a> — Plugin ID: <code>tamirsuliman-weathermap-panel</code>
 </center>
 
@@ -20,7 +20,7 @@ This plugin is a continuation of the original [knightss27/grafana-network-weathe
 | Area | Change |
 |---|---|
 | Plugin ID | `tamirsuliman-weathermap-panel` (was `knightss27-weathermap-panel`) |
-| Grafana SDK | Updated to `@grafana/*` v11 — requires **Grafana 12.0.0+** |
+| Grafana SDK | Updated to `@grafana/*` v11 — requires **Grafana 11.0.0+** |
 | React | Upgraded from React 17 → React 18 |
 | Styling | Migrated from deprecated `stylesFactory` → `useStyles2` + `@emotion/css` |
 | Deprecated APIs | Replaced `Vector.get()` with direct array indexing |
@@ -36,7 +36,7 @@ Contributions and bug reports are welcome at [github.com/allamiro/grafana-networ
 
 ### Installing on a local Grafana
 
-Requires **Grafana 12.0.0 or later**.
+Requires **Grafana 11.0.0 or later**.
 
 #### Option A — Grafana Marketplace (once approved)
 


### PR DESCRIPTION
The `grafanaDependency` was set to `>=12.0.0` conservatively, but our levitate API compatibility tests pass for Grafana 10.4.0, 11.0.0, and 12.0.0. Lowering to `>=11.0.0` is accurate and expands the installable user base significantly.

Changes:
- `plugin.json`: `grafanaDependency` → `>=11.0.0`
- `package.json`: version → `1.3.1`
- `CHANGELOG.md`: entry for v1.3.1
- `website/docs/index.md`: update version references
- `website/docs/faq.md`: update minimum version FAQ answer

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowered the minimum Grafana requirement from >=12.0.0 to >=11.0.0 based on passing API compatibility tests on 11.x and 12.x. Also fixed the docs logo path so it loads on GitHub Pages subdirectories.

- **Dependencies**
  - Set `grafanaDependency` to >=11.0.0; updated docs to state Grafana 11.0.0+ and `@grafana/*` v11 API compatibility.
  - Bumped version to 1.3.1 and added a CHANGELOG entry.

- **Bug Fixes**
  - Switched the docs logo to a relative path in `website/docs/index.md` so it renders on GitHub Pages subpaths.

<sup>Written for commit 6e248d14fb7f2801f00bb377fe42aaa8a8957150. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

