### PR TITLE
chore(release): bump version to 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.5.2](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.2) (2026-07-01)
+
+### Features
+
+* **node-link-tab**: new per-node **Open Link in Same Tab** toggle (`Node.openInSameTab`) in the node editor — when enabled, clicking a node's dashboard link navigates in the current tab (`_self`) instead of opening a new one (`_blank`); URL sanitization is unchanged and the default (off) preserves the existing new-tab behavior ([#61](https://github.com/allamiro/grafana-network-weathermap-ng/issues/61), PR [#136](https://github.com/allamiro/grafana-network-weathermap-ng/pull/136))
+
 ## [1.5.1](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.1) (2026-07-01)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Release **v1.5.2** (patch).

Bumps `package.json` to `1.5.2` and adds the CHANGELOG entry. Only change since v1.5.1:

- **feat(#61)**: per-node **Open Link in Same Tab** toggle (`Node.openInSameTab`) — PR #136.

After merge, tag `v1.5.2` is pushed to trigger the release workflow (build + sign + provenance attestation + GitHub release). `plugin.json` version is injected from `package.json` at build time (`%VERSION%`), so no manual edit there.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare v1.5.2 release by bumping `package.json` and updating the changelog. This release adds a per-node Open Link in Same Tab toggle (`Node.openInSameTab`): when enabled, node links open in the current tab; default stays new-tab.

<sup>Written for commit bb98a23e8702fa5cb4d300de620aa635b306c886. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

