### PR TITLE
chore(release): bump version to 1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.4.3](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.4.3) (2026-06-10)
+
+### Features
+
+* **oversubscribed-scale**: color scale thresholds above 100% now work correctly for oversubscribed links — legend band sizing uses a dynamic ceiling (`max(101, highest_threshold + 1)`) instead of a hardcoded 101, fixing broken proportions when any threshold exceeds 100%; top-band label now shows `X%+` to indicate the color applies at or above that threshold ([#65](https://github.com/allamiro/grafana-network-weathermap-ng/issues/65), PR [#125](https://github.com/allamiro/grafana-network-weathermap-ng/pull/125))
+
 ## [1.4.2](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.4.2) (2026-06-10)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Bumps version to 1.4.3. Includes PR #125 — color scale thresholds above 100% for oversubscribed links (#65).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release 1.4.3. Fixes oversubscribed link color scales with thresholds above 100% by using a dynamic legend ceiling and showing X%+ for the top band.

<sup>Written for commit 52c8d5df0c32b55f0c70c21725d8c7b0685f1e20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

