### PR TITLE
feat(#61): option to open node dashboard link in same tab

### DIFF
--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -633,10 +633,10 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
   // Navigate to a user-provided dashboard link only if it passes URL validation.
   // Values may have been produced by template-variable substitution at runtime,
   // so they are re-sanitized here before ever reaching window.open.
-  const openDashboardLink = (rawLink: string) => {
+  const openDashboardLink = (rawLink: string, sameTab = false) => {
     const safeLink = sanitizeUrl(rawLink);
     if (safeLink) {
-      window.open(safeLink, '_blank', 'noopener,noreferrer');
+      window.open(safeLink, sameTab ? '_self' : '_blank', 'noopener,noreferrer');
     }
   };
 
@@ -1438,7 +1438,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                           return v;
                         });
                       } else if (!isEditMode && tempNodes[i].dashboardLink) {
-                        openDashboardLink(tempNodes[i].dashboardLink);
+                        openDashboardLink(tempNodes[i].dashboardLink, tempNodes[i].openInSameTab);
                       }
                       // Force an update
                       onOptionsChange(options);

--- a/src/forms/NodeForm.tsx
+++ b/src/forms/NodeForm.tsx
@@ -345,6 +345,21 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                     name={'Dashboard link'}
                   />
                 </InlineField>
+                <InlineField
+                  grow
+                  label={'Open Link in Same Tab'}
+                  className={styles.inlineField}
+                  tooltip={'When enabled, the dashboard link opens in the current tab instead of a new one.'}
+                >
+                  <InlineSwitch
+                    value={node.openInSameTab === true}
+                    onChange={(e) => {
+                      let options = value;
+                      options.nodes[i].openInSameTab = e.currentTarget.checked;
+                      onChange(options);
+                    }}
+                  />
+                </InlineField>
                 <InlineField grow label={'Show Label'} className={styles.inlineField}>
                   <InlineSwitch
                     value={node.showLabel !== false}

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,7 @@ export interface Node {
   label?: string;
   showLabel?: boolean;
   dashboardLink?: string;
+  openInSameTab?: boolean;
   anchors: {
     [Anchor.Center]: NodeAnchor;
     [Anchor.Top]: NodeAnchor;


### PR DESCRIPTION
Closes #61

## Feature
Node dashboard links always opened in a new browser tab. This adds a per-node **Open Link in Same Tab** toggle so operators can choose to navigate in the current tab instead.

## Changes
- `types.ts` — new optional `Node.openInSameTab?: boolean`.
- `WeathermapPanel.tsx` — `openDashboardLink(rawLink, sameTab = false)` opens with `_self` when `sameTab` is set, otherwise `_blank`; the node click handler passes `node.openInSameTab`. URL sanitization (`sanitizeUrl`) is unchanged.
- `NodeForm.tsx` — new **Open Link in Same Tab** `InlineSwitch` next to the Dashboard Link field.

## Behavior
- Toggle **off** (default): opens in a new tab — identical to current behavior.
- Toggle **on**: opens in the same tab (`_self`).

Backward compatible: `openInSameTab` is optional and defaults to falsy, so existing node configs are unaffected.

## Verification
- `npm run typecheck` — passes
- `npm run lint` — clean
- `npm run test:ci` — 21/21 pass
- `npm run build` — compiles successfully

CHANGELOG/version bump intentionally left to the `release/*` PR, per repo convention.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-node “Open Link in Same Tab” toggle so node dashboard links can open in the current tab. Implements issue #61; default remains opening in a new tab, so existing nodes are unaffected.

- **New Features**
  - Optional `Node.openInSameTab` field.
  - `openDashboardLink(rawLink, sameTab)` uses `_self` when enabled; URL sanitization remains.
  - Node form adds an InlineSwitch next to the Dashboard Link field.

<sup>Written for commit 3fec83664e4284512ee10ba8cdb1e6d58a11736a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

