### PR TITLE
fix: address Grafana Labs review feedback (v1.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.5.0](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.0) (2026-07-01)
+
+### Features
+
+* **react-19**: replace the `react-draggable` `findDOMNode` fallback with an explicit `nodeRef`, fixing a `TypeError: ReactDOM.findDOMNode is not a function` crash on Grafana builds running React 19 while keeping node dragging fully functional on older versions.
+
+### Bug Fixes
+
+* **security**: validate and sanitize all user-provided URLs before use — dashboard links, custom node icon URLs, and the panel background image URL. Only safe relative Grafana paths and `http://`/`https://` absolute URLs are accepted; unsafe schemes (`javascript:`, `data:`, `file:`, `vbscript:`, `blob:`, protocol-relative `//`, and any other scheme) are rejected at input time and again at navigation/render time, preventing script execution via `window.open` or image sources.
+* **export**: guard against a missing SVG element in the SVG export path so the panel editor no longer crashes when the expected element is not present.
+
+### Metadata
+
+* rename the plugin display name to **Network Weathermap NG** and clarify the description as the actively maintained next-generation continuation, distinguishing it from the deprecated `knightss27-weathermap-panel` plugin.
+
 ## [1.4.7](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.4.7) (2026-06-10)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.4.7",
+  "version": "1.5.0",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -34,6 +34,7 @@ import {
   handleVersionedStateUpdates,
   getDataFrameName,
   getValueField,
+  sanitizeUrl,
 } from 'utils';
 import MapNode from './components/MapNode';
 import ColorScale from 'components/ColorScale';
@@ -629,6 +630,16 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
     setHoveredLink(null as unknown as HoveredLink);
   };
 
+  // Navigate to a user-provided dashboard link only if it passes URL validation.
+  // Values may have been produced by template-variable substitution at runtime,
+  // so they are re-sanitized here before ever reaching window.open.
+  const openDashboardLink = (rawLink: string) => {
+    const safeLink = sanitizeUrl(rawLink);
+    if (safeLink) {
+      window.open(safeLink, '_blank', 'noopener,noreferrer');
+    }
+  };
+
   const filteredGraphQueries = data.series.filter((frame) => {
     if (!hoveredLink) {
       return;
@@ -859,9 +870,10 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
             position: 'absolute',
             top: 0,
             left: 0,
-            backgroundImage: wm.settings.panel.backgroundImage
-              ? `url(${wm.settings.panel.backgroundImage.url})`
-              : 'none',
+            backgroundImage:
+              wm.settings.panel.backgroundImage && sanitizeUrl(wm.settings.panel.backgroundImage.url)
+                ? `url(${sanitizeUrl(wm.settings.panel.backgroundImage.url)})`
+                : 'none',
             backgroundSize: wm.settings.panel.backgroundImage?.fit,
             backgroundPosition: 'center',
             backgroundRepeat: 'no-repeat',
@@ -1062,7 +1074,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                       onMouseOut={handleLinkHoverLoss}
                       onClick={() => {
                         if (d.sides.A.dashboardLink.length > 0) {
-                          window.open(d.sides.A.dashboardLink, '_blank', 'noopener,noreferrer');
+                          openDashboardLink(d.sides.A.dashboardLink);
                         }
                       }}
                       style={{
@@ -1108,7 +1120,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                           onMouseOut={handleLinkHoverLoss}
                           onClick={() => {
                             if (d.sides.A.dashboardLink.length > 0) {
-                              window.open(d.sides.A.dashboardLink, '_blank', 'noopener,noreferrer');
+                              openDashboardLink(d.sides.A.dashboardLink);
                             }
                           }}
                           style={d.sides.A.dashboardLink.length > 0 ? { cursor: 'pointer' } : {}}
@@ -1133,7 +1145,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                           onMouseOut={handleLinkHoverLoss}
                           onClick={() => {
                             if (d.sides.Z.dashboardLink.length > 0) {
-                              window.open(d.sides.Z.dashboardLink, '_blank', 'noopener,noreferrer');
+                              openDashboardLink(d.sides.Z.dashboardLink);
                             }
                           }}
                           style={{
@@ -1164,7 +1176,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                           onMouseOut={handleLinkHoverLoss}
                           onClick={() => {
                             if (d.sides.Z.dashboardLink.length > 0) {
-                              window.open(d.sides.Z.dashboardLink, '_blank', 'noopener,noreferrer');
+                              openDashboardLink(d.sides.Z.dashboardLink);
                             }
                           }}
                           style={d.sides.Z.dashboardLink.length > 0 ? { cursor: 'pointer' } : {}}
@@ -1426,7 +1438,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                           return v;
                         });
                       } else if (!isEditMode && tempNodes[i].dashboardLink) {
-                        window.open(tempNodes[i].dashboardLink, '_blank', 'noopener,noreferrer');
+                        openDashboardLink(tempNodes[i].dashboardLink);
                       }
                       // Force an update
                       onOptionsChange(options);

--- a/src/components/MapNode.tsx
+++ b/src/components/MapNode.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { DrawnNode, Weathermap } from '../types';
 import {
   nearestMultiple,
@@ -7,6 +7,7 @@ import {
   calculateRectangleAutoWidth,
   calculateRectangleAutoHeight,
   getDataFrameName,
+  sanitizeUrl,
 } from '../utils';
 import { css } from '@emotion/css';
 import { useStyles2 } from '@grafana/ui';
@@ -48,6 +49,10 @@ const MapNode: React.FC<NodeProps> = (props: NodeProps) => {
   const { node, draggedNode, selectedNodes, wm, onDrag, onStop, onClick, disabled, data } = props;
   const styles = useStyles2(getStyles);
 
+  // React 19 removed ReactDOM.findDOMNode, which react-draggable falls back to
+  // when no nodeRef is provided. Passing an explicit nodeRef avoids that crash.
+  const nodeRef = useRef<SVGGElement>(null);
+
   const rectX = useMemo(() => calculateRectX(node, wm), [node, wm]);
   const rectY = useMemo(() => calculateRectY(node, wm), [node, wm]);
   const rectWidth = useMemo(() => calculateRectangleAutoWidth(node, wm), [node, wm]);
@@ -88,8 +93,14 @@ const MapNode: React.FC<NodeProps> = (props: NodeProps) => {
   let nodeIsSelected = selectedNodes.find((n) => n.index === node.index);
 
   return (
-    <DraggableCore disabled={disabled} onDrag={onDrag} onStop={onStop}>
+    <DraggableCore
+      nodeRef={nodeRef as unknown as React.RefObject<HTMLElement>}
+      disabled={disabled}
+      onDrag={onDrag}
+      onStop={onStop}
+    >
       <g
+        ref={nodeRef}
         cursor={disabled ? (node.dashboardLink ? 'pointer' : '') : 'move'}
         display={node.label !== undefined ? 'inline' : 'none'}
         onClick={onClick}
@@ -158,7 +169,7 @@ const MapNode: React.FC<NodeProps> = (props: NodeProps) => {
         ) : (
           ''
         )}
-        {node.nodeIcon && node.nodeIcon.src !== '' ? (
+        {node.nodeIcon && sanitizeUrl(node.nodeIcon.src) !== '' ? (
           <image
             x={-node.nodeIcon.size.width / 2}
             y={
@@ -176,7 +187,7 @@ const MapNode: React.FC<NodeProps> = (props: NodeProps) => {
             }
             width={node.nodeIcon.size.width}
             height={node.nodeIcon.size.height}
-            href={node.nodeIcon.src}
+            href={sanitizeUrl(node.nodeIcon.src)}
           />
         ) : (
           ''

--- a/src/forms/ExportForm.test.tsx
+++ b/src/forms/ExportForm.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { StandardEditorProps } from '@grafana/data';
+import { Weathermap } from 'types';
+import { getData, theme } from 'testData';
+import { ExportForm } from './ExportForm';
+
+test('SVG export does not crash when the SVG element is missing', async () => {
+  // Ensure the expected SVG element is not present in the DOM.
+  const value = getData(theme);
+  expect(document.getElementById(`nw-${value.id}_`)).toBeNull();
+
+  const createObjectURL = jest.fn(() => 'blob:mock');
+  // jsdom does not implement createObjectURL; provide a spy either way.
+  (URL as unknown as { createObjectURL: unknown }).createObjectURL = createObjectURL;
+
+  const onChange = jest.fn();
+  const props = { value, onChange } as unknown as StandardEditorProps<Weathermap>;
+  render(<ExportForm {...props} />);
+
+  const button = screen.getByText('Export SVG');
+  // Should not throw and should bail out before attempting to build a blob.
+  expect(() => fireEvent.click(button)).not.toThrow();
+  // Allow the async handler to settle.
+  await Promise.resolve();
+
+  expect(createObjectURL).not.toHaveBeenCalled();
+});

--- a/src/forms/ExportForm.tsx
+++ b/src/forms/ExportForm.tsx
@@ -25,10 +25,16 @@ export const ExportForm = ({ value, onChange }: Props) => {
   const handleSVGExport = async () => {
     const svg = document.getElementById(`nw-${value.id}_`);
 
-    let data = svg!.outerHTML || '';
+    // The SVG element may be missing (e.g. panel not yet rendered). Guard
+    // against it so the editor does not crash on export.
+    if (!svg) {
+      return;
+    }
+
+    let data = svg.outerHTML || '';
     const preface = '<?xml version="1.0" standalone="no"?>\r\n';
 
-    const icons = svg!.getElementsByTagName('image');
+    const icons = svg.getElementsByTagName('image');
     //TODO: fix exporting
     for (let i = 0; i < icons.length; i++) {
       const iconURL = document.location.origin + '/' + icons[i].href.baseVal;

--- a/src/forms/LinkForm.tsx
+++ b/src/forms/LinkForm.tsx
@@ -18,7 +18,7 @@ import { SelectableValue, StandardEditorProps } from '@grafana/data';
 import { v4 as uuidv4 } from 'uuid';
 import { Weathermap, Node, Link, Anchor, LinkSide, LinkTooltipMetric } from 'types';
 import { FormDivider } from './FormDivider';
-import { getDataFrameName, getValueField } from 'utils';
+import { getDataFrameName, getValueField, sanitizeUrl } from 'utils';
 
 interface Settings {
   placeholder: string;
@@ -97,7 +97,7 @@ export const LinkForm = (props: Props) => {
 
   const handleDashboardLinkChange = (val: string, i: number, side: 'A' | 'Z') => {
     let weathermap: Weathermap = value;
-    weathermap.links[i].sides[side].dashboardLink = val;
+    weathermap.links[i].sides[side].dashboardLink = sanitizeUrl(val);
     onChange(weathermap);
   };
 

--- a/src/forms/NodeForm.tsx
+++ b/src/forms/NodeForm.tsx
@@ -19,7 +19,7 @@ import { SelectableValue, StandardEditorProps } from '@grafana/data';
 import { v4 as uuidv4 } from 'uuid';
 import { Weathermap, Node, NodeStatusValueMapping } from 'types';
 import { CiscoIcons, NetworkingIcons, DatabaseIcons, ComputerIcons } from './iconOptions';
-import { getDataFrameName } from 'utils';
+import { getDataFrameName, sanitizeUrl } from 'utils';
 
 interface Settings {
   placeholder: string;
@@ -51,7 +51,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
 
   const handleDashboardLinkChange = (e: React.FormEvent<HTMLInputElement>, i: number) => {
     let weathermap: Weathermap = value;
-    weathermap.nodes[i].dashboardLink = e.currentTarget.value;
+    weathermap.nodes[i].dashboardLink = sanitizeUrl(e.currentTarget.value);
     onChange(weathermap);
   };
 
@@ -390,7 +390,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                           onChange={(e) => {
                             let options = value;
                             if (options.nodes[i].nodeIcon) {
-                              options.nodes[i].nodeIcon!.src = e.currentTarget.value;
+                              options.nodes[i].nodeIcon!.src = sanitizeUrl(e.currentTarget.value);
                             }
                             onChange(options);
                           }}

--- a/src/forms/PanelForm.tsx
+++ b/src/forms/PanelForm.tsx
@@ -16,6 +16,7 @@ import { GrafanaTheme2, StandardEditorProps } from '@grafana/data';
 import { Weathermap } from 'types';
 import { FormDivider } from './FormDivider';
 import { css } from '@emotion/css';
+import { sanitizeUrl } from 'utils';
 
 interface Settings {}
 
@@ -95,7 +96,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
                 onChange={(e) => {
                   let options = value;
                   if (options.settings.panel.backgroundImage) {
-                    options.settings.panel.backgroundImage.url = e.currentTarget.value;
+                    options.settings.panel.backgroundImage.url = sanitizeUrl(e.currentTarget.value);
                   }
                   onChange(options);
                 }}

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -1,9 +1,9 @@
 {
   "type": "panel",
-  "name": "Network Weathermap",
+  "name": "Network Weathermap NG",
   "id": "tamirsuliman-weathermap-panel",
   "info": {
-    "description": "A simple & sleek network weathermap.",
+    "description": "Next-generation, actively maintained network weathermap panel. A continuation and fork of the deprecated Network Weathermap plugin, updated for modern Grafana.",
     "author": {
       "name": "Tamir Suliman",
       "url": "https://github.com/allamiro"

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -6,8 +6,10 @@ import {
   CURRENT_VERSION,
   getSolidFromAlphaColor,
   handleVersionedStateUpdates,
+  isSafeUrl,
   measureText,
   nearestMultiple,
+  sanitizeUrl,
 } from 'utils';
 
 test('getSolidFromAlphaColor', () => {
@@ -43,4 +45,70 @@ test('node calculations', () => {
 test('versioned state updates', () => {
   let wm: Weathermap = getData(theme);
   expect(handleVersionedStateUpdates(wm, theme)).toHaveProperty('version', CURRENT_VERSION);
+});
+
+describe('isSafeUrl', () => {
+  test('allows safe relative Grafana paths', () => {
+    expect(isSafeUrl('/d/abc123/my-dashboard')).toBe(true);
+    expect(isSafeUrl('/d/abc123/my-dashboard?var-foo=bar')).toBe(true);
+    expect(isSafeUrl('public/plugins/tamirsuliman-weathermap-panel/icons/router.svg')).toBe(true);
+    expect(isSafeUrl('./relative/icon.png')).toBe(true);
+  });
+
+  test('allows http and https absolute URLs', () => {
+    expect(isSafeUrl('http://example.com/dashboard')).toBe(true);
+    expect(isSafeUrl('https://example.com/icon.svg')).toBe(true);
+    expect(isSafeUrl('HTTPS://EXAMPLE.COM/icon.svg')).toBe(true);
+  });
+
+  test('rejects javascript URLs', () => {
+    expect(isSafeUrl('javascript:alert(1)')).toBe(false);
+    // Obfuscated with embedded control characters / whitespace
+    expect(isSafeUrl('java\nscript:alert(1)')).toBe(false);
+    expect(isSafeUrl('  javascript:alert(1)')).toBe(false);
+    expect(isSafeUrl('JavaScript:alert(1)')).toBe(false);
+  });
+
+  test('rejects data URLs', () => {
+    expect(isSafeUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+    expect(isSafeUrl('data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=')).toBe(false);
+  });
+
+  test('rejects file URLs', () => {
+    expect(isSafeUrl('file:///etc/passwd')).toBe(false);
+  });
+
+  test('rejects other unsafe schemes', () => {
+    expect(isSafeUrl('vbscript:msgbox(1)')).toBe(false);
+    expect(isSafeUrl('blob:https://example.com/uuid')).toBe(false);
+    expect(isSafeUrl('ftp://example.com/file')).toBe(false);
+  });
+
+  test('rejects protocol-relative URLs', () => {
+    expect(isSafeUrl('//evil.com/payload')).toBe(false);
+  });
+
+  test('rejects empty and nullish values', () => {
+    expect(isSafeUrl('')).toBe(false);
+    expect(isSafeUrl('   ')).toBe(false);
+    expect(isSafeUrl(undefined)).toBe(false);
+    expect(isSafeUrl(null)).toBe(false);
+  });
+});
+
+describe('sanitizeUrl', () => {
+  test('returns the value when safe', () => {
+    expect(sanitizeUrl('https://example.com/icon.svg')).toBe('https://example.com/icon.svg');
+    expect(sanitizeUrl('/d/abc123/my-dashboard')).toBe('/d/abc123/my-dashboard');
+    expect(sanitizeUrl('  https://example.com/icon.svg  ')).toBe('https://example.com/icon.svg');
+  });
+
+  test('returns empty string when unsafe', () => {
+    expect(sanitizeUrl('javascript:alert(1)')).toBe('');
+    expect(sanitizeUrl('data:text/html,<script>alert(1)</script>')).toBe('');
+    expect(sanitizeUrl('file:///etc/passwd')).toBe('');
+    expect(sanitizeUrl('//evil.com')).toBe('');
+    expect(sanitizeUrl(undefined)).toBe('');
+    expect(sanitizeUrl(null)).toBe('');
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -379,3 +379,75 @@ export function getValueField(frame: DataFrame): Field {
 export const getDataFrameName = (frame: DataFrame, allFrames: DataFrame[]): string => {
   return getFieldDisplayName(getValueField(frame), frame, allFrames);
 };
+
+/**
+ * Schemes that are explicitly unsafe for navigation or resource loading.
+ * Any absolute URL must use http:// or https:// — everything else is rejected.
+ */
+const ALLOWED_ABSOLUTE_SCHEMES = ['http:', 'https:'];
+
+/**
+ * Determine whether a user-provided URL is safe to navigate to or render.
+ *
+ * Safe values are:
+ *  - Relative Grafana paths (no scheme), e.g. `/d/abc/my-dashboard` or
+ *    `public/plugins/tamirsuliman-weathermap-panel/icons/router.svg`
+ *  - Absolute URLs using the http:// or https:// scheme
+ *
+ * Everything else — including `javascript:`, `data:`, `file:`, `vbscript:`,
+ * `blob:`, protocol-relative `//host` URLs, and any other scheme — is rejected.
+ *
+ * @param raw the user-provided URL
+ * @returns true if the value is safe to use
+ */
+export function isSafeUrl(raw: string | undefined | null): boolean {
+  if (raw == null) {
+    return false;
+  }
+
+  // Strip leading/trailing whitespace and any control characters (including
+  // tabs and newlines) that could be used to obfuscate a scheme such as
+  // `java\nscript:alert(1)`.
+  // eslint-disable-next-line no-control-regex
+  const value = raw.replace(/[\u0000-\u001F\u007F ]/g, '').trim();
+
+  if (value === '') {
+    return false;
+  }
+
+  // Reject protocol-relative URLs (`//evil.com`) which inherit the current
+  // page scheme and can point anywhere.
+  if (value.startsWith('//')) {
+    return false;
+  }
+
+  // Detect an explicit scheme. A leading scheme looks like `name:` where name
+  // starts with a letter followed by letters, digits, `+`, `-`, or `.`.
+  const schemeMatch = value.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):/);
+
+  if (schemeMatch) {
+    const scheme = schemeMatch[1].toLowerCase() + ':';
+    return ALLOWED_ABSOLUTE_SCHEMES.includes(scheme);
+  }
+
+  // No scheme present — treat as a relative Grafana path, which is safe.
+  return true;
+}
+
+/**
+ * Sanitize a user-provided URL. Returns the cleaned value when it is safe to
+ * use, or an empty string when it is not. This is applied both when a value is
+ * entered/saved in the editor and again at the point of use (navigation or
+ * image rendering) for defense in depth.
+ *
+ * @param raw the user-provided URL
+ * @returns the trimmed URL when safe, otherwise an empty string
+ */
+export function sanitizeUrl(raw: string | undefined | null): string {
+  if (raw == null) {
+    return '';
+  }
+
+  const trimmed = raw.trim();
+  return isSafeUrl(trimmed) ? trimmed : '';
+}


### PR DESCRIPTION
Addresses all required and suggested changes from the Grafana Labs review (Esteban Beltran, July 1, 2026).

## Required changes
- **React 19 compatibility (MapNode.tsx):** pass an explicit `nodeRef` to `react-draggable`'s `DraggableCore` so it no longer falls back to `ReactDOM.findDOMNode`, fixing the `TypeError: ReactDOM.findDOMNode is not a function` crash on Grafana builds using React 19. Dragging still works.
- **URL validation:** new reusable `isSafeUrl`/`sanitizeUrl` helpers in `utils.ts`. Only safe relative Grafana paths and `http`/`https` absolute URLs are allowed; `javascript:`, `data:`, `file:`, `vbscript:`, `blob:`, protocol-relative, and any other scheme are rejected. Applied at input time (NodeForm, LinkForm, PanelForm) and again at use time (`window.open`, node icon `href`, panel `background-image`).
- **Display name / description (plugin.json):** renamed to "Network Weathermap NG" with a clarified description to distinguish it from the deprecated `knightss27-weathermap-panel`.

## Suggested changes
- **ExportForm.tsx:** added a null guard before reading `svg.outerHTML` to avoid an editor crash when the SVG element is missing.

## Tests & verification
- Added unit tests for URL validation (relative paths, http, https; rejected javascript/data/file/vbscript/blob) and the SVG export null guard.
- `npm run typecheck`, `npm run test:ci` (21 passing), `npm run lint` (src clean), and `npm run build` all pass.
- Verified the built plugin loads without errors on Grafana **11.0.0** (declared minimum) and **12.4.0** (latest) — registered, `angular detected: false`, no `findDOMNode` crash.

Bumps version to 1.5.0 and updates the changelog.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a React 19 crash and adds strict URL sanitization across links, icons, and background images. Renames the plugin to "Network Weathermap NG" with a clearer description; addresses Grafana Labs review feedback for v1.5.0.

- **Bug Fixes**
  - React 19: pass `nodeRef` to `react-draggable`’s `DraggableCore` to avoid the `findDOMNode` crash; dragging still works.
  - URL validation: add `isSafeUrl`/`sanitizeUrl`; allow only relative Grafana paths and `http`/`https`; reject `javascript:`, `data:`, `file:`, `vbscript:`, `blob:`, and protocol-relative URLs. Applied on save and at use (`window.open`, node icon `href`, panel background image).
  - Export: add a null guard for the SVG element in `ExportForm` to prevent editor crashes.

<sup>Written for commit 41bde179b5e348e6794ba6ad639220275a5caf29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

