### PR TITLE
feat(#73): add configurable extra metric rows to link tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.4.6](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.4.6) (2026-06-10)
+
+### Features
+
+* **tooltip-metrics**: link tooltip now supports additional metric rows (errors, discards, drops, latency, or any metric) — a new "Tooltip Extra Metrics" section in the link editor lets operators add any number of named metrics, each with an optional inbound query, outbound query, and independent unit formatter; added metrics appear as extra rows in the hover tooltip below the throughput section, resolved live from the panel's data frames ([#73](https://github.com/allamiro/grafana-network-weathermap-ng/issues/73))
+
 ## [1.4.5](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.4.5) (2026-06-10)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -6,6 +6,7 @@ import {
   DrawnNode,
   Link,
   LinkSide,
+  LinkTooltipMetric,
   Node,
   SimpleOptions,
   Position,
@@ -706,6 +707,35 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
               Throughput (%) - Inbound: {hoveredLink.link.sides[hoveredLink.side === 'A' ? 'Z' : 'A'].currentPercentageText}, Outbound:{' '}
               {hoveredLink.link.sides[hoveredLink.side === 'A' ? 'A' : 'Z'].currentPercentageText}
             </div>
+            {hoveredLink.link.tooltipMetrics && hoveredLink.link.tooltipMetrics.length > 0 && (
+              <div style={{ borderTop: `1px solid ${theme.colors.border.medium}`, marginTop: '4px', paddingTop: '4px' }}>
+                {hoveredLink.link.tooltipMetrics.map((metric: LinkTooltipMetric, idx: number) => {
+                  const fmt = getlinkValueFormatter(
+                    metric.units || (hoveredLink.link.units ? hoveredLink.link.units : wm.settings.link.defaultUnits ? wm.settings.link.defaultUnits : 'bps')
+                  );
+                  const linkDecimals = wm.settings.link.linkDecimals;
+                  const inboundVal = metric.queryA ? dataFrameMap.get(metric.queryA) : undefined;
+                  const outboundVal = metric.queryZ ? dataFrameMap.get(metric.queryZ) : undefined;
+                  const fmtVal = (v: number | undefined) => {
+                    if (v === undefined) { return 'n/a'; }
+                    const r = fmt(v, linkDecimals);
+                    return `${r.text} ${r.suffix}`.trim();
+                  };
+                  const parts: string[] = [];
+                  if (metric.queryA !== undefined && metric.queryA !== '') {
+                    parts.push(`Inbound: ${fmtVal(inboundVal)}`);
+                  }
+                  if (metric.queryZ !== undefined && metric.queryZ !== '') {
+                    parts.push(`Outbound: ${fmtVal(outboundVal)}`);
+                  }
+                  return (
+                    <div key={idx} style={{ fontSize: wm.settings.tooltip.fontSize }}>
+                      {metric.label}{parts.length > 0 ? ` - ${parts.join(', ')}` : ''}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
             <div style={{ fontSize: wm.settings.tooltip.fontSize, paddingBottom: '4px' }}>
               {hoveredLink.link.sides[hoveredLink.side].dashboardLink.length > 0 ? 'Click to see more.' : ''}
             </div>

--- a/src/forms/LinkForm.tsx
+++ b/src/forms/LinkForm.tsx
@@ -16,7 +16,7 @@ import {
 } from '@grafana/ui';
 import { SelectableValue, StandardEditorProps } from '@grafana/data';
 import { v4 as uuidv4 } from 'uuid';
-import { Weathermap, Node, Link, Anchor, LinkSide } from 'types';
+import { Weathermap, Node, Link, Anchor, LinkSide, LinkTooltipMetric } from 'types';
 import { FormDivider } from './FormDivider';
 import { getDataFrameName, getValueField } from 'utils';
 
@@ -518,6 +518,95 @@ export const LinkForm = (props: Props) => {
                   }}
                 />
               </InlineField>
+              <FormDivider title="Tooltip Extra Metrics" />
+              {(link.tooltipMetrics ?? []).map((metric: LinkTooltipMetric, mi: number) => (
+                <React.Fragment key={mi}>
+                  <InlineFieldRow>
+                    <InlineField grow label={`Metric ${mi + 1} Label`} style={{ width: '100%' }}>
+                      <Input
+                        value={metric.label}
+                        onChange={(e) => {
+                          let wm = value;
+                          wm.links[i].tooltipMetrics![mi].label = e.currentTarget.value;
+                          onChange(wm);
+                        }}
+                        placeholder={'e.g. Errors, Drops, Latency'}
+                        type={'text'}
+                        className={styles.nodeLabel}
+                      />
+                    </InlineField>
+                  </InlineFieldRow>
+                  <InlineField grow label={`Metric ${mi + 1} Inbound Query`} style={{ width: '100%' }}>
+                    <Select
+                      onChange={(v) => {
+                        let wm = value;
+                        wm.links[i].tooltipMetrics![mi].queryA = v ? v.value : undefined;
+                        onChange(wm);
+                      }}
+                      value={dataWithIds.find((p) => p.value === metric.queryA) ?? null}
+                      options={dataWithIds}
+                      placeholder={'Select inbound query'}
+                      isClearable
+                      menuShouldPortal
+                    />
+                  </InlineField>
+                  <InlineField grow label={`Metric ${mi + 1} Outbound Query`} style={{ width: '100%' }}>
+                    <Select
+                      onChange={(v) => {
+                        let wm = value;
+                        wm.links[i].tooltipMetrics![mi].queryZ = v ? v.value : undefined;
+                        onChange(wm);
+                      }}
+                      value={dataWithIds.find((p) => p.value === metric.queryZ) ?? null}
+                      options={dataWithIds}
+                      placeholder={'Select outbound query'}
+                      isClearable
+                      menuShouldPortal
+                    />
+                  </InlineField>
+                  <InlineField grow label={`Metric ${mi + 1} Units`} style={{ width: '100%' }}>
+                    <UnitPicker
+                      onChange={(val) => {
+                        let wm = value;
+                        wm.links[i].tooltipMetrics![mi].units = val;
+                        onChange(wm);
+                      }}
+                      value={metric.units}
+                    />
+                  </InlineField>
+                  <InlineFieldRow>
+                    <Button
+                      variant="secondary"
+                      icon="trash-alt"
+                      size="sm"
+                      onClick={() => {
+                        let wm = value;
+                        wm.links[i].tooltipMetrics!.splice(mi, 1);
+                        onChange(wm);
+                      }}
+                      style={{ marginBottom: '8px' }}
+                    >
+                      Remove Metric {mi + 1}
+                    </Button>
+                  </InlineFieldRow>
+                </React.Fragment>
+              ))}
+              <Button
+                variant="secondary"
+                icon="plus"
+                size="sm"
+                onClick={() => {
+                  let wm = value;
+                  if (!wm.links[i].tooltipMetrics) {
+                    wm.links[i].tooltipMetrics = [];
+                  }
+                  wm.links[i].tooltipMetrics!.push({ label: '', queryA: undefined, queryZ: undefined });
+                  onChange(wm);
+                }}
+                style={{ marginBottom: '8px' }}
+              >
+                Add Metric
+              </Button>
               <InlineFieldRow className={styles.row}>
                 <Button variant="destructive" icon="trash-alt" size="md" onClick={() => removeLink(i)} className={''}>
                   Remove Link

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,6 +104,13 @@ export interface LinkSide {
   portLabel?: string;
 }
 
+export interface LinkTooltipMetric {
+  label: string;
+  queryA?: string;
+  queryZ?: string;
+  units?: string;
+}
+
 export interface Link {
   id: string;
   nodes: [Node, Node];
@@ -116,6 +123,7 @@ export interface Link {
   stroke: number;
   showThroughputPercentage: boolean;
   linkOffset?: number;
+  tooltipMetrics?: LinkTooltipMetric[];
   statusQuery?: string;
   statusDownColor?: string;
   statusBlink?: boolean;


### PR DESCRIPTION
## Summary

- Adds a `LinkTooltipMetric` interface (`label`, `queryA`, `queryZ`, `units`) and `tooltipMetrics?: LinkTooltipMetric[]` to the `Link` type
- Renders extra metric rows in the link hover tooltip below the existing throughput rows, separated by a divider; each metric formats its values using its own unit formatter (falls back to link units when none specified)
- Adds a **Tooltip Extra Metrics** section in the link editor with Add/Remove controls, label text input, inbound and outbound query selects, and a unit picker per metric
- Fully backward compatible: no `tooltipMetrics` = tooltip unchanged

## How to use

1. Open a link in the link editor
2. Scroll to **Tooltip Extra Metrics** section
3. Click **Add Metric**
4. Enter a label (e.g. "Errors"), select inbound/outbound queries, optionally pick units
5. Repeat for more metrics; hover the link to see all rows

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] All 10 unit tests pass (`npm test`)
- [ ] Add a metric with a label and both queries; hover link — confirm extra row appears
- [ ] Metric with only an inbound query: only "Inbound: X" shows
- [ ] Metric with custom units: value formatted with that unit
- [ ] Link with no `tooltipMetrics` renders identically to before

Closes #73

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable extra metric rows to link tooltips, so you can show KPIs like errors, drops, or latency with per-direction queries and units. Backward compatible; tooltips are unchanged if `tooltipMetrics` is not set.

- **New Features**
  - Added `LinkTooltipMetric` and `tooltipMetrics?: LinkTooltipMetric[]` on `Link`.
  - Tooltip renders added rows below throughput with a divider; values use per-metric units (fallback to link/default).
  - Link editor includes a “Tooltip Extra Metrics” section with Add/Remove, label input, inbound/outbound query selects, and a unit picker.

<sup>Written for commit ae2a4232a011a2a9b3e096d0fdd9d05231e826d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

