### PR TITLE
feat(#60): absolute value scale mode for color thresholds

### DIFF
--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -84,19 +84,26 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
   const [selectedNodes, setSelectedNodes] = useState([] as DrawnNode[]);
 
   function getScaleColor(current: number, max: number) {
-    if (max === 0) {
-      return getSolidFromAlphaColor(wm.settings.link.stroke.color, wm.settings.panel.backgroundColor);
-    }
-
-    const percent = (current / max) * 100;
     const defaultColor = getSolidFromAlphaColor(wm.settings.link.stroke.color, wm.settings.panel.backgroundColor);
     let assignedColor = defaultColor;
 
-    wm.scale.forEach((threshold: Threshold) => {
-      if (threshold.percent <= percent) {
-        assignedColor = threshold.color;
+    if (wm.settings.colorScaleMode === 'value') {
+      wm.scale.forEach((threshold: Threshold) => {
+        if (threshold.percent <= current) {
+          assignedColor = threshold.color;
+        }
+      });
+    } else {
+      if (max === 0) {
+        return defaultColor;
       }
-    });
+      const percent = (current / max) * 100;
+      wm.scale.forEach((threshold: Threshold) => {
+        if (threshold.percent <= percent) {
+          assignedColor = threshold.color;
+        }
+      });
+    }
 
     return assignedColor;
   }

--- a/src/components/ColorScale.tsx
+++ b/src/components/ColorScale.tsx
@@ -20,14 +20,21 @@ const ColorScale: React.FC<ColorScaleProps> = (props: ColorScaleProps) => {
   if (settings.scale) {
     // Double check scale existence, since sometimes it doesn't before we get here.
     const minBandHeight = (settings.scale.fontSizing?.threshold ?? 12) + 4;
+    const isValueMode = settings.colorScaleMode === 'value';
 
-    thresholds.forEach((threshold, i) => {
-      const current: number = threshold.percent;
-      const next: number = thresholds[i + 1] !== undefined ? thresholds[i + 1].percent : 101;
-      let height: number = ((next - current) / 100) * settings.scale.size.height;
-      height = Math.max(height, minBandHeight);
-      scaleHeights[i] = height.toString() + 'px';
-    });
+    if (isValueMode || thresholds.length === 0) {
+      thresholds.forEach((_, i) => {
+        scaleHeights[i] = Math.max(settings.scale.size.height / Math.max(thresholds.length, 1), minBandHeight).toString() + 'px';
+      });
+    } else {
+      thresholds.forEach((threshold, i) => {
+        const current: number = threshold.percent;
+        const next: number = thresholds[i + 1] !== undefined ? thresholds[i + 1].percent : 101;
+        let height: number = ((next - current) / 100) * settings.scale.size.height;
+        height = Math.max(height, minBandHeight);
+        scaleHeights[i] = height.toString() + 'px';
+      });
+    }
   }
 
   if (settings.scale && settings.scale.fontSizing) {
@@ -56,41 +63,54 @@ const ColorScale: React.FC<ColorScaleProps> = (props: ColorScaleProps) => {
         >
           {settings.scale.title}
         </div>
-        {thresholds.map((threshold, i) => (
-          <div className={styles.colorScaleItem} key={i} data-testid="scale-item">
-            <span
-              className={cx(
-                styles.colorBox,
-                css`
-                  background: ${threshold.color};
-                  height: ${scaleHeights[i]};
-                  width: ${settings.scale.size.width}px;
-                `
-              )}
-            ></span>
-            <span
-              className={cx(
-                styles.colorLabel,
-                css`
-                  font-size: ${settings.scale.fontSizing.threshold}px;
-                  color: ${theme.colors.getContrastText(
-                    settings.panel.backgroundColor.startsWith('image')
-                      ? settings.panel.backgroundColor.split('|', 3)[1]
-                      : settings.panel.backgroundColor
-                  )};
-                `
-              )}
-            >
-              {threshold.percent +
-                '%' +
-                (thresholds[i + 1] === undefined
-                  ? threshold.percent >= 100
-                    ? ''
-                    : ' - 100%'
-                  : ' - ' + thresholds[i + 1].percent + '%')}
-            </span>
-          </div>
-        ))}
+        {thresholds.map((threshold, i) => {
+          const isValueMode = settings.colorScaleMode === 'value';
+          let label: string;
+          if (isValueMode) {
+            label =
+              thresholds[i + 1] === undefined
+                ? String(threshold.percent) + '+'
+                : threshold.percent + ' – ' + thresholds[i + 1].percent;
+          } else {
+            label =
+              threshold.percent +
+              '%' +
+              (thresholds[i + 1] === undefined
+                ? threshold.percent >= 100
+                  ? ''
+                  : ' - 100%'
+                : ' - ' + thresholds[i + 1].percent + '%');
+          }
+          return (
+            <div className={styles.colorScaleItem} key={i} data-testid="scale-item">
+              <span
+                className={cx(
+                  styles.colorBox,
+                  css`
+                    background: ${threshold.color};
+                    height: ${scaleHeights[i]};
+                    width: ${settings.scale.size.width}px;
+                  `
+                )}
+              ></span>
+              <span
+                className={cx(
+                  styles.colorLabel,
+                  css`
+                    font-size: ${settings.scale.fontSizing.threshold}px;
+                    color: ${theme.colors.getContrastText(
+                      settings.panel.backgroundColor.startsWith('image')
+                        ? settings.panel.backgroundColor.split('|', 3)[1]
+                        : settings.panel.backgroundColor
+                    )};
+                  `
+                )}
+              >
+                {label}
+              </span>
+            </div>
+          );
+        })}
       </div>
     );
   } else {

--- a/src/forms/ColorForm.tsx
+++ b/src/forms/ColorForm.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { css } from '@emotion/css';
-import { Button, Input, ColorPicker, Icon, useStyles2 } from '@grafana/ui';
-import { GrafanaTheme2, StandardEditorProps } from '@grafana/data';
+import { Button, Input, ColorPicker, Icon, useStyles2, RadioButtonGroup } from '@grafana/ui';
+import { GrafanaTheme2, SelectableValue, StandardEditorProps } from '@grafana/data';
 import { Weathermap } from 'types';
 
 interface Settings {
@@ -63,6 +63,21 @@ export const ColorForm = (props: Props) => {
 
   const [editedPercents, setEditedPercents] = useState(value.scale);
 
+  const scaleModeOptions: Array<SelectableValue<'percent' | 'value'>> = [
+    { label: 'Percentage', value: 'percent' },
+    { label: 'Absolute Value', value: 'value' },
+  ];
+
+  const currentMode = value.settings.colorScaleMode ?? 'percent';
+
+  const handleModeChange = (mode: 'percent' | 'value') => {
+    let weathermap: Weathermap = value;
+    weathermap.settings.colorScaleMode = mode;
+    onChange(weathermap);
+  };
+
+  const thresholdLabel = currentMode === 'value' ? 'Value' : '%';
+
   return (
     <React.Fragment>
       <h6
@@ -74,6 +89,10 @@ export const ColorForm = (props: Props) => {
       >
         Color Scale
       </h6>
+      <div className={styles.modeRow}>
+        <span className={styles.modeLabel}>Scale Mode</span>
+        <RadioButtonGroup options={scaleModeOptions} value={currentMode} onChange={handleModeChange} size="sm" />
+      </div>
       {editedPercents.map((threshold, i) => (
         <Input
           className={styles.item}
@@ -98,7 +117,12 @@ export const ColorForm = (props: Props) => {
               </div>
             </div>
           }
-          suffix={<Icon className={styles.trashIcon} name="trash-alt" onClick={() => handleDeletePercent(i)} />}
+          suffix={
+            <>
+              <span className={styles.unitSuffix}>{thresholdLabel}</span>
+              <Icon className={styles.trashIcon} name="trash-alt" onClick={() => handleDeletePercent(i)} />
+            </>
+          }
         />
       ))}
 
@@ -154,6 +178,22 @@ const getStyles = (theme: GrafanaTheme2) => {
       &:last-child {
         margin-bottom: 0;
       }
+    `,
+    modeRow: css`
+      display: flex;
+      align-items: center;
+      gap: ${theme.spacing(1)};
+      margin-bottom: ${theme.spacing(1)};
+    `,
+    modeLabel: css`
+      font-size: ${theme.typography.bodySmall.fontSize};
+      color: ${theme.colors.text.secondary};
+      white-space: nowrap;
+    `,
+    unitSuffix: css`
+      font-size: ${theme.typography.bodySmall.fontSize};
+      color: ${theme.colors.text.secondary};
+      padding: 0 ${theme.spacing(0.5)};
     `,
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -201,6 +201,7 @@ export interface WeathermapSettings {
     node: number;
     link: number;
   };
+  colorScaleMode?: 'percent' | 'value';
   panel: PanelOptions;
   tooltip: TooltipOptions;
   scale: TrafficPanelSettings;


### PR DESCRIPTION
## Summary

- Adds `colorScaleMode?: 'percent' | 'value'` to `WeathermapSettings` in `types.ts`
- In **value mode**, `getScaleColor()` compares the raw metric directly against threshold values (bypassing the `current/max * 100` percent calculation) — supports negative values like dBm, SNR
- **Color Scale editor** (`ColorForm.tsx`) gains a "Scale Mode" radio toggle (Percentage / Absolute Value); threshold input suffix shows `%` or `Value` accordingly
- **Color Scale legend** (`ColorScale.tsx`) renders value ranges (e.g. `-90 – -80`) instead of percent ranges when in value mode; band heights divide equally when values aren't percentage-bounded

## Test plan

- [ ] Create a panel with a signal-strength metric (e.g. dBm values around -90 to -50)
- [ ] Open Color Scale editor, switch Scale Mode to **Absolute Value**
- [ ] Add thresholds: e.g. `-90` (red), `-75` (yellow), `-60` (green)
- [ ] Confirm links color correctly based on raw value, not percentage of bandwidth
- [ ] Confirm scale legend shows value ranges, not percent ranges
- [ ] Switch back to **Percentage** mode — confirm existing percent behavior is unchanged
- [ ] Verify typecheck and build pass (both clean)

Closes #60

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an absolute value scale mode for color thresholds so link colors can be driven by raw metrics (e.g., dBm, SNR, latency) instead of percentages. The legend and editor adapt to the selected mode; percentage remains the default. Closes #60.

- New Features
  - Added `colorScaleMode?: 'percent' | 'value'` to `WeathermapSettings`.
  - In value mode, `getScaleColor()` compares raw values to thresholds (supports negatives).
  - Legend shows value ranges; band heights split evenly when not percentage-bounded.
  - Color Scale editor adds a "Scale Mode" toggle; threshold inputs show `%` or `Value`.

- Migration
  - No action needed; existing panels stay in percentage mode by default.

<sup>Written for commit 2ba5822ca23ac678a0b9dc936ff86d509d3e8354. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

