### PR TITLE
fix(testing): repair docker-compose test stack (exporter Go version + provisioning perms)

### DIFF
--- a/testing/exporter/Dockerfile
+++ b/testing/exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine
+FROM golang:1.25-alpine
 
 WORKDIR /app
 

--- a/testing/grafana/Dockerfile
+++ b/testing/grafana/Dockerfile
@@ -22,6 +22,11 @@ ENV GF_PATHS_PLUGINS="/var/lib/grafana-plugins"
 RUN mkdir -p "$GF_PATHS_PLUGINS" && \
     chown -R grafana:${GF_GID} "$GF_PATHS_PLUGINS"
 
+# Ensure the provisioning and dashboard files are readable by the grafana user
+# regardless of the file mode they were checked out with (a restrictive host
+# umask can otherwise make these unreadable inside the container).
+RUN chmod -R a+rX /etc/grafana/provisioning /var/lib/grafana/dashboards
+
 RUN if [ $GF_INSTALL_IMAGE_RENDERER_PLUGIN = "true" ]; then \
     echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
     echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \


### PR DESCRIPTION
Fixes the local `testing/` docker-compose stack that reviewers use.

## Problems
- The `exporter` service failed to build: its `go.mod` declares `go 1.25.0` but the Dockerfile used `golang:1.21-alpine`, so `go build` errored (`go.mod requires go >= 1.25.0`). This aborted the whole `docker compose up --build`.
- Grafana provisioning directories could be unreadable by the container's grafana user when the repo is checked out with a restrictive host umask, causing `permission denied` on `/etc/grafana/provisioning/*` and skipping the datasource/dashboard.

## Fixes
- Bump the exporter build image to `golang:1.25-alpine` to match `go.mod`.
- `chmod -R a+rX` the provisioning and dashboard paths in the grafana image so they are always readable inside the container.

## Verification
`docker compose up --build` in `testing/` now brings up exporter, prometheus, and grafana. Confirmed:
- exporter builds and serves `/metrics`
- the Prometheus datasource and sample dashboard provision with no permission errors
- the `tamirsuliman-weathermap-panel` plugin loads and the sample dashboard references it

No plugin source changes; does not affect the published v1.5.0 artifact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the local `testing/` docker-compose stack by aligning the exporter’s Go version and making Grafana provisioning files readable. The stack builds and starts; Prometheus datasource and the sample dashboard provision correctly.

- **Bug Fixes**
  - Bumped exporter base image to `golang:1.25-alpine` to match `go.mod` (`go 1.25.0`) and fix build failures.
  - Ensured `/etc/grafana/provisioning` and `/var/lib/grafana/dashboards` are readable in the Grafana image (`chmod -R a+rX`) to prevent permission errors from restrictive host umasks.

<sup>Written for commit b8053fa36fc8680bf00639b80f4d0b408fef3030. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

