### PR TITLE
feat(#75): configurable node status value mappings

### DIFF
--- a/src/components/MapNode.tsx
+++ b/src/components/MapNode.tsx
@@ -54,14 +54,22 @@ const MapNode: React.FC<NodeProps> = (props: NodeProps) => {
   const rectHeight = useMemo(() => calculateRectangleAutoHeight(node, wm), [node, wm]);
   const textY = useMemo(() => calculateTextY(node), [node]);
 
-  let nodeIsDown = false;
+  let nodeStatusColor: string | null = null;
   if (node.statusQuery) {
-    let recentFrame = data.series
+    const recentFrame = data.series
       .filter((series) => getDataFrameName(series, data.series) === node.statusQuery)
       .map((frame) => frame.fields[1].values[frame.fields[1].values.length - 1]);
 
-    // Check if the node is down (data returns 0 or below, or doesn't exist)
-    nodeIsDown = recentFrame.length === 0 || (recentFrame.length > 0 && recentFrame[0] < 1);
+    const rawValue = recentFrame.length > 0 ? recentFrame[0] : undefined;
+
+    if (rawValue === undefined) {
+      nodeStatusColor = node.colors.statusDown;
+    } else if (node.statusValueMappings && node.statusValueMappings.length > 0) {
+      const match = node.statusValueMappings.find((m) => m.value === rawValue);
+      nodeStatusColor = match ? match.color : null;
+    } else {
+      nodeStatusColor = rawValue < 1 ? node.colors.statusDown : null;
+    }
   }
 
   // Check if this node is selected for dragging
@@ -108,7 +116,7 @@ const MapNode: React.FC<NodeProps> = (props: NodeProps) => {
                     ? 'transparent'
                     : getSolidFromAlphaColor(node.colors.background, wm.settings.panel.backgroundColor)
                   : getSolidFromAlphaColor(
-                      nodeIsDown ? node.colors.statusDown : node.colors.border,
+                      nodeStatusColor !== null ? nodeStatusColor : node.colors.border,
                       wm.settings.panel.backgroundColor
                     )
               }

--- a/src/forms/NodeForm.tsx
+++ b/src/forms/NodeForm.tsx
@@ -16,7 +16,7 @@ import {
 } from '@grafana/ui';
 import { SelectableValue, StandardEditorProps } from '@grafana/data';
 import { v4 as uuidv4 } from 'uuid';
-import { Weathermap, Node } from 'types';
+import { Weathermap, Node, NodeStatusValueMapping } from 'types';
 import { CiscoIcons, NetworkingIcons, DatabaseIcons, ComputerIcons } from './iconOptions';
 import { getDataFrameName } from 'utils';
 
@@ -454,6 +454,64 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                       }}
                     />
                   </InlineLabel>
+                  <p style={{ margin: '8px 0 4px', fontSize: '12px', fontWeight: 600 }}>Value Mappings</p>
+                  <p style={{ margin: '0 0 6px', fontSize: '11px', opacity: 0.7 }}>
+                    Map query values to border colors. Overrides the default &lt;1 = down rule.
+                  </p>
+                  {(node.statusValueMappings || []).map((mapping, mi) => (
+                    <InlineFieldRow key={mi} className={styles.inlineRow}>
+                      <InlineField label="Value">
+                        <Input
+                          type="number"
+                          value={mapping.value}
+                          onChange={(e) => {
+                            let weathermap: Weathermap = value;
+                            weathermap.nodes[i].statusValueMappings![mi].value = e.currentTarget.valueAsNumber;
+                            onChange(weathermap);
+                          }}
+                          width={8}
+                        />
+                      </InlineField>
+                      <InlineLabel width={'auto'} style={{ marginBottom: '4px' }}>
+                        Color:
+                        <ColorPicker
+                          color={mapping.color}
+                          onChange={(color) => {
+                            let weathermap: Weathermap = value;
+                            weathermap.nodes[i].statusValueMappings![mi].color = color;
+                            onChange(weathermap);
+                          }}
+                        />
+                      </InlineLabel>
+                      <Button
+                        variant="destructive"
+                        icon="trash-alt"
+                        size="sm"
+                        onClick={() => {
+                          let weathermap: Weathermap = value;
+                          weathermap.nodes[i].statusValueMappings!.splice(mi, 1);
+                          onChange(weathermap);
+                        }}
+                      />
+                    </InlineFieldRow>
+                  ))}
+                  <Button
+                    variant="secondary"
+                    icon="plus"
+                    size="sm"
+                    onClick={() => {
+                      let weathermap: Weathermap = value;
+                      const newMapping: NodeStatusValueMapping = { value: 0, color: '#ff0000' };
+                      weathermap.nodes[i].statusValueMappings = [
+                        ...(weathermap.nodes[i].statusValueMappings || []),
+                        newMapping,
+                      ];
+                      onChange(weathermap);
+                    }}
+                    style={{ marginTop: '4px' }}
+                  >
+                    Add Mapping
+                  </Button>
                 </ControlledCollapse>
               </InlineFieldRow>
               <InlineFieldRow className={styles.inlineRow}>

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,11 @@ export interface Icon {
   drawInside: boolean;
 }
 
+export interface NodeStatusValueMapping {
+  value: number;
+  color: string;
+}
+
 export interface Node {
   id: string;
   position: [number, number];
@@ -84,6 +89,7 @@ export interface Node {
   nodeIcon: Icon | null;
   isConnection: boolean;
   statusQuery?: string;
+  statusValueMappings?: NodeStatusValueMapping[];
 }
 
 export interface LinkSide {


### PR DESCRIPTION
## Summary

Adds per-node **Status Value Mappings** so any metric value can be mapped to a border color. This replaces the hardcoded binary "< 1 = down" rule with a flexible multi-state system.

**Example use case (Mikrotik SNMP)**:
| Value | Meaning |
|-------|---------|
| 1 | UP → green |
| 2 | DOWN → red |
| 3 | Testing → yellow |
| 4 | Unknown → gray |

Closes #75

## Changes

- `src/types.ts` — added `NodeStatusValueMapping` interface and `statusValueMappings?: NodeStatusValueMapping[]` on `Node`
- `src/components/MapNode.tsx` — replaced binary `nodeIsDown` logic with `nodeStatusColor` that respects value mappings
- `src/forms/NodeForm.tsx` — added mapping editor in the Status section (add / edit value+color / remove rows)

## Behavior

| Condition | Border color |
|-----------|-------------|
| No `statusQuery` | Normal border |
| `statusQuery` set, no data | `statusDown` color |
| `statusQuery` set, `statusValueMappings` empty | Legacy: value < 1 → `statusDown` |
| `statusQuery` set, mappings configured, value matches | Mapped color |
| `statusQuery` set, mappings configured, no match | Normal border |

## Test plan

- [ ] Configure a node with `statusQuery` and no mappings — verify < 1 still shows statusDown color
- [ ] Add value mappings (e.g. 1 → green, 2 → red) and verify the correct color appears for each value
- [ ] Verify "no match" falls back to normal border color
- [ ] Verify "no data" falls back to statusDown color regardless of mappings
- [ ] Verify existing nodes without mappings are unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-node status value mappings to map metric values to border colors. Keeps legacy "<1 = down" behavior when no mappings are set.

- **New Features**
  - Types: added `NodeStatusValueMapping` and optional `Node.statusValueMappings`.
  - Rendering: `MapNode` computes `nodeStatusColor` from mappings; fallbacks—no data → `statusDown`, no mappings → legacy rule, no match → normal border.
  - UI: `NodeForm` includes a simple editor to add, edit, or remove value→color mappings.

<sup>Written for commit b7f67d2ea3977b9606820ab3e22288fe5b126f52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

