### PR TITLE
chore(release): bump version to 1.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.4.4](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.4.4) (2026-06-10)
+
+### Features
+
+* **link-decimals**: new global "Link Value Decimal Places" setting in Panel Options → Link Options — sets the number of decimal places for all link throughput labels (value text, bandwidth text, and percentage text); leave blank for automatic precision (existing behavior unchanged) ([#66](https://github.com/allamiro/grafana-network-weathermap-ng/issues/66), PR [#127](https://github.com/allamiro/grafana-network-weathermap-ng/pull/127))
+
 ## [1.4.3](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.4.3) (2026-06-10)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Bumps version to 1.4.4. Includes PR #127 — configurable decimal places for link throughput display (#66).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.4.4 adds a global “Link Value Decimal Places” setting to control the number of decimals on link throughput labels. Leaving it blank keeps automatic precision.

- **New Features**
  - New control in Panel Options → Link Options; applies to value, bandwidth, and percentage labels for all links.

<sup>Written for commit 7e6931ac986c3d79b5440a119751d5a6739f4324. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

