### PR TITLE
feat(#63): support multiple parallel links between the same two nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.4.5](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.4.5) (2026-06-10)
+
+### Features
+
+* **parallel-links**: support multiple links between the same two nodes with independent visual paths — a per-link "Link Offset" field (in the link editor, Link Options section) shifts the line perpendicularly to the A→Z direction; set positive/negative values on each parallel link to spread them apart; arrows, labels, and gradient coloring all follow the offset line correctly; zero or blank offset (default) preserves current straight-line behavior ([#63](https://github.com/allamiro/grafana-network-weathermap-ng/issues/63))
+
 ## [1.4.4](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.4.4) (2026-06-10)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -383,6 +383,18 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
     toReturn.lineStartA = getMultiLinkPosition(tempNodes[toReturn.source.index], toReturn.sides.A);
     toReturn.lineStartZ = getMultiLinkPosition(tempNodes[toReturn.target.index], toReturn.sides.Z);
 
+    if (d.linkOffset) {
+      const dx = toReturn.lineStartZ.x - toReturn.lineStartA.x;
+      const dy = toReturn.lineStartZ.y - toReturn.lineStartA.y;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      if (dist > 0) {
+        const nx = (-dy / dist) * d.linkOffset;
+        const ny = (dx / dist) * d.linkOffset;
+        toReturn.lineStartA = { x: toReturn.lineStartA.x + nx, y: toReturn.lineStartA.y + ny };
+        toReturn.lineStartZ = { x: toReturn.lineStartZ.x + nx, y: toReturn.lineStartZ.y + ny };
+      }
+    }
+
     toReturn.lineEndA = getMiddlePoint(
       toReturn.lineStartZ,
       toReturn.lineStartA,

--- a/src/forms/LinkForm.tsx
+++ b/src/forms/LinkForm.tsx
@@ -387,6 +387,26 @@ export const LinkForm = (props: Props) => {
                   }}
                 />
               </InlineField>
+              <InlineField
+                grow
+                label={'Link Offset (parallel links)'}
+                style={{ width: '100%' }}
+                tooltip={'Shifts the link line perpendicular to its direction. Use different values on parallel links between the same nodes to separate them visually.'}
+              >
+                <Input
+                  value={link.linkOffset ?? ''}
+                  onChange={(e) => {
+                    let wm = value;
+                    const raw = e.currentTarget.value;
+                    wm.links[i].linkOffset = raw === '' ? undefined : Number(raw);
+                    onChange(wm);
+                  }}
+                  placeholder={'0'}
+                  type={'number'}
+                  className={styles.nodeLabel}
+                  name={'linkOffset'}
+                />
+              </InlineField>
               <ControlledCollapse label="Stroke and Arrow">
                 <InlineField grow label="Link Stroke Width" className={styles.inlineField}>
                   <Slider

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,6 +115,7 @@ export interface Link {
   arrows: ArrowOptions;
   stroke: number;
   showThroughputPercentage: boolean;
+  linkOffset?: number;
   statusQuery?: string;
   statusDownColor?: string;
   statusBlink?: boolean;


### PR DESCRIPTION
## Summary

- Adds `linkOffset?: number` field to the `Link` type — a per-link perpendicular displacement in SVG units
- Applies the offset to both `lineStartA` and `lineStartZ` **before** arrow, midpoint, and gradient calculations in `generateDrawnLink`, so all visual elements (arrows, labels, gradient colors) follow the shifted line automatically
- Adds a **Link Offset (parallel links)** number input in the link editor (Link Options section) with a tooltip explaining the field
- Zero or blank (default) preserves existing straight-line behavior — fully backward compatible

## How to use

1. Add two links between the same pair of nodes (e.g., node A → node B)
2. On the first link, set **Link Offset** to e.g. `15`
3. On the second link, set **Link Offset** to `-15`
4. Both links now appear as distinct parallel paths; each has its own query, label, color, and arrow

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] All 10 unit tests pass (`npm test`)
- [ ] Add two links between the same nodes; confirm they appear as separate parallel lines when Link Offset differs
- [ ] Confirm zero / blank offset renders identically to previous behavior
- [ ] Confirm arrows and throughput labels sit correctly on the offset lines
- [ ] Confirm gradient coloring follows offset lines

Closes #63

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for parallel links between the same two nodes via a per-link offset that shifts the line perpendicular to A→Z. Arrows, labels, and gradients follow the offset; zero/blank keeps existing straight lines.

- **New Features**
  - Added `linkOffset?: number` to `Link` (SVG units; positive or negative).
  - Applied offset to `lineStartA/Z` before arrow/label/gradient calculations for consistent visuals.
  - Link editor: new "Link Offset (parallel links)" number input with a tooltip.

<sup>Written for commit 73baceed0c36a5298dec841bb1a9e75100c6a123. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

