### PR TITLE
chore(#34): add release helper script and release checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,38 @@ This starts Grafana at `http://localhost:3000` with the plugin pre-loaded and sa
 4. Ensure `npm run test:ci` and `npm run typecheck` pass
 5. Open a pull request referencing the issue number
 
+## Releasing
+
+Releases are **tag-driven**: pushing a tag `vX.Y.Z` triggers
+[`release.yml`](.github/workflows/release.yml), which builds, signs, generates a
+provenance attestation, and publishes a GitHub release. The workflow verifies
+that the tag matches the `version` in `package.json`, so the two must stay in
+sync. We ship each release via a `release/vX.Y.Z` PR that is reviewed and merged
+before tagging.
+
+Use the helper script (`scripts/release.sh`, also `npm run release`):
+
+```bash
+# 1. Prepare: branch off origin/main, bump package.json, edit CHANGELOG, push.
+scripts/release.sh prepare 1.5.3        # or: npm run release -- prepare 1.5.3
+
+# 2. Open the release PR, let CI pass, and squash-merge it into main.
+
+# 3. Tag: verify main is on the new version, then push the tag to publish.
+scripts/release.sh tag 1.5.3            # or: npm run release -- tag 1.5.3
+```
+
+### Release checklist
+
+- [ ] All feature/fix PRs for the release are merged into `main`
+- [ ] Pick a version per [semver](https://semver.org/): new feature → minor, bug/chore → patch
+- [ ] `scripts/release.sh prepare <version>` — bumps `package.json` and opens `CHANGELOG.md`
+- [ ] CHANGELOG entry added at the top with the correct date and issue/PR links
+- [ ] Open the `release/vX.Y.Z` PR; confirm CI (lint, typecheck, test, build, API checks) is green
+- [ ] Squash-merge the release PR into `main`
+- [ ] `scripts/release.sh tag <version>` — pushes `vX.Y.Z`
+- [ ] Confirm the release workflow succeeds and the GitHub release + `.zip` asset are published
+
 ## Reporting bugs
 
 Use the [bug report template](https://github.com/allamiro/grafana-network-weathermap-ng/issues/new?template=bug_report.md).

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint --cache --ignore-path ./.gitignore --ext .js,.jsx,.ts,.tsx .",
     "lint:fix": "npm run lint --fix",
     "posttest": "make-coverage-badge",
+    "release": "bash scripts/release.sh",
     "server": "docker-compose up --build",
     "sign": "npx --yes @grafana/sign-plugin@latest",
     "test": "jest --watch --onlyChanged",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# release.sh — helper for cutting a new plugin release.
+#
+# The release is tag-driven: pushing a tag `vX.Y.Z` triggers
+# `.github/workflows/release.yml` (build + sign + provenance + GitHub release).
+# `release.yml` verifies that the tag equals the `package.json` version, so the
+# two must always match. This script keeps them in sync and follows the repo
+# convention of a `release/vX.Y.Z` PR that is reviewed and merged before tagging.
+#
+# Usage:
+#   scripts/release.sh prepare <version>   # step 1: branch + bump + commit + push, then open a PR
+#   scripts/release.sh tag <version>       # step 2: after the release PR merges, tag main to publish
+#
+# Example (releasing 1.5.3):
+#   scripts/release.sh prepare 1.5.3       # edit CHANGELOG when prompted, push, open & merge the PR
+#   scripts/release.sh tag 1.5.3           # pushes tag v1.5.3 -> release workflow runs
+#
+set -euo pipefail
+
+die() { echo "error: $*" >&2; exit 1; }
+
+# X.Y.Z, no leading "v"
+validate_version() {
+  local v="$1"
+  [[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "version must be semver X.Y.Z (got '$v')"
+}
+
+pkg_version() {
+  node -p "require('./package.json').version"
+}
+
+require_clean_tree() {
+  git diff --quiet && git diff --cached --quiet || die "working tree is not clean; commit or stash first"
+}
+
+cmd="${1:-}"
+version="${2:-}"
+
+[[ -n "$cmd" && -n "$version" ]] || die "usage: scripts/release.sh {prepare|tag} <version>"
+validate_version "$version"
+
+# Always operate from the repo root.
+cd "$(dirname "$0")/.."
+
+tag="v${version}"
+
+case "$cmd" in
+  prepare)
+    require_clean_tree
+    git fetch origin --quiet
+    branch="release/${tag}"
+    echo "==> Creating ${branch} from origin/main"
+    git checkout -b "$branch" origin/main
+
+    echo "==> Bumping package.json to ${version}"
+    npm version "$version" --no-git-tag-version --allow-same-version >/dev/null
+
+    cat <<EOF
+
+==> Now edit CHANGELOG.md: add a new section at the top:
+
+    ## [${version}](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/${tag}) (YYYY-MM-DD)
+
+    ### Features / Bug Fixes / Chores
+    * ... describe the change ... (#issue, PR #nnn)
+
+Press Enter to open CHANGELOG.md in \${EDITOR:-vi}, or Ctrl-C to edit it yourself.
+EOF
+    read -r _
+    "${EDITOR:-vi}" CHANGELOG.md
+
+    git add package.json CHANGELOG.md
+    git commit -m "chore(release): bump version to ${version}"
+    git push -u origin "$branch"
+
+    echo
+    echo "==> Done. Open the PR and merge it (squash), then run:"
+    echo "      scripts/release.sh tag ${version}"
+    ;;
+
+  tag)
+    echo "==> Fetching latest main"
+    git fetch origin --quiet
+    remote_version="$(git show origin/main:package.json | node -p "JSON.parse(require('fs').readFileSync(0)).version")"
+    [[ "$remote_version" == "$version" ]] || \
+      die "origin/main package.json is ${remote_version}, not ${version} — is the release PR merged?"
+
+    git rev-parse -q --verify "refs/tags/${tag}" >/dev/null && die "tag ${tag} already exists"
+
+    local_sha="$(git rev-parse origin/main)"
+    echo "==> Tagging ${local_sha} as ${tag}"
+    git tag -a "$tag" "$local_sha" -m "Release ${tag}"
+    git push origin "$tag"
+
+    echo "==> Pushed ${tag}. The release workflow will build, sign, and publish the GitHub release."
+    ;;
+
+  *)
+    die "unknown command '${cmd}' (expected 'prepare' or 'tag')"
+    ;;
+esac


### PR DESCRIPTION
Closes #34

## What
Adds a repeatable release helper and documents the process, addressing both options in the issue's acceptance criteria (a `scripts/release.sh` **and** a CONTRIBUTING release procedure).

## `scripts/release.sh` (also `npm run release`)
Mirrors the repo's tag-driven flow (`release.yml` requires the tag to equal `package.json` version), split around the human PR review:

- **`prepare <version>`** — branch `release/vX.Y.Z` off `origin/main`, bump `package.json` (`npm version --no-git-tag-version`), open `CHANGELOG.md` to add the entry, commit `chore(release): bump version to X.Y.Z`, and push.
- **`tag <version>`** — after the release PR is merged, verify `origin/main` is on `<version>`, then create and push an annotated tag `vX.Y.Z` (triggers build + sign + attestation + GitHub release).

Guards: semver validation, clean-tree check, refuses to tag if `origin/main` isn't on the target version (i.e. PR not merged yet), and refuses to recreate an existing tag. All error paths exit non-zero.

## CONTRIBUTING.md
New **Releasing** section with the two-step commands plus a checkbox **release checklist**.

## Verification
- `bash -n scripts/release.sh` — syntax OK
- Guards exercised: no-args, bad semver, unknown command, and `tag` against a non-matching version all exit `1` with a clear message
- `npm run lint` — clean
- Script committed with the executable bit (`100755`)

No plugin runtime code changed (tooling/docs only).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a repeatable release helper and documents the tag-driven process to keep `package.json` and git tags in sync. Also adds an `npm run release` script and a simple release checklist.

- **New Features**
  - `scripts/release.sh` with `prepare <version>` and `tag <version>` to drive release PRs and tagging.
  - `npm run release` alias to run the helper.
  - Safety checks: semver validation, clean tree, tag uniqueness, and `origin/main` version match.
  - CONTRIBUTING updates: clear “Releasing” steps and a short checklist.

<sup>Written for commit e91da59d574c33fb5ee1c9ba7822e53c182f0fac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

