### PR TITLE
feat(#77): dashboard variable / templating support for dynamic weathermaps

### DIFF
--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -22,7 +22,7 @@ import {
   useStyles2,
   useTheme2,
 } from '@grafana/ui';
-import { locationService } from '@grafana/runtime';
+import { getTemplateSrv, locationService } from '@grafana/runtime';
 import {
   measureText,
   getSolidFromAlphaColor,
@@ -43,7 +43,20 @@ function generateDrawnNode(d: Node, i: number, wm: Weathermap): DrawnNode {
   toReturn.index = i;
   toReturn.x = toReturn.position[0];
   toReturn.y = toReturn.position[1];
-  toReturn.labelWidth = measureText(d.label ? d.label : '', wm.settings.fontSizing.node).width;
+
+  // Resolve Grafana template variables ($var) at draw time
+  const tmplSrv = getTemplateSrv();
+  if (toReturn.label !== undefined) {
+    toReturn.label = tmplSrv.replace(toReturn.label);
+  }
+  if (toReturn.statusQuery) {
+    toReturn.statusQuery = tmplSrv.replace(toReturn.statusQuery);
+  }
+  if (toReturn.dashboardLink) {
+    toReturn.dashboardLink = tmplSrv.replace(toReturn.dashboardLink);
+  }
+
+  toReturn.labelWidth = measureText(toReturn.label ? toReturn.label : '', wm.settings.fontSizing.node).width;
   toReturn.anchors = {
     0: { numLinks: toReturn.anchors[0].numLinks, numFilledLinks: 0 },
     1: { numLinks: toReturn.anchors[1].numLinks, numFilledLinks: 0 },
@@ -279,6 +292,23 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
   function generateDrawnLink(d: Link, i: number, frameMap: Map<string, number>): DrawnLink {
     let toReturn: DrawnLink = { ...d, sides: { A: { ...d.sides.A }, Z: { ...d.sides.Z } } } as DrawnLink;
     toReturn.index = i;
+
+    // Resolve Grafana template variables ($var) in all query and link strings
+    const tmplSrv = getTemplateSrv();
+    (['A', 'Z'] as const).forEach((side) => {
+      if (toReturn.sides[side].bandwidthQuery) {
+        toReturn.sides[side].bandwidthQuery = tmplSrv.replace(toReturn.sides[side].bandwidthQuery!);
+      }
+      if (toReturn.sides[side].query) {
+        toReturn.sides[side].query = tmplSrv.replace(toReturn.sides[side].query!);
+      }
+      if (toReturn.sides[side].dashboardLink) {
+        toReturn.sides[side].dashboardLink = tmplSrv.replace(toReturn.sides[side].dashboardLink);
+      }
+    });
+    if (toReturn.statusQuery) {
+      toReturn.statusQuery = tmplSrv.replace(toReturn.statusQuery);
+    }
 
     const linkValueFormatter = getlinkValueFormatter(
       d.units ? d.units : wm.settings.link.defaultUnits ? wm.settings.link.defaultUnits : 'bps'
@@ -648,8 +678,8 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                 justifyContent: 'center',
               }}
             >
-              {hoveredLink.link.nodes[0].label} {hoveredLink.side === 'A' ? '--->' : '<---'}{' '}
-              {hoveredLink.link.nodes[1].label}
+              {hoveredLink.link.source.label} {hoveredLink.side === 'A' ? '--->' : '<---'}{' '}
+              {hoveredLink.link.target.label}
             </div>
             <div style={{ fontSize: wm.settings.tooltip.fontSize }}>
               Usage - Inbound: {hoveredLink.link.sides[hoveredLink.side === 'A' ? 'Z' : 'A'].currentValueText}, Outbound:{' '}

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -47,13 +47,13 @@ function generateDrawnNode(d: Node, i: number, wm: Weathermap): DrawnNode {
   // Resolve Grafana template variables ($var) at draw time
   const tmplSrv = getTemplateSrv();
   if (toReturn.label !== undefined) {
-    toReturn.label = tmplSrv.replace(toReturn.label);
+    toReturn.label = tmplSrv?.replace(toReturn.label) ?? toReturn.label;
   }
   if (toReturn.statusQuery) {
-    toReturn.statusQuery = tmplSrv.replace(toReturn.statusQuery);
+    toReturn.statusQuery = tmplSrv?.replace(toReturn.statusQuery) ?? toReturn.statusQuery;
   }
   if (toReturn.dashboardLink) {
-    toReturn.dashboardLink = tmplSrv.replace(toReturn.dashboardLink);
+    toReturn.dashboardLink = tmplSrv?.replace(toReturn.dashboardLink) ?? toReturn.dashboardLink;
   }
 
   toReturn.labelWidth = measureText(toReturn.label ? toReturn.label : '', wm.settings.fontSizing.node).width;
@@ -297,17 +297,17 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
     const tmplSrv = getTemplateSrv();
     (['A', 'Z'] as const).forEach((side) => {
       if (toReturn.sides[side].bandwidthQuery) {
-        toReturn.sides[side].bandwidthQuery = tmplSrv.replace(toReturn.sides[side].bandwidthQuery!);
+        toReturn.sides[side].bandwidthQuery = tmplSrv?.replace(toReturn.sides[side].bandwidthQuery!) ?? toReturn.sides[side].bandwidthQuery;
       }
       if (toReturn.sides[side].query) {
-        toReturn.sides[side].query = tmplSrv.replace(toReturn.sides[side].query!);
+        toReturn.sides[side].query = tmplSrv?.replace(toReturn.sides[side].query!) ?? toReturn.sides[side].query;
       }
       if (toReturn.sides[side].dashboardLink) {
-        toReturn.sides[side].dashboardLink = tmplSrv.replace(toReturn.sides[side].dashboardLink);
+        toReturn.sides[side].dashboardLink = tmplSrv?.replace(toReturn.sides[side].dashboardLink) ?? toReturn.sides[side].dashboardLink;
       }
     });
     if (toReturn.statusQuery) {
-      toReturn.statusQuery = tmplSrv.replace(toReturn.statusQuery);
+      toReturn.statusQuery = tmplSrv?.replace(toReturn.statusQuery) ?? toReturn.statusQuery;
     }
 
     const linkValueFormatter = getlinkValueFormatter(


### PR DESCRIPTION
## Summary

- Calls `getTemplateSrv().replace()` on all user-entered strings at draw time so Grafana dashboard variables like `$site`, `$region`, or `${host}` are resolved before query matching, label rendering, and dashboard link navigation
- Applies to: node labels, node status queries, node dashboard links, link A/Z queries, link A/Z bandwidth queries, link A/Z dashboard links, link status queries
- Node box sizing uses the resolved label width so the box fits the interpolated text
- Tooltip header uses resolved node labels (via `source`/`target` on `DrawnLink` which are `DrawnNode` objects with variables already resolved)
- No schema changes — fully backward-compatible; maps with no variables behave identically

## How it works

`generateDrawnNode` and `generateDrawnLink` now call `getTemplateSrv().replace()` on every string field before writing values into the `DrawnNode`/`DrawnLink` structs. Since all downstream rendering, frame lookups, and click handlers read from those structs, variable resolution is automatic throughout.

## Use cases enabled (from upstream #27)

- **Multi-site maps**: `$site` variable in queries like `traffic-$site-core-in` — one weathermap per dashboard variable value
- **Dynamic labels**: node label `Router - $site` shows the selected site name at runtime
- **Variable-driven dashboard links**: `/d/abc123/detail?var-host=$host` on links/nodes
- **Multi-tenant maps**: data source variable `$ds` in bandwidth queries

## Test plan

- [ ] Create a dashboard variable `site` with values `nyc`, `lon`
- [ ] Add a node with label `POP - $site` — confirm it renders as `POP - nyc` / `POP - lon`
- [ ] Add a link with query `traffic-$site-uplink` — confirm it matches the correct data frame for the selected variable
- [ ] Add a node dashboard link `/d/xyz?var-site=$site` — confirm it opens with the correct variable value
- [ ] Verify maps with no variables are unaffected (template replace on a string with no `$` is a no-op)

Closes #77

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Grafana dashboard variable support by resolving `$var` with `getTemplateSrv().replace()` at draw time, and guards `getTemplateSrv()` for test environments. Enables dynamic labels, queries, and dashboard links with no schema changes; maps without variables behave the same (closes #77).

- **New Features**
  - Resolve variables in node labels, status queries, and dashboard links; node box width adapts to resolved text.
  - Resolve variables in link A/Z queries, bandwidth queries, status queries, and dashboard links; tooltip header shows resolved `source`/`target` labels.

<sup>Written for commit 9be1d213010f46720acab0169122adab495fbffe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

