### PR TITLE
chore(release): bump version to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.4.0](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.4.0) (2026-06-10)
+
+### Features
+
+* **node-status**: configurable status value mappings per node — map any query value to a border color (e.g. Mikrotik: 1=UP/green, 2=DOWN/red, 3=Testing/yellow); replaces the binary `<1 = down` rule when mappings are configured; existing nodes with no mappings are unaffected ([#75](https://github.com/allamiro/grafana-network-weathermap-ng/issues/75), PR [#116](https://github.com/allamiro/grafana-network-weathermap-ng/pull/116))
+* **link-icon-boundary**: new per-node "Attach Links to Icon Boundary" toggle (`useIconBoundaryForLinks`) — when enabled, link attachment points shift to the icon edge instead of the label-rectangle edge for nodes with external icons (`drawInside: false`), eliminating visual pass-through on large icons ([#78](https://github.com/allamiro/grafana-network-weathermap-ng/issues/78), PR [#115](https://github.com/allamiro/grafana-network-weathermap-ng/pull/115))
+* **link-visualization**: three new link display options — dynamic stroke width (scales with bandwidth utilization), flow animation (animated dashes showing traffic direction), and gradient coloring (per-link SVG gradient blending A-side and Z-side scale colors) ([#79](https://github.com/allamiro/grafana-network-weathermap-ng/issues/79), PR [#114](https://github.com/allamiro/grafana-network-weathermap-ng/pull/114))
+* **node-enhancements**: label visibility toggle (show/hide node label independently of node), duplicate node button (copies node with offset position and cleared anchors), icon aspect-ratio lock toggle in node editor ([#80](https://github.com/allamiro/grafana-network-weathermap-ng/issues/80), PR [#113](https://github.com/allamiro/grafana-network-weathermap-ng/pull/113))
+
 ## [1.3.1](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.3.1) (2026-06-10)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
## Release v1.4.0

Bumps version from 1.3.1 → 1.4.0 following merge of four feature PRs.

### What's in this release

- **#116** feat(#75): configurable node status value mappings
- **#115** feat(#78): attach link lines to node icon boundary
- **#114** feat(#79): configurable link bandwidth visualization styles
- **#113** feat(#80): label visibility toggle, duplicate node, icon aspect-ratio lock

Closes #75, #78, #79, #80

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.4.0 bumps the plugin to include configurable node status mapping, better link rendering, and new node editor controls. This improves visual clarity and editing speed.

- **New Features**
  - Node status: per-node mappings from query values to border colors; unchanged behavior if no mapping set.
  - Link attachment: toggle to attach links to the icon boundary for external icons.
  - Link visualization: dynamic width by utilization, flow animation, and A/Z gradient coloring.
  - Node editor: label visibility toggle, duplicate node, and icon aspect-ratio lock.

<sup>Written for commit 11bd842394098ae8fd89cc51d749a310f645f93b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

