### PR TITLE
chore(release): bump version to 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.4.2](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.4.2) (2026-06-10)
+
+### Features
+
+* **template-variables**: Grafana dashboard variables (`$var`, `${var}`) are now resolved at draw time across all user-entered string fields — node labels, node/link status queries, node/link dashboard links, link A/Z throughput queries, and link A/Z bandwidth queries; enables dynamic multi-site maps, variable-driven queries, and variable-based dashboard links without duplicating panels ([#77](https://github.com/allamiro/grafana-network-weathermap-ng/issues/77), PR [#123](https://github.com/allamiro/grafana-network-weathermap-ng/pull/123))
+
 ## [1.4.1](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.4.1) (2026-06-10)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
## v1.4.2 Release

Bumps version to 1.4.2 and updates CHANGELOG.

### Included
- **#123** — Grafana template variable support in all weathermap string fields (#77)

### Changes
- `package.json`: `1.4.1` → `1.4.2`
- `CHANGELOG.md`: add v1.4.2 section

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.4.2 to ship Grafana dashboard template variable support across weathermap string fields. Updates `package.json` version and `CHANGELOG.md`.

- **New Features**
  - Resolve `$var` and `${var}` at draw time in: node labels; node/link status queries; node/link dashboard links; link A/Z throughput and bandwidth queries.

<sup>Written for commit 6a50aabfbcfe214054bc9a9155b12ee072ffae01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

