### PR TITLE
feat(#79): configurable link bandwidth visualization styles

### DIFF
--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -101,6 +101,15 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
     return assignedColor;
   }
 
+  function getLinkStroke(currentValue: number, bandwidth: number, fixedStroke: number): number {
+    const ds = wm.settings.link.dynamicStroke;
+    if (!ds?.enabled || bandwidth === 0) {
+      return fixedStroke;
+    }
+    const pct = Math.min(1, Math.max(0, currentValue / bandwidth));
+    return ds.minWidth + (ds.maxWidth - ds.minWidth) * pct;
+  }
+
   // Get the middle point between two nodes
   function getMiddlePoint(source: Position, target: Position, offset: number): Position {
     const x = (source.x + target.x) / 2;
@@ -781,8 +790,8 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
             setSelectedNodes([]);
           }}
         >
-          {wm.settings.panel.grid.enabled ? (
-            <defs>
+          <defs>
+            {wm.settings.panel.grid.enabled && (
               <pattern
                 id="smallGrid"
                 width={wm.settings.panel.grid.size}
@@ -797,10 +806,43 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                   opacity={1}
                 />
               </pattern>
-            </defs>
-          ) : (
-            ''
-          )}
+            )}
+            {wm.settings.link.flowAnimation?.enabled && (
+              <style>{`
+                @keyframes link-flow-forward {
+                  from { stroke-dashoffset: 15; }
+                  to { stroke-dashoffset: 0; }
+                }
+              `}</style>
+            )}
+            {wm.settings.link.gradientColor &&
+              links.map((d) => (
+                <React.Fragment key={d.id}>
+                  <linearGradient
+                    id={`grad-a-${d.id}`}
+                    x1={d.lineStartA.x}
+                    y1={d.lineStartA.y}
+                    x2={d.lineEndA.x}
+                    y2={d.lineEndA.y}
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop offset="0%" stopColor={getScaleColor(d.sides.A.currentValue, d.sides.A.bandwidth)} />
+                    <stop offset="100%" stopColor={getScaleColor(d.sides.Z.currentValue, d.sides.Z.bandwidth)} />
+                  </linearGradient>
+                  <linearGradient
+                    id={`grad-z-${d.id}`}
+                    x1={d.lineStartZ.x}
+                    y1={d.lineStartZ.y}
+                    x2={d.lineEndZ.x}
+                    y2={d.lineEndZ.y}
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop offset="0%" stopColor={getScaleColor(d.sides.Z.currentValue, d.sides.Z.bandwidth)} />
+                    <stop offset="100%" stopColor={getScaleColor(d.sides.A.currentValue, d.sides.A.bandwidth)} />
+                  </linearGradient>
+                </React.Fragment>
+              ))}
+          </defs>
           <g
             transform={`translate(${
               (wm.settings.panel.panelSize.width * Math.pow(1.2, wm.settings.panel.zoomScale) -
@@ -884,8 +926,12 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                     height={Math.abs(d.target.y - d.source.y)}
                   >
                     <line
-                      strokeWidth={d.stroke}
-                      stroke={getScaleColor(d.sides.A.currentValue, d.sides.A.bandwidth)}
+                      strokeWidth={getLinkStroke(d.sides.A.currentValue, d.sides.A.bandwidth, d.stroke)}
+                      stroke={
+                        wm.settings.link.gradientColor
+                          ? `url(#grad-a-${d.id})`
+                          : getScaleColor(d.sides.A.currentValue, d.sides.A.bandwidth)
+                      }
                       x1={d.lineStartA.x}
                       y1={d.lineStartA.y}
                       x2={d.lineEndA.x}
@@ -899,7 +945,15 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                           window.open(d.sides.A.dashboardLink, '_blank', 'noopener,noreferrer');
                         }
                       }}
-                      style={d.sides.A.dashboardLink.length > 0 ? { cursor: 'pointer' } : {}}
+                      style={{
+                        ...(d.sides.A.dashboardLink.length > 0 ? { cursor: 'pointer' } : {}),
+                        ...(wm.settings.link.flowAnimation?.enabled
+                          ? {
+                              strokeDasharray: '10 5',
+                              animation: `link-flow-forward ${wm.settings.link.flowAnimation.speed}s linear infinite`,
+                            }
+                          : {}),
+                      }}
                     ></line>
                     {tempNodes[d.source.index].isConnection ? (
                       <circle
@@ -938,8 +992,12 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                           style={d.sides.A.dashboardLink.length > 0 ? { cursor: 'pointer' } : {}}
                         ></polygon>
                         <line
-                          strokeWidth={d.stroke}
-                          stroke={getScaleColor(d.sides.Z.currentValue, d.sides.Z.bandwidth)}
+                          strokeWidth={getLinkStroke(d.sides.Z.currentValue, d.sides.Z.bandwidth, d.stroke)}
+                          stroke={
+                            wm.settings.link.gradientColor
+                              ? `url(#grad-z-${d.id})`
+                              : getScaleColor(d.sides.Z.currentValue, d.sides.Z.bandwidth)
+                          }
                           x1={d.lineStartZ.x}
                           y1={d.lineStartZ.y}
                           x2={d.lineEndZ.x}
@@ -953,7 +1011,15 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                               window.open(d.sides.Z.dashboardLink, '_blank', 'noopener,noreferrer');
                             }
                           }}
-                          style={d.sides.Z.dashboardLink.length > 0 ? { cursor: 'pointer' } : {}}
+                          style={{
+                            ...(d.sides.Z.dashboardLink.length > 0 ? { cursor: 'pointer' } : {}),
+                            ...(wm.settings.link.flowAnimation?.enabled
+                              ? {
+                                  strokeDasharray: '10 5',
+                                  animation: `link-flow-forward ${wm.settings.link.flowAnimation.speed}s linear infinite`,
+                                }
+                              : {}),
+                          }}
                         ></line>
                         <polygon
                           points={`

--- a/src/forms/PanelForm.tsx
+++ b/src/forms/PanelForm.tsx
@@ -319,6 +319,92 @@ export const PanelForm = ({ value, onChange }: Props) => {
         </InlineLabel>
         <FormDivider title="Arrow Options" />
 
+        <FormDivider title="Link Visualization" />
+        <InlineField grow label="Gradient Color" tooltip="Blend A-side and Z-side utilization colors along each link" className={styles.inlineField}>
+          <InlineSwitch
+            value={value.settings.link.gradientColor ?? false}
+            onChange={(e) => {
+              let options = value;
+              options.settings.link.gradientColor = e.currentTarget.checked;
+              onChange(options);
+            }}
+          />
+        </InlineField>
+        <InlineField grow label="Flow Animation" tooltip="Animate dashes along each link to indicate traffic direction" className={styles.inlineField}>
+          <InlineSwitch
+            value={value.settings.link.flowAnimation?.enabled ?? false}
+            onChange={(e) => {
+              let options = value;
+              if (!options.settings.link.flowAnimation) {
+                options.settings.link.flowAnimation = { enabled: false, speed: 2 };
+              }
+              options.settings.link.flowAnimation.enabled = e.currentTarget.checked;
+              onChange(options);
+            }}
+          />
+        </InlineField>
+        {value.settings.link.flowAnimation?.enabled && (
+          <InlineField grow label="Animation Speed (s)" tooltip="Duration in seconds for one full animation cycle" className={styles.inlineField}>
+            <Slider
+              min={0.5}
+              max={10}
+              value={value.settings.link.flowAnimation?.speed ?? 2}
+              step={0.5}
+              onChange={(num) => {
+                let options = value;
+                if (!options.settings.link.flowAnimation) {
+                  options.settings.link.flowAnimation = { enabled: true, speed: 2 };
+                }
+                options.settings.link.flowAnimation.speed = num;
+                onChange(options);
+              }}
+            />
+          </InlineField>
+        )}
+        <InlineField grow label="Dynamic Stroke Width" tooltip="Scale link thickness with traffic utilization instead of using a fixed stroke" className={styles.inlineField}>
+          <InlineSwitch
+            value={value.settings.link.dynamicStroke?.enabled ?? false}
+            onChange={(e) => {
+              let options = value;
+              if (!options.settings.link.dynamicStroke) {
+                options.settings.link.dynamicStroke = { enabled: false, minWidth: 1, maxWidth: 10 };
+              }
+              options.settings.link.dynamicStroke.enabled = e.currentTarget.checked;
+              onChange(options);
+            }}
+          />
+        </InlineField>
+        {value.settings.link.dynamicStroke?.enabled && (
+          <>
+            <InlineField grow label="Min Stroke Width" className={styles.inlineField}>
+              <Slider
+                min={1}
+                max={20}
+                value={value.settings.link.dynamicStroke?.minWidth ?? 1}
+                step={1}
+                onChange={(num) => {
+                  let options = value;
+                  options.settings.link.dynamicStroke!.minWidth = num;
+                  onChange(options);
+                }}
+              />
+            </InlineField>
+            <InlineField grow label="Max Stroke Width" className={styles.inlineField}>
+              <Slider
+                min={1}
+                max={30}
+                value={value.settings.link.dynamicStroke?.maxWidth ?? 10}
+                step={1}
+                onChange={(num) => {
+                  let options = value;
+                  options.settings.link.dynamicStroke!.maxWidth = num;
+                  onChange(options);
+                }}
+              />
+            </InlineField>
+          </>
+        )}
+
         <FormDivider title="Grid Options" />
         <InlineFieldRow className={styles.inlineRow}>
           <InlineField grow label="Enable Node Grid Snapping" className={styles.inlineField}>

--- a/src/forms/WeathermapBuilder.tsx
+++ b/src/forms/WeathermapBuilder.tsx
@@ -45,6 +45,9 @@ export const WeathermapBuilder = (props: Props) => {
           font: theme.colors.secondary.contrastText,
         },
         showAllWithPercentage: false,
+        dynamicStroke: { enabled: false, minWidth: 1, maxWidth: 10 },
+        flowAnimation: { enabled: false, speed: 2 },
+        gradientColor: false,
       },
       fontSizing: {
         node: 10,

--- a/src/types.ts
+++ b/src/types.ts
@@ -178,6 +178,16 @@ export interface WeathermapSettings {
     showAllWithPercentage: boolean;
     defaultUnits?: string;
     valueMappingMode?: 'last' | 'avg';
+    dynamicStroke?: {
+      enabled: boolean;
+      minWidth: number;
+      maxWidth: number;
+    };
+    flowAnimation?: {
+      enabled: boolean;
+      speed: number;
+    };
+    gradientColor?: boolean;
   };
   fontSizing: {
     node: number;


### PR DESCRIPTION
## Summary

- **Dynamic stroke width**: link line thickness scales with bandwidth utilization (configurable min/max px)
- **Flow animation**: animated dashes indicate traffic direction (configurable speed)
- **Gradient coloring**: per-link SVG `linearGradient` blends A-side and Z-side scale colors

Closes #79

## Changes

- `src/types.ts` — added `dynamicStroke`, `flowAnimation`, `gradientColor` to `WeathermapSettings.link`
- `src/WeathermapPanel.tsx` — `getLinkStroke()` helper; conditional `<defs>` with keyframes and per-link gradient elements; updated A/Z line rendering
- `src/forms/PanelForm.tsx` — "Link Visualization" settings section
- `src/forms/WeathermapBuilder.tsx` — defaults for new settings fields

## Test plan

- [ ] Toggle each visualization option on/off in panel edit mode
- [ ] Verify dynamic stroke scales visually with bandwidth %
- [ ] Verify flow animation direction matches A→Z / Z→A
- [ ] Verify gradient blends between the two side colors
- [ ] No regression on existing links with all options disabled

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add configurable link visualization styles—dynamic stroke width, flow animation, and gradient coloring—to clarify utilization and direction. Closes #79.

- **New Features**
  - Dynamic stroke width (`dynamicStroke`) scales link thickness by utilization with configurable min/max.
  - Flow animation (`flowAnimation`) adds direction-aware dashed movement with a speed control.
  - Gradient coloring (`gradientColor`) blends A- and Z-side utilization via per-link SVG `linearGradient`.
  - New "Link Visualization" settings in `PanelForm` with sensible defaults in `WeathermapBuilder`; rendering updated in `WeathermapPanel` (`getLinkStroke`, conditional `<defs>`). All options default off to preserve current visuals.

<sup>Written for commit 9a53c3465ca6bc789fe700f51170bf40acecb7bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

