### PR TITLE
ci(#33): add lint to PR quality gate (and fix eslint config)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,11 @@
 {
-  "extends": "./.config/.eslintrc"
+  "extends": "./.config/.eslintrc",
+  "ignorePatterns": [
+    "jest.config.js",
+    "jest-setup.js",
+    "jest-polyfills.js",
+    ".prettierrc.js",
+    "playwright.config.ts",
+    "tests/"
+  ]
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
           node-version: '24'
           cache: 'npm'
       - run: npm ci --legacy-peer-deps
+      - run: npm run lint
       - run: npm run typecheck
       - run: npm run test:ci
       - run: npm run build


### PR DESCRIPTION
Closes #33

## Problem
The PR CI (`test.yml`, triggered on `pull_request`) ran `typecheck`, `test:ci`, and `build` but **not** `lint`. And `npm run lint` was actually broken: type-aware ESLint (`parserOptions.project` from the scaffolded `.config/.eslintrc`) tried to parse files that aren't part of the TS source project, failing with 5 parse errors:

```
jest.config.js, jest-setup.js, jest-polyfills.js, .prettierrc.js,
playwright.config.ts, tests/panel.spec.ts
  Parsing error: ... file was not found in any of the provided project(s)
```

## Changes
- **`.eslintrc`** — add `ignorePatterns` for those non-source config/test files. The scaffolded `.config/.eslintrc` (marked DO NOT EDIT) is untouched; the override lives in the root config as intended. `npm run lint` now passes clean.
- **`.github/workflows/test.yml`** — add `npm run lint` before typecheck, so every PR enforces the full gate: **lint → typecheck → test → build**.

## Notes
- Kept the workflow/job name `Test` to avoid renaming a required status check in branch protection. `test.yml` already runs on all PRs, so this fulfils the issue's intent (full quality gate on PRs) without a duplicate `ci.yml`.
- `tests/` is ignored by lint for now because the e2e spec isn't in the TS project; wiring proper lint/types for e2e belongs with #38.

## Verification
Locally all four gates exit 0: `lint`, `typecheck`, `test:ci`, `build`.

No plugin runtime code changed (CI/config only).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add lint to the PR quality gate and fix ESLint config so `npm run lint` passes. This fulfills #33 by enforcing a full gate on every PR: lint → typecheck → test → build.

- **Bug Fixes**
  - `.eslintrc`: add ignorePatterns for Jest/Prettier/Playwright configs and `tests/` that aren’t in the TS project.
  - `.github/workflows/test.yml`: run `npm run lint` before typecheck.

<sup>Written for commit cef959e3aab5d6446740b3f5c960edf4be570da3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

