### PR TITLE
chore(release): bump version to 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.4.1](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.4.1) (2026-06-10)
+
+### Features
+
+* **link-port-labels**: configurable A-side and Z-side port/interface labels on links — enter interface names (e.g. `ge-0/0/0`) per side in the link editor; labels render adjacent to the link line at 25% from each endpoint, rotated to follow the link direction ([#71](https://github.com/allamiro/grafana-network-weathermap-ng/issues/71), PR [#119](https://github.com/allamiro/grafana-network-weathermap-ng/pull/119))
+* **link-status**: per-link up/down status indicator — assign a status query to any link; when the value is 0 or absent the link renders in a configurable down color with a dashed stroke; optional blink animation draws attention to down links; overrides gradient/flow-animation rendering while down ([#56](https://github.com/allamiro/grafana-network-weathermap-ng/issues/56), PR [#120](https://github.com/allamiro/grafana-network-weathermap-ng/pull/120))
+* **absolute-scale**: color scale mode toggle (Percentage / Absolute Value) — in absolute mode, threshold values are compared directly against raw metric values instead of percentage of max bandwidth, enabling dBm, SNR, latency, and other non-percentage scales; the color scale legend adapts to show value ranges; backward-compatible (existing configs default to percentage mode) ([#60](https://github.com/allamiro/grafana-network-weathermap-ng/issues/60), PR [#121](https://github.com/allamiro/grafana-network-weathermap-ng/pull/121))
+
 ## [1.4.0](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.4.0) (2026-06-10)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
## v1.4.1 Release

Bumps version to 1.4.1 and updates CHANGELOG. Includes three new features merged to main:

- **#119** — Port/interface labels on links (#71)
- **#120** — Link up/down status indicator (#56)
- **#121** — Absolute value color scale mode (#60)

## Changes
- `package.json`: `1.4.0` → `1.4.1`
- `CHANGELOG.md`: add v1.4.1 section

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps version to 1.4.1 and updates the CHANGELOG for release. Ships link port/interface labels, per-link up/down status indicator, and an absolute value color-scale mode.

<sup>Written for commit 373adbff96725afa6661f4709ac829ff9c08a8ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

