### PR TITLE
feat(#78): attach link lines to node icon boundary

### DIFF
--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -160,6 +160,26 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
     };
   }
 
+  // How much extra y-offset the icon adds above the node rect top (for Top anchor)
+  function getIconTopExtra(d: DrawnNode): number {
+    if (!d.nodeIcon || d.nodeIcon.drawInside || !d.useIconBoundaryForLinks) {
+      return 0;
+    }
+    const rectH = calculateRectangleAutoHeight(d, wm);
+    if (d.label && d.label.length > 0) {
+      return d.nodeIcon.size.height + d.nodeIcon.padding.vertical + 1;
+    }
+    return Math.max(0, d.nodeIcon.size.height / 2 - rectH / 2);
+  }
+
+  // How much extra x-offset the icon adds beyond the rect edge (for Left/Right anchors)
+  function getIconWidthExtra(d: DrawnNode): number {
+    if (!d.nodeIcon || d.nodeIcon.drawInside || !d.useIconBoundaryForLinks) {
+      return 0;
+    }
+    return Math.max(0, d.nodeIcon.size.width / 2 - calculateRectangleAutoWidth(d, wm) / 2);
+  }
+
   // Calculate the position of a link given the node and side information
   function getMultiLinkPosition(d: DrawnNode, side: LinkSide): Position {
     // Set initial x and y values for links. Defaults to center x of the node, and the middle y.
@@ -191,11 +211,12 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
 
     // Change x values for left/right anchors
     if (side.anchor === Anchor.Left || side.anchor === Anchor.Right) {
-      // Align left/right
+      const iconWidthExtra = getIconWidthExtra(d);
+      // Align left/right, extending to icon edge when useIconBoundaryForLinks is set
       if (side.anchor === Anchor.Left) {
-        x -= calculateRectangleAutoWidth(d, wm) / 2 - maxLinkWidth / 2;
+        x -= calculateRectangleAutoWidth(d, wm) / 2 - maxLinkWidth / 2 + iconWidthExtra;
       } else {
-        x += calculateRectangleAutoWidth(d, wm) / 2 - maxLinkWidth / 2;
+        x += calculateRectangleAutoWidth(d, wm) / 2 - maxLinkWidth / 2 + iconWidthExtra;
       }
       // Calculate vertical alignments given # of links
       if (!d.compactVerticalLinks && d.anchors[side.anchor].numLinks > 1) {
@@ -230,6 +251,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
       } else if (side.anchor === Anchor.Top) {
         y -= calculateRectangleAutoHeight(d, wm) / 2;
         y += maxLinkWidth / 2;
+        y -= getIconTopExtra(d);
       }
     }
     // Mark that we've drawn another link

--- a/src/forms/NodeForm.tsx
+++ b/src/forms/NodeForm.tsx
@@ -400,6 +400,16 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                       onChange={(e) => handleIconDrawChange(e.currentTarget.checked, i)}
                     />
                   </InlineField>
+                  <InlineField grow label={'Attach Links to Icon Boundary'}>
+                    <InlineSwitch
+                      value={node.useIconBoundaryForLinks ?? false}
+                      onChange={(e) => {
+                        let weathermap: Weathermap = value;
+                        weathermap.nodes[i].useIconBoundaryForLinks = e.currentTarget.checked;
+                        onChange(weathermap);
+                      }}
+                    />
+                  </InlineField>
                 </ControlledCollapse>
               </InlineFieldRow>
               <InlineFieldRow className={styles.inlineRow}>

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,7 @@ export interface Node {
     statusDown: string;
   };
   nodeIcon: Icon | null;
+  useIconBoundaryForLinks?: boolean;
   isConnection: boolean;
   statusQuery?: string;
 }


### PR DESCRIPTION
## Summary

- Adds a per-node toggle **"Attach Links to Icon Boundary"** (`useIconBoundaryForLinks`) in the Icon settings section
- When enabled on a node with an external icon (`drawInside: false`), link attachment points shift outward to the icon edge instead of the label-rectangle edge:
  - **Top anchor** — extends upward to the icon's top edge (accounting for icon height + vertical padding)
  - **Left/Right anchors** — extends outward to the icon's left/right edge when the icon is wider than the node rectangle
  - **Bottom anchor** — unchanged (icon is above the label, not below)
- Defaults to `false` on all existing nodes — no visual regression

Closes #78

## Changes

- `src/types.ts` — added `useIconBoundaryForLinks?: boolean` to `Node`
- `src/WeathermapPanel.tsx` — `getIconTopExtra()` and `getIconWidthExtra()` helpers; applied in `getMultiLinkPosition()` for Top/Left/Right anchors
- `src/forms/NodeForm.tsx` — toggle added inside the Icon collapse section after "Draw Inside"

## Test plan

- [ ] Add a node with a large external icon (drawInside: false) and a link on the Top anchor
- [ ] Enable "Attach Links to Icon Boundary" — verify link now attaches at the icon top edge, not the text-box top edge
- [ ] Verify Left/Right anchors also shift outward when icon is wider than node rect
- [ ] Verify existing nodes with this option off are unchanged
- [ ] Verify nodes with drawInside: true are unaffected (option has no effect)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-node toggle to attach link lines to a node’s external icon edge instead of the label box, improving placement for large icons and closing #78. Defaults to off to avoid visual regressions.

- New Features
  - Per-node switch in Icon settings: `Attach Links to Icon Boundary` (stored as `useIconBoundaryForLinks`).
  - With external icons (`drawInside: false`), Top/Left/Right anchors attach to the icon edge; Bottom is unchanged.
  - No effect when `drawInside: true`. Defaults to off on existing nodes.

<sup>Written for commit f4e4328e8c9d1aee5c8bb1512ebd3e7bd07f85a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

