### PR TITLE
feat(#65): color scale thresholds above 100% for oversubscribed links

### DIFF
--- a/src/components/ColorScale.tsx
+++ b/src/components/ColorScale.tsx
@@ -27,10 +27,12 @@ const ColorScale: React.FC<ColorScaleProps> = (props: ColorScaleProps) => {
         scaleHeights[i] = Math.max(settings.scale.size.height / Math.max(thresholds.length, 1), minBandHeight).toString() + 'px';
       });
     } else {
+      const maxThreshold = thresholds[thresholds.length - 1]?.percent ?? 100;
+      const ceiling = Math.max(101, maxThreshold + 1);
       thresholds.forEach((threshold, i) => {
         const current: number = threshold.percent;
-        const next: number = thresholds[i + 1] !== undefined ? thresholds[i + 1].percent : 101;
-        let height: number = ((next - current) / 100) * settings.scale.size.height;
+        const next: number = thresholds[i + 1] !== undefined ? thresholds[i + 1].percent : ceiling;
+        let height: number = ((next - current) / ceiling) * settings.scale.size.height;
         height = Math.max(height, minBandHeight);
         scaleHeights[i] = height.toString() + 'px';
       });
@@ -77,7 +79,7 @@ const ColorScale: React.FC<ColorScaleProps> = (props: ColorScaleProps) => {
               '%' +
               (thresholds[i + 1] === undefined
                 ? threshold.percent >= 100
-                  ? ''
+                  ? '+'
                   : ' - 100%'
                 : ' - ' + thresholds[i + 1].percent + '%');
           }


### PR DESCRIPTION
## Summary

- Fixes `ColorScale` legend band sizing when any threshold exceeds 100%: the ceiling for the top band is now `max(101, highest_threshold + 1)` instead of hardcoded `101`, which previously produced a negative height for the last band (e.g. threshold at 125% gave `(101-125)/100 * height = negative`, caught by `minBandHeight` but wrong proportions)
- The proportional denominator uses the same ceiling so all bands scale correctly relative to each other
- Last threshold label now shows `X%+` instead of bare `X%` when ≥ 100%, consistent with how absolute-value mode labels the top band

## What already worked (no change needed)
- `getScaleColor()` already computes `percent = (current/max)*100` — a 125% oversubscribed link already matched a 125% threshold correctly
- `ColorForm` input has no `max` attribute — users could already type > 100 values
- `currentPercentageText` in the tooltip already shows `125.00%`

## Test plan
- [ ] Add thresholds: e.g. 0% (green), 75% (yellow), 100% (red), 125% (purple)
- [ ] Confirm oversubscribed link (current > max bandwidth) colors purple in the panel
- [ ] Confirm legend shows `0% - 75%`, `75% - 100%`, `100% - 125%`, `125%+` with proportional band heights
- [ ] Confirm existing maps with all thresholds ≤ 100% are visually unchanged
- [ ] Tests pass (all 10)

Closes #65

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Supports color scale thresholds above 100% and fixes legend band sizing so oversubscribed links render with correct proportions and a clear “X%+” top label. Addresses #65.

- **Bug Fixes**
  - Use a dynamic ceiling: max(101, highest_threshold + 1) for the top band.
  - Scale band heights using the same ceiling for correct proportions.
  - Show “X%+” for the last threshold when ≥ 100%.

<sup>Written for commit 81428dfafc483c6a7f4ad5305102ab563c7ebcba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

