### PR TITLE
feat(#69): in-panel error and no-data notices

### DIFF
--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -152,6 +152,54 @@ test('Connected links', () => {
   expect(screen.getAllByTestId('link')).toHaveLength(2);
 });
 
+test('Shows an error notice when a query fails', () => {
+  let testProps = { ...mPanelProps };
+  testProps.options.weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  testProps.data = {
+    state: LoadingState.Error,
+    series: [],
+    error: { message: 'boom' },
+    timeRange: getDefaultRelativeTimeRange(),
+  } as unknown as PanelProps<SimpleOptions>['data'];
+
+  render(<WeathermapPanel {...testProps} />);
+
+  const notice = screen.getByTestId('weathermap-data-notice');
+  expect(notice.textContent).toContain('Query error');
+  expect(notice.textContent).toContain('boom');
+});
+
+test('Shows a no-data notice when queries are configured but return nothing', () => {
+  let testProps = { ...mPanelProps };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  weathermap.links[0].sides.A.query = 'A-series';
+  testProps.options.weathermap = weathermap;
+  testProps.data = {
+    state: LoadingState.Done,
+    series: [],
+    timeRange: getDefaultRelativeTimeRange(),
+  } as unknown as PanelProps<SimpleOptions>['data'];
+
+  render(<WeathermapPanel {...testProps} />);
+
+  const notice = screen.getByTestId('weathermap-data-notice');
+  expect(notice.textContent).toContain('No data');
+});
+
+test('Shows no notice for a topology-only map with no queries', () => {
+  let testProps = { ...mPanelProps };
+  testProps.options.weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  testProps.data = {
+    state: LoadingState.Done,
+    series: [],
+    timeRange: getDefaultRelativeTimeRange(),
+  } as unknown as PanelProps<SimpleOptions>['data'];
+
+  render(<WeathermapPanel {...testProps} />);
+
+  expect(screen.queryByTestId('weathermap-data-notice')).toBeNull();
+});
+
 test('Check edit mode display', () => {
   let testProps = { ...mPanelProps };
   testProps.options.weathermap = handleVersionedStateUpdates(getConnectedLinkData(theme), theme);

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef, useMemo } from 'react';
-import { DataFrame, Field, FieldType, getTimeZone, getValueFormat, PanelProps } from '@grafana/data';
+import { DataFrame, Field, FieldType, getTimeZone, getValueFormat, LoadingState, PanelProps } from '@grafana/data';
 import {
   Anchor,
   DrawnLink,
@@ -655,6 +655,36 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
     return displayName === hoveredLink.link.sides.A.query || displayName === hoveredLink.link.sides.Z.query;
   });
 
+  // Build an in-panel notice for query errors or missing data so operators can
+  // diagnose problems without opening the browser console. The map still renders
+  // underneath; the notice is a non-interactive banner overlaid at the top.
+  const dataNotice: { level: 'error' | 'info'; message: string } | null = (() => {
+    if (data.state === LoadingState.Error) {
+      const message = data.error?.message || data.errors?.[0]?.message || 'A query returned an error.';
+      return { level: 'error', message: `Query error: ${message}` };
+    }
+    // Only warn about missing data when the map actually expects some — i.e. at
+    // least one node or link has a query configured. A topology-only map is fine.
+    const expectsData = Boolean(
+      wm?.links?.some(
+        (l) =>
+          l.sides.A.query ||
+          l.sides.Z.query ||
+          l.sides.A.bandwidthQuery ||
+          l.sides.Z.bandwidthQuery ||
+          l.statusQuery
+      ) || wm?.nodes?.some((n) => n.statusQuery)
+    );
+    if (expectsData && data.series.length === 0 && data.state !== LoadingState.Loading) {
+      return {
+        level: 'info',
+        message:
+          'No data returned by the panel’s queries. Check the queries, the data source, and the dashboard time range.',
+      };
+    }
+    return null;
+  })();
+
   if (wm) {
     return (
       <div
@@ -668,6 +698,36 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
           `
         )}
       >
+        {dataNotice ? (
+          <div
+            role="alert"
+            data-testid="weathermap-data-notice"
+            className={css`
+              position: absolute;
+              top: 8px;
+              left: 50%;
+              transform: translateX(-50%);
+              max-width: 90%;
+              z-index: 9999;
+              pointer-events: none;
+              padding: 6px 12px;
+              border-radius: 4px;
+              font-size: 12px;
+              text-align: center;
+              box-shadow: ${theme.shadows.z1};
+              background-color: ${dataNotice.level === 'error'
+                ? theme.colors.error.main
+                : theme.colors.warning.main};
+              color: ${dataNotice.level === 'error'
+                ? theme.colors.error.contrastText
+                : theme.colors.warning.contrastText};
+            `}
+          >
+            {dataNotice.message}
+          </div>
+        ) : (
+          ''
+        )}
         {hoveredLink ? (
           <div
             className={css`


### PR DESCRIPTION
Closes #69

## Problem
When a query failed, a data frame was malformed, or nothing matched, the panel showed **no indication** — users had to open browser devtools to see the `console.warn`s.

## Change
Adds a non-interactive notice banner overlaid at the top-center of the panel (the map still renders underneath):

- **Query error** — when `data.state === LoadingState.Error`, a red banner shows `Query error: <message>` (from `data.error` / `data.errors`).
- **No data** — an amber banner *only* when the map actually expects data (at least one node or link has a query configured) and the query set returns an empty series while not loading. A topology-only map (no queries) shows nothing, avoiding noise on a freshly-built map.

Banner is `pointer-events: none`, theme-colored (`error`/`warning`), and marked `role="alert"` with `data-testid="weathermap-data-notice"`.

## Tests
Three new cases in `WeathermapPanel.test.tsx`:
- error state → shows "Query error … boom"
- queries configured + empty series → shows "No data"
- topology-only map + empty series → no notice

## Verification
`lint`, `typecheck`, `test:ci` (24/24), and `build` all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a top-center notice banner in the panel for query errors and no data so operators can see issues without opening devtools. The map still renders underneath.

- **New Features**
  - Query error: red banner shows “Query error: <message>” from the data error.
  - No data: amber banner only when at least one node/link has a query and the result is empty while not loading; topology-only maps show nothing.
  - UX: non-interactive overlay (pointer-events: none), theme-colored, `role="alert"`, `data-testid="weathermap-data-notice"`.

<sup>Written for commit e36c8a6a200f7670ced2afecdfe99c1917e60183. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

