### PR TITLE
feat(#68): node color based on received metric value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.4.7](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.4.7) (2026-06-10)
+
+### Features
+
+* **node-color-metric**: nodes can now be colored dynamically based on a metric query value — threshold mappings in the node Status section assign colors when the query value meets or exceeds a threshold (highest matching threshold wins), replacing the previous exact-value match; a new **Color Target** toggle (Border / Background / Both) controls which part of the node is colored, enabling full background fill coloring for CPU utilization, temperature, availability score, and similar metrics; all changes are backward compatible (existing status queries and StatusDown color behavior unchanged) ([#68](https://github.com/allamiro/grafana-network-weathermap-ng/issues/68))
+
 ## [1.4.6](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.4.6) (2026-06-10)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/components/MapNode.tsx
+++ b/src/components/MapNode.tsx
@@ -65,12 +65,24 @@ const MapNode: React.FC<NodeProps> = (props: NodeProps) => {
     if (rawValue === undefined) {
       nodeStatusColor = node.colors.statusDown;
     } else if (node.statusValueMappings && node.statusValueMappings.length > 0) {
-      const match = node.statusValueMappings.find((m) => m.value === rawValue);
+      // Threshold matching: apply the highest threshold whose value <= rawValue
+      const sorted = [...node.statusValueMappings].sort((a, b) => a.value - b.value);
+      const match = sorted.filter((m) => m.value <= rawValue).pop();
       nodeStatusColor = match ? match.color : null;
     } else {
       nodeStatusColor = rawValue < 1 ? node.colors.statusDown : null;
     }
   }
+
+  const colorTarget = node.nodeStatusColorTarget ?? 'border';
+  const statusFill =
+    nodeStatusColor !== null && (colorTarget === 'background' || colorTarget === 'both')
+      ? nodeStatusColor
+      : null;
+  const statusStroke =
+    nodeStatusColor !== null && (colorTarget === 'border' || colorTarget === 'both')
+      ? nodeStatusColor
+      : null;
 
   // Check if this node is selected for dragging
   let nodeIsSelected = selectedNodes.find((n) => n.index === node.index);
@@ -106,7 +118,10 @@ const MapNode: React.FC<NodeProps> = (props: NodeProps) => {
               fill={
                 node.isConnection
                   ? 'transparent'
-                  : getSolidFromAlphaColor(node.colors.background, wm.settings.panel.backgroundColor)
+                  : getSolidFromAlphaColor(
+                      statusFill !== null ? statusFill : node.colors.background,
+                      wm.settings.panel.backgroundColor
+                    )
               }
               stroke={
                 nodeIsSelected
@@ -116,7 +131,7 @@ const MapNode: React.FC<NodeProps> = (props: NodeProps) => {
                     ? 'transparent'
                     : getSolidFromAlphaColor(node.colors.background, wm.settings.panel.backgroundColor)
                   : getSolidFromAlphaColor(
-                      nodeStatusColor !== null ? nodeStatusColor : node.colors.border,
+                      statusStroke !== null ? statusStroke : node.colors.border,
                       wm.settings.panel.backgroundColor
                     )
               }

--- a/src/forms/NodeForm.tsx
+++ b/src/forms/NodeForm.tsx
@@ -7,6 +7,7 @@ import {
   InlineFieldRow,
   InlineSwitch,
   Select,
+  RadioButtonGroup,
   useStyles2,
   ControlledCollapse,
   InlineLabel,
@@ -515,13 +516,29 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                       }}
                     />
                   </InlineLabel>
-                  <p style={{ margin: '8px 0 4px', fontSize: '12px', fontWeight: 600 }}>Value Mappings</p>
+                  <p style={{ margin: '8px 0 4px', fontSize: '12px', fontWeight: 600 }}>Color Target</p>
+                  <div style={{ marginBottom: '8px' }}>
+                    <RadioButtonGroup
+                      options={[
+                        { label: 'Border', value: 'border' },
+                        { label: 'Background', value: 'background' },
+                        { label: 'Both', value: 'both' },
+                      ] as Array<{ label: string; value: 'border' | 'background' | 'both' }>}
+                      value={node.nodeStatusColorTarget ?? 'border'}
+                      onChange={(v) => {
+                        let weathermap: Weathermap = value;
+                        weathermap.nodes[i].nodeStatusColorTarget = v;
+                        onChange(weathermap);
+                      }}
+                    />
+                  </div>
+                  <p style={{ margin: '8px 0 4px', fontSize: '12px', fontWeight: 600 }}>Threshold Mappings</p>
                   <p style={{ margin: '0 0 6px', fontSize: '11px', opacity: 0.7 }}>
-                    Map query values to border colors. Overrides the default &lt;1 = down rule.
+                    When metric value ≥ threshold, apply that color. The highest matching threshold wins. Overrides the default &lt;1 = down rule.
                   </p>
                   {(node.statusValueMappings || []).map((mapping, mi) => (
                     <InlineFieldRow key={mi} className={styles.inlineRow}>
-                      <InlineField label="Value">
+                      <InlineField label="Threshold (≥)">
                         <Input
                           type="number"
                           value={mapping.value}

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,6 +92,7 @@ export interface Node {
   isConnection: boolean;
   statusQuery?: string;
   statusValueMappings?: NodeStatusValueMapping[];
+  nodeStatusColorTarget?: 'border' | 'background' | 'both';
 }
 
 export interface LinkSide {


### PR DESCRIPTION
## Summary

- Adds nodeStatusColorTarget (border/background/both) to Node type
- Fixes threshold matching: exact-match replaced with highest-matching-threshold (m.value <= rawValue)
- Applies status color to background fill, border stroke, or both
- Adds Color Target radio group in node Status section
- Renames mapping label to Threshold (>=) with updated help text

Closes #68

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable dynamic node coloring based on metric values with threshold rules, configurable to apply to the border, background, or both. Closes #68 while keeping existing dashboards working by default.

- **New Features**
  - Threshold mappings: apply color when metric ≥ threshold; highest matching threshold wins.
  - Color Target in node Status: Border, Background, or Both (defaults to Border).
  - Background fill can reflect status color; without mappings, the "<1 = down" rule still applies.
  - Renamed mapping label to "Threshold (≥)" with clearer help text.

<sup>Written for commit 04b09b438489678a4e7e832ea72b26d4f7453151. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

