### PR TITLE
feat(#71): display port/interface labels on links

### DIFF
--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -1175,6 +1175,70 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
               })}
             </g>
             <g>
+              {links.map((d, i) => {
+                if (d.nodes[0].id === d.nodes[1].id) {
+                  return;
+                }
+                const dx = d.lineEndA.x - d.lineStartA.x;
+                const dy = d.lineEndA.y - d.lineStartA.y;
+                const len = Math.sqrt(dx * dx + dy * dy);
+                if (len === 0) {
+                  return;
+                }
+                let angleDeg = Math.atan2(dy, dx) * (180 / Math.PI);
+                const flipped = angleDeg > 90 || angleDeg < -90;
+                if (flipped) {
+                  angleDeg += 180;
+                }
+                const perpOffset = -(d.stroke / 2 + wm.settings.fontSizing.link / 2 + 2);
+                const labelDist = Math.min(len * 0.25, 30);
+
+                const aPosX = d.lineStartA.x + (dx / len) * labelDist;
+                const aPosY = d.lineStartA.y + (dy / len) * labelDist;
+
+                const zdx = d.lineEndZ.x - d.lineStartZ.x;
+                const zdy = d.lineEndZ.y - d.lineStartZ.y;
+                const zlen = Math.sqrt(zdx * zdx + zdy * zdy);
+                const zPosX = zlen > 0 ? d.lineStartZ.x + (zdx / zlen) * labelDist : d.lineStartZ.x;
+                const zPosY = zlen > 0 ? d.lineStartZ.y + (zdy / zlen) * labelDist : d.lineStartZ.y;
+
+                return (
+                  <React.Fragment key={i}>
+                    {d.sides.A.portLabel && (
+                      <g transform={`translate(${aPosX},${aPosY}) rotate(${angleDeg})`}>
+                        <text
+                          x={0}
+                          y={perpOffset}
+                          textAnchor="middle"
+                          dominantBaseline="auto"
+                          fontSize={`${wm.settings.fontSizing.link}px`}
+                          fill={wm.settings.link.label.font}
+                          className={styles.noSelect}
+                        >
+                          {d.sides.A.portLabel}
+                        </text>
+                      </g>
+                    )}
+                    {d.sides.Z.portLabel && (
+                      <g transform={`translate(${zPosX},${zPosY}) rotate(${angleDeg})`}>
+                        <text
+                          x={0}
+                          y={flipped ? -perpOffset : perpOffset}
+                          textAnchor="middle"
+                          dominantBaseline="auto"
+                          fontSize={`${wm.settings.fontSizing.link}px`}
+                          fill={wm.settings.link.label.font}
+                          className={styles.noSelect}
+                        >
+                          {d.sides.Z.portLabel}
+                        </text>
+                      </g>
+                    )}
+                  </React.Fragment>
+                );
+              })}
+            </g>
+            <g>
               {nodes.map((d, i) => (
                 <MapNode
                   key={d.id}
@@ -1320,6 +1384,12 @@ const getStyles = () => {
       color: black;
       padding: 5px 10px;
       font-size: 12px;
+    `,
+    noSelect: css`
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
     `,
   };
 };

--- a/src/forms/LinkForm.tsx
+++ b/src/forms/LinkForm.tsx
@@ -342,6 +342,21 @@ export const LinkForm = (props: Props) => {
                             name={`${sName}dashboardLink`}
                           />
                         </InlineField>
+                        <InlineField grow label={`${sName} Port Label`} style={{ width: '100%' }}>
+                          <Input
+                            value={side.portLabel ?? ''}
+                            onChange={(e) => {
+                              let weathermap: Weathermap = value;
+                              weathermap.links[i].sides[sName].portLabel =
+                                e.currentTarget.value || undefined;
+                              onChange(weathermap);
+                            }}
+                            placeholder={'e.g. ge-0/0/1'}
+                            type={'text'}
+                            className={styles.nodeLabel}
+                            name={`${sName}portLabel`}
+                          />
+                        </InlineField>
                       </React.Fragment>
                     )}
                   </React.Fragment>

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,7 @@ export interface LinkSide {
   labelOffset: number;
   anchor: Anchor;
   dashboardLink: string;
+  portLabel?: string;
 }
 
 export interface Link {


### PR DESCRIPTION
## Summary

Adds an optional **port/interface label** per link side (A and Z). Labels are rendered directly on the diagram alongside the link line — rotated to match the link angle, positioned near the node endpoint, and offset perpendicular to the link so they don't overlap the line.

Closes #71

## Behavior

- A-side and Z-side each have an independent "Port Label" text input (e.g. `ge-0/0/1`, `eth0`, `Te1/0/1`)
- Empty value = no label rendered (fully backward compatible)
- Label is placed ~25% from the node endpoint along the link (capped at 30px max distance)
- Text is rotated to follow the link direction and flipped automatically so it's always readable (never upside-down)
- Font size follows the existing "Link Font Size" setting
- Label color follows the existing link label font color setting

## Changes

- `src/types.ts` — added `portLabel?: string` to `LinkSide`
- `src/WeathermapPanel.tsx` — new `<g>` render block computing angle and position for A/Z port labels; added `noSelect` CSS class
- `src/forms/LinkForm.tsx` — "A Port Label" and "Z Port Label" text inputs added per side, after Dashboard Link

## Test plan

- [ ] Set a port label on A-side (e.g. `ge-0/0/0`) — verify it appears near the source node, rotated along the link
- [ ] Set a port label on Z-side — verify it appears near the target node
- [ ] Verify vertical and diagonal links render the label readable (not upside-down)
- [ ] Verify empty port label shows nothing (no blank space rendered)
- [ ] Verify existing links with no port label are unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional per-side port/interface labels on links to show port IDs like ge-0/0/1 next to the line. Labels render near node endpoints, rotate with the link (auto-flipped for readability), and reuse existing link label styles — closes #71.

- **New Features**
  - Added "A Port Label" and "Z Port Label" inputs in the link form.
  - Empty value hides the label (backward compatible).
  - Text is non-selectable to avoid accidental selection.
  - Data model: `LinkSide.portLabel?: string`.

<sup>Written for commit 4f5c28f88baa19d41fe75b37dea44e9af025d944. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

