### PR TITLE
fix(security): pin form-data to 4.0.6 (clear osv-scanner HIGH blocker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.5.3](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.3) (2026-07-02)
+
+### Bug Fixes
+
+* **security**: pin the transitive `form-data` dependency to `4.0.6` via an npm `overrides` entry, resolving the HIGH-severity CRLF-injection advisory GHSA-hmw2-7cc7-3qxx (affecting `>=4.0.0 <4.0.6`) that osv-scanner flagged in `package-lock.json`. `form-data` is a dev-only transitive dependency (via `jest-environment-jsdom` → `jsdom`) and is not part of the shipped plugin bundle; `npm audit` now reports 0 high/critical vulnerabilities. No plugin runtime changes from 1.5.2.
+
 ## [1.5.2](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.2) (2026-07-01)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.1.0",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamirsuliman-weathermap-panel",
-      "version": "1.1.0",
+      "version": "1.5.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",
@@ -8209,17 +8209,17 @@
       "dev": true
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -8646,9 +8646,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
@@ -96,6 +96,7 @@
     "serialize-javascript": "7.0.5",
     "dompurify": "3.4.8",
     "js-cookie": "3.0.8",
+    "form-data": "4.0.6",
     "@grafana/ui": {
       "uuid": "11.1.1"
     }


### PR DESCRIPTION
The Grafana submission for **v1.5.2** was blocked (`Failed`) by **osv-scanner** reporting a **HIGH-severity** advisory in `form-data`:

- **GHSA-hmw2-7cc7-3qxx** — CRLF injection via unescaped multipart field names/filenames (CWE-93, CVSS 7.5), affecting `form-data >=4.0.0 <4.0.6`.

`form-data` is a **dev-only transitive dependency** (`jest-environment-jsdom` → `jsdom`) and is **not** part of the shipped plugin bundle, but osv-scanner scans the full `package-lock.json` and blocks on HIGH regardless.

## Fix
- Add `form-data: "4.0.6"` (the patched release) to the existing npm `overrides` block and regenerate the lockfile.

## Verification (run locally)
- `npm audit` → **0 high, 0 critical** (was 1 high); `form-data` no longer flagged.
- `npm run typecheck` → pass
- `npm run test:ci` → **21/21 pass**
- `npm run lint` → pass
- `npm run build` → success

No plugin runtime changes from 1.5.2. Bumps version to 1.5.3.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned dev-only transitive `form-data` to 4.0.6 to clear the HIGH osv-scanner advisory and unblock the Grafana submission. No runtime changes; version bumped to 1.5.3.

- **Bug Fixes**
  - Added direct dependency `form-data@4.0.6` to force the patched version used by `jest-environment-jsdom` → `jsdom`.
  - Resolves GHSA-hmw2-7cc7-3qxx (CRLF injection) affecting `>=4.0.0 <4.0.6`; `npm audit` now shows 0 high/critical.
  - Updated lockfile and changelog; no plugin bundle impact since `form-data` is dev-only.

<sup>Written for commit 7b386335996a2b46ceabbb21800b656147f9c8d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

