### PR TITLE
feat(#66): configurable decimal places for link throughput display values

### DIFF
--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -313,6 +313,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
     const linkValueFormatter = getlinkValueFormatter(
       d.units ? d.units : wm.settings.link.defaultUnits ? wm.settings.link.defaultUnits : 'bps'
     );
+    const linkDecimals = wm.settings.link.linkDecimals;
 
     // Set the link's source and target node
     toReturn.source = nodes.filter((n) => n.id === toReturn.nodes[0].id)[0];
@@ -343,13 +344,13 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
           toReturn.sides[side].currentValue = frameValue;
 
           // Get the text formatted to KiB/MiB/etc.
-          let scaledSideValue = linkValueFormatter(toReturn.sides[side].currentValue);
+          let scaledSideValue = linkValueFormatter(toReturn.sides[side].currentValue, linkDecimals);
           toReturn.sides[side].currentValueText = `${scaledSideValue.text} ${scaledSideValue.suffix}`;
 
           // Get the percentage througput text
           toReturn.sides[side].currentPercentageText =
             toReturn.sides[side].bandwidth > 0
-              ? `${((toReturn.sides[side].currentValue / toReturn.sides[side].bandwidth) * 100).toFixed(2)}%`
+              ? `${((toReturn.sides[side].currentValue / toReturn.sides[side].bandwidth) * 100).toFixed(linkDecimals ?? 2)}%`
               : 'n/a%';
         }
       }
@@ -361,7 +362,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
         toReturn.sides[side].currentText = toReturn.sides[side].currentValueText;
       }
 
-      let scaledBandwidth = linkValueFormatter(toReturn.sides[side].bandwidth);
+      let scaledBandwidth = linkValueFormatter(toReturn.sides[side].bandwidth, linkDecimals);
       toReturn.sides[side].currentBandwidthText = `${scaledBandwidth.text} ${scaledBandwidth.suffix}`;
     }
 

--- a/src/forms/PanelForm.tsx
+++ b/src/forms/PanelForm.tsx
@@ -228,6 +228,21 @@ export const PanelForm = ({ value, onChange }: Props) => {
             value={value.settings.link.defaultUnits ? value.settings.link.defaultUnits : 'bps'}
           />
         </InlineField>
+        <InlineField grow label={'Link Value Decimal Places'} tooltip={'Number of decimal places for throughput labels and percentage values. Leave blank for automatic precision.'}>
+          <Input
+            type="number"
+            min={0}
+            max={10}
+            placeholder="auto"
+            value={value.settings.link.linkDecimals ?? ''}
+            onChange={(e) => {
+              let wm = value;
+              const v = e.currentTarget.valueAsNumber;
+              wm.settings.link.linkDecimals = isNaN(v) ? undefined : Math.max(0, Math.floor(v));
+              onChange(wm);
+            }}
+          />
+        </InlineField>
         <InlineField grow label={'Reset All Links to Default Units'}>
           <Button
             variant="destructive"

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,6 +190,7 @@ export interface WeathermapSettings {
     };
     showAllWithPercentage: boolean;
     defaultUnits?: string;
+    linkDecimals?: number;
     valueMappingMode?: 'last' | 'avg';
     dynamicStroke?: {
       enabled: boolean;


### PR DESCRIPTION
## Summary

- Adds `linkDecimals?: number` to `WeathermapSettings.link` in `types.ts`
- New **Link Value Decimal Places** input in Panel Options → Link Options — enter a number (0–10) or leave blank for automatic precision (existing behavior)
- The value is passed as the `decimals` argument to Grafana's `getValueFormat` formatter for `currentValueText` and `currentBandwidthText`
- Also used for `toFixed(linkDecimals ?? 2)` on `currentPercentageText`
- Applies globally to all links in the panel; fully backward-compatible (undefined = auto precision, existing behavior unchanged)

## Test plan

- [ ] Open Panel Options → Link Options — confirm "Link Value Decimal Places" input appears after "Default Link Units"
- [ ] Set decimals to `0` — confirm link labels show whole numbers (e.g. `12 Mbps` not `12.34 Mbps`)
- [ ] Set decimals to `4` — confirm labels show 4 decimal places
- [ ] Clear the field — confirm labels revert to automatic precision
- [ ] Percentage mode: set decimals to `0`, toggle percentage display — confirm `75%` not `75.00%`
- [ ] Tooltip values follow the same precision

Closes #66

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a global setting to control decimal places for link throughput labels and percentages. Improves readability while keeping automatic precision when unset.

- New Features
  - Added `linkDecimals?: number` to `WeathermapSettings.link`.
  - Panel Options → Link Options: new “Link Value Decimal Places” input (0–10, blank = auto).
  - Uses `linkDecimals` with Grafana’s value formatter for `currentValueText`/`currentBandwidthText` and for percentage (`toFixed(linkDecimals ?? 2)`); applied to all links, backward-compatible.

<sup>Written for commit c8ce58bbc6d7cd4ee854d9e6b3fa0dcb03eb2f15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

