### PR TITLE
chore(release): bump version to 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.5.1](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.1) (2026-07-01)
+
+### Bug Fixes
+
+* **testing**: repair the `testing/` docker-compose stack — bump the exporter build image to `golang:1.25-alpine` to match its `go.mod` (the previous `1.21` image failed the build and prevented the stack from starting), and ensure the Grafana provisioning and dashboard files are readable inside the container regardless of the host checkout umask. `docker compose up --build` now starts Grafana with the plugin pre-loaded and sample data provisioned. No plugin runtime changes from 1.5.0.
+
 ## [1.5.0](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.0) (2026-07-01)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Bumps version to 1.5.1 so the docker-compose testing fixes from #134 are included in a tagged release referenced by the Grafana submission. No plugin runtime changes from 1.5.0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release 1.5.1 to include the testing docker-compose fixes so a tagged build has a working local stack for the Grafana submission. Exporter builds on `golang:1.25-alpine` and provisioning/dashboard files are readable in the container; no plugin runtime changes from 1.5.0.

<sup>Written for commit 8a328ca6b8a41f60edb42dd1b7c64ec34ca1cb5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

