### PR TITLE
feat(#56): link up/down status indicator

### DIFF
--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -377,6 +377,13 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
       toReturn.arrows.width
     );
 
+    if (d.statusQuery) {
+      const sv = frameMap.get(d.statusQuery);
+      toReturn.isDown = sv === undefined || sv < 1;
+    } else {
+      toReturn.isDown = false;
+    }
+
     return toReturn;
   }
 
@@ -837,6 +844,14 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                 }
               `}</style>
             )}
+            {links.some((d) => d.isDown && d.statusBlink) && (
+              <style>{`
+                @keyframes link-blink {
+                  0%, 100% { opacity: 1; }
+                  50% { opacity: 0.15; }
+                }
+              `}</style>
+            )}
             {wm.settings.link.gradientColor &&
               links.map((d) => (
                 <React.Fragment key={d.id}>
@@ -950,10 +965,13 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                     <line
                       strokeWidth={getLinkStroke(d.sides.A.currentValue, d.sides.A.bandwidth, d.stroke)}
                       stroke={
-                        wm.settings.link.gradientColor
+                        d.isDown
+                          ? (d.statusDownColor || '#d32f2f')
+                          : wm.settings.link.gradientColor
                           ? `url(#grad-a-${d.id})`
                           : getScaleColor(d.sides.A.currentValue, d.sides.A.bandwidth)
                       }
+                      strokeDasharray={d.isDown ? '8 4' : undefined}
                       x1={d.lineStartA.x}
                       y1={d.lineStartA.y}
                       x2={d.lineEndA.x}
@@ -969,7 +987,9 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                       }}
                       style={{
                         ...(d.sides.A.dashboardLink.length > 0 ? { cursor: 'pointer' } : {}),
-                        ...(wm.settings.link.flowAnimation?.enabled
+                        ...(d.isDown && d.statusBlink
+                          ? { animation: 'link-blink 1s ease-in-out infinite' }
+                          : wm.settings.link.flowAnimation?.enabled
                           ? {
                               strokeDasharray: '10 5',
                               animation: `link-flow-forward ${wm.settings.link.flowAnimation.speed}s linear infinite`,
@@ -1001,7 +1021,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                                         ${d.arrowPolygonA.p2.x}
                                         ${d.arrowPolygonA.p2.y}
                                     `}
-                          fill={getScaleColor(d.sides.A.currentValue, d.sides.A.bandwidth)}
+                          fill={d.isDown ? (d.statusDownColor || '#d32f2f') : getScaleColor(d.sides.A.currentValue, d.sides.A.bandwidth)}
                           onMouseMove={(e) => {
                             handleLinkHover(d, 'A', e);
                           }}
@@ -1016,10 +1036,13 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                         <line
                           strokeWidth={getLinkStroke(d.sides.Z.currentValue, d.sides.Z.bandwidth, d.stroke)}
                           stroke={
-                            wm.settings.link.gradientColor
+                            d.isDown
+                              ? (d.statusDownColor || '#d32f2f')
+                              : wm.settings.link.gradientColor
                               ? `url(#grad-z-${d.id})`
                               : getScaleColor(d.sides.Z.currentValue, d.sides.Z.bandwidth)
                           }
+                          strokeDasharray={d.isDown ? '8 4' : undefined}
                           x1={d.lineStartZ.x}
                           y1={d.lineStartZ.y}
                           x2={d.lineEndZ.x}
@@ -1035,7 +1058,9 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                           }}
                           style={{
                             ...(d.sides.Z.dashboardLink.length > 0 ? { cursor: 'pointer' } : {}),
-                            ...(wm.settings.link.flowAnimation?.enabled
+                            ...(d.isDown && d.statusBlink
+                              ? { animation: 'link-blink 1s ease-in-out infinite' }
+                              : wm.settings.link.flowAnimation?.enabled
                               ? {
                                   strokeDasharray: '10 5',
                                   animation: `link-flow-forward ${wm.settings.link.flowAnimation.speed}s linear infinite`,
@@ -1052,7 +1077,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                                         ${d.arrowPolygonZ.p2.x}
                                         ${d.arrowPolygonZ.p2.y}
                                     `}
-                          fill={getScaleColor(d.sides.Z.currentValue, d.sides.Z.bandwidth)}
+                          fill={d.isDown ? (d.statusDownColor || '#d32f2f') : getScaleColor(d.sides.Z.currentValue, d.sides.Z.bandwidth)}
                           onMouseMove={(e) => {
                             handleLinkHover(d, 'Z', e);
                           }}

--- a/src/forms/LinkForm.tsx
+++ b/src/forms/LinkForm.tsx
@@ -2,9 +2,11 @@ import React, { useState } from 'react';
 import { css } from '@emotion/css';
 import {
   Button,
+  ColorPicker,
   ControlledCollapse,
   InlineField,
   InlineFieldRow,
+  InlineLabel,
   InlineSwitch,
   Input,
   Select,
@@ -445,6 +447,42 @@ export const LinkForm = (props: Props) => {
                   Apply to All?
                 </Button>
               </ControlledCollapse>
+              <FormDivider title="Link Status" />
+              <InlineField grow label="Status Query" style={{ width: '100%' }}>
+                <Select
+                  onChange={(v) => {
+                    let weathermap: Weathermap = value;
+                    weathermap.links[i].statusQuery = v ? v.value : undefined;
+                    onChange(weathermap);
+                  }}
+                  value={dataWithIds.find((p) => p.value === link.statusQuery) ?? null}
+                  options={dataWithIds}
+                  placeholder="Select query (value < 1 = down)"
+                  isClearable
+                  menuShouldPortal
+                />
+              </InlineField>
+              <InlineLabel width={'auto'} style={{ marginBottom: '4px' }}>
+                Down Color:
+                <ColorPicker
+                  color={link.statusDownColor || '#d32f2f'}
+                  onChange={(color) => {
+                    let weathermap: Weathermap = value;
+                    weathermap.links[i].statusDownColor = color;
+                    onChange(weathermap);
+                  }}
+                />
+              </InlineLabel>
+              <InlineField grow label="Blink when down">
+                <InlineSwitch
+                  value={link.statusBlink ?? false}
+                  onChange={(e) => {
+                    let weathermap: Weathermap = value;
+                    weathermap.links[i].statusBlink = e.currentTarget.checked;
+                    onChange(weathermap);
+                  }}
+                />
+              </InlineField>
               <InlineFieldRow className={styles.row}>
                 <Button variant="destructive" icon="trash-alt" size="md" onClick={() => removeLink(i)} className={''}>
                   Remove Link

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,6 +114,9 @@ export interface Link {
   arrows: ArrowOptions;
   stroke: number;
   showThroughputPercentage: boolean;
+  statusQuery?: string;
+  statusDownColor?: string;
+  statusBlink?: boolean;
 }
 
 export interface DrawnNode extends Node {
@@ -154,6 +157,7 @@ export interface DrawnLink extends Link {
   lineEndZ: Position;
   arrowCenterZ: Position;
   arrowPolygonZ: any;
+  isDown: boolean;
 }
 
 export interface HoveredLink {


### PR DESCRIPTION
## Summary

Adds a per-link **status query** that visually marks a link as **down** when the query value is `< 1` or absent.

Closes #56

## Visual behavior when a link is down

| Element | Change |
|---------|--------|
| A and Z lines | Color overridden → down color (default `#d32f2f`) |
| A and Z lines | Dashed stroke (`8 4` pattern) |
| A and Z arrows | Color overridden → down color |
| Optional blink | 1 s ease-in-out fade (toggle per link) |

## New per-link settings (in "Link Status" section of Link editor)

| Setting | Description |
|---------|-------------|
| **Status Query** | Query whose value determines link state (value < 1 OR no data = down) |
| **Down Color** | Color applied when link is down (default red `#d32f2f`) |
| **Blink when down** | Enables CSS opacity animation on the dashed line |

## Changes

- `src/types.ts` — added `statusQuery?`, `statusDownColor?`, `statusBlink?` to `Link`; added `isDown: boolean` to `DrawnLink`
- `src/WeathermapPanel.tsx` — `isDown` computed in `generateDrawnLink`; `@keyframes link-blink` injected into `<defs>` when needed; A/Z lines and arrow polygons check `isDown` for color/dash/animation overrides
- `src/forms/LinkForm.tsx` — "Link Status" section with query selector, color picker, and blink toggle

## Test plan

- [ ] Set Status Query on a link — with value ≥ 1, verify no visual change
- [ ] Set value < 1 — verify dashed red line on both A and Z sides
- [ ] Enable "Blink when down" — verify pulsing animation
- [ ] Change "Down Color" — verify custom color appears
- [ ] Verify links with no status query are unchanged
- [ ] Verify "no data" also triggers the down state

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-link up/down indicator based on a status query. When down (value < 1 or no data), the link switches to a dashed line with a configurable color and optional blink; links without a status query are unchanged.

- New Features
  - Link editor adds "Link Status": select status query, set down color, toggle blink.
  - Down-state visuals: A/Z lines and arrows use the down color, dashed stroke, optional 1s fade blink.
  - Meets #56 per-link up/down indicator requirement.

<sup>Written for commit 1f09ef99391f07e92b076ff9b6e8352c392d97d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

