### PR TITLE
feat(#72): node hover tooltips with additional metrics

### DIFF
--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -200,6 +200,50 @@ test('Shows no notice for a topology-only map with no queries', () => {
   expect(screen.queryByTestId('weathermap-data-notice')).toBeNull();
 });
 
+test('Shows a node tooltip with configured metrics on hover', () => {
+  let testProps = { ...mPanelProps };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  weathermap.nodes[0].tooltipMetrics = [{ label: 'Latency', query: 'latency-series', units: 's' }];
+  testProps.options.weathermap = weathermap;
+  testProps.onOptionsChange = (options: SimpleOptions) => {
+    testProps.options = options;
+  };
+
+  render(<WeathermapPanel {...testProps} />);
+
+  // No tooltip until we hover.
+  expect(screen.queryByTestId('weathermap-node-tooltip')).toBeNull();
+
+  // Hover the node that has metrics configured.
+  const nodeGroup = screen.getByText(weathermap.nodes[0].label!).closest('g')!;
+  fireEvent.mouseMove(nodeGroup);
+
+  const tooltip = screen.getByTestId('weathermap-node-tooltip');
+  expect(tooltip.textContent).toContain('Latency');
+  // With no matching series the value resolves to n/a rather than crashing.
+  expect(tooltip.textContent).toContain('n/a');
+
+  // Leaving the node hides the tooltip again.
+  fireEvent.mouseLeave(nodeGroup);
+  expect(screen.queryByTestId('weathermap-node-tooltip')).toBeNull();
+});
+
+test('Shows no node tooltip when the node has no configured metrics', () => {
+  let testProps = { ...mPanelProps };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  testProps.options.weathermap = weathermap;
+  testProps.onOptionsChange = (options: SimpleOptions) => {
+    testProps.options = options;
+  };
+
+  render(<WeathermapPanel {...testProps} />);
+
+  const nodeGroup = screen.getByText(weathermap.nodes[0].label!).closest('g')!;
+  fireEvent.mouseMove(nodeGroup);
+
+  expect(screen.queryByTestId('weathermap-node-tooltip')).toBeNull();
+});
+
 test('Check edit mode display', () => {
   let testProps = { ...mPanelProps };
   testProps.options.weathermap = handleVersionedStateUpdates(getConnectedLinkData(theme), theme);

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -12,6 +12,8 @@ import {
   Position,
   Weathermap,
   HoveredLink,
+  HoveredNode,
+  NodeTooltipMetric,
   Threshold,
 } from 'types';
 import { css, cx } from '@emotion/css';
@@ -630,6 +632,31 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
     setHoveredLink(null as unknown as HoveredLink);
   };
 
+  const [hoveredNode, setHoveredNode] = useState(null as unknown as HoveredNode);
+
+  const handleNodeHover = (d: DrawnNode, e: React.MouseEvent<SVGElement>) => {
+    // Only show a tooltip when the node actually has metrics configured, and
+    // never while a node is being dragged in edit mode.
+    if (e.shiftKey || draggedNode || !d.tooltipMetrics || d.tooltipMetrics.length === 0) {
+      return;
+    }
+    let mouseX = e.clientX;
+    let mouseY = e.clientY;
+    if (wrapperRef.current) {
+      const rect = wrapperRef.current.getBoundingClientRect();
+      mouseX = e.clientX - rect.left;
+      mouseY = e.clientY - rect.top;
+    }
+    setHoveredNode({ node: d, mouseX, mouseY });
+  };
+
+  const handleNodeHoverLoss = (e: React.MouseEvent<SVGElement>) => {
+    if (e.shiftKey) {
+      return;
+    }
+    setHoveredNode(null as unknown as HoveredNode);
+  };
+
   // Navigate to a user-provided dashboard link only if it passes URL validation.
   // Values may have been produced by template-variable substitution at runtime,
   // so they are re-sanitized here before ever reaching window.open.
@@ -920,6 +947,59 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
             ) : (
               ''
             )}
+          </div>
+        ) : (
+          ''
+        )}
+        {hoveredNode && hoveredNode.node.tooltipMetrics && hoveredNode.node.tooltipMetrics.length > 0 ? (
+          <div
+            data-testid="weathermap-node-tooltip"
+            className={css`
+              position: absolute;
+              top: ${hoveredNode.mouseY - 10}px;
+              left: ${hoveredNode.mouseX + 14}px;
+              transform: translate(
+                ${hoveredNode.mouseX > width2 * 0.65 ? '-100%' : '0%'},
+                ${hoveredNode.mouseY < 120 ? '0%' : '-100%'}
+              );
+              pointer-events: none;
+              background-color: ${wm.settings.tooltip.backgroundColor};
+              color: ${wm.settings.tooltip.textColor} !important;
+              font-size: ${wm.settings.tooltip.fontSize} !important;
+              z-index: 10000;
+              display: flex;
+              flex-direction: column;
+              padding: ${wm.settings.tooltip.fontSize}px;
+              border-radius: 4px;
+              border: 1px solid ${theme.colors.border.medium};
+            `}
+          >
+            <div
+              style={{
+                fontSize: wm.settings.tooltip.fontSize,
+                borderBottom: `1px solid ${theme.colors.border.medium}`,
+                marginBottom: '4px',
+                display: 'flex',
+                justifyContent: 'center',
+              }}
+            >
+              {hoveredNode.node.label}
+            </div>
+            {hoveredNode.node.tooltipMetrics.map((metric: NodeTooltipMetric, idx: number) => {
+              const fmt = getlinkValueFormatter(metric.units || 'none');
+              const raw = metric.query ? dataFrameMap.get(metric.query) : undefined;
+              let valueText = 'n/a';
+              if (raw !== undefined) {
+                const formatted = fmt(raw, wm.settings.link.linkDecimals);
+                valueText = `${formatted.text} ${formatted.suffix}`.trim();
+              }
+              return (
+                <div key={idx} style={{ fontSize: wm.settings.tooltip.fontSize }}>
+                  {metric.label ? `${metric.label}: ` : ''}
+                  {valueText}
+                </div>
+              );
+            })}
           </div>
         ) : (
           ''
@@ -1503,6 +1583,8 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                       // Force an update
                       onOptionsChange(options);
                     },
+                    onMouseMove: (e) => handleNodeHover(d, e),
+                    onMouseLeave: (e) => handleNodeHoverLoss(e),
                     disabled: !isEditMode,
                     data: data,
                   }}

--- a/src/components/MapNode.tsx
+++ b/src/components/MapNode.tsx
@@ -22,6 +22,8 @@ interface NodeProps {
   onDrag: DraggableEventHandler;
   onStop: DraggableEventHandler;
   onClick: React.MouseEventHandler<SVGGElement>;
+  onMouseMove?: React.MouseEventHandler<SVGGElement>;
+  onMouseLeave?: React.MouseEventHandler<SVGGElement>;
   disabled: boolean;
   data: PanelData;
 }
@@ -46,7 +48,8 @@ function calculateRectY(d: DrawnNode, wm: Weathermap) {
 }
 
 const MapNode: React.FC<NodeProps> = (props: NodeProps) => {
-  const { node, draggedNode, selectedNodes, wm, onDrag, onStop, onClick, disabled, data } = props;
+  const { node, draggedNode, selectedNodes, wm, onDrag, onStop, onClick, onMouseMove, onMouseLeave, disabled, data } =
+    props;
   const styles = useStyles2(getStyles);
 
   // React 19 removed ReactDOM.findDOMNode, which react-draggable falls back to
@@ -104,6 +107,8 @@ const MapNode: React.FC<NodeProps> = (props: NodeProps) => {
         cursor={disabled ? (node.dashboardLink ? 'pointer' : '') : 'move'}
         display={node.label !== undefined ? 'inline' : 'none'}
         onClick={onClick}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
         transform={`translate(${
           wm.settings.panel.grid.enabled &&
           draggedNode &&

--- a/src/forms/NodeForm.tsx
+++ b/src/forms/NodeForm.tsx
@@ -14,10 +14,11 @@ import {
   ColorPicker,
   Slider,
   useTheme2,
+  UnitPicker,
 } from '@grafana/ui';
 import { SelectableValue, StandardEditorProps } from '@grafana/data';
 import { v4 as uuidv4 } from 'uuid';
-import { Weathermap, Node, NodeStatusValueMapping } from 'types';
+import { Weathermap, Node, NodeStatusValueMapping, NodeTooltipMetric } from 'types';
 import { CiscoIcons, NetworkingIcons, DatabaseIcons, ComputerIcons } from './iconOptions';
 import { getDataFrameName, sanitizeUrl } from 'utils';
 
@@ -604,6 +605,86 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                     style={{ marginTop: '4px' }}
                   >
                     Add Mapping
+                  </Button>
+                </ControlledCollapse>
+              </InlineFieldRow>
+              <InlineFieldRow className={styles.inlineRow}>
+                <ControlledCollapse label="Tooltip">
+                  <p style={{ margin: '0 0 6px', fontSize: '11px', opacity: 0.7 }}>
+                    Show additional metric values (latency, packet loss, CPU, etc.) when hovering over this node.
+                  </p>
+                  {(node.tooltipMetrics ?? []).map((metric: NodeTooltipMetric, mi: number) => (
+                    <React.Fragment key={mi}>
+                      <InlineFieldRow>
+                        <InlineField grow label={`Metric ${mi + 1} Label`} style={{ width: '100%' }}>
+                          <Input
+                            value={metric.label}
+                            onChange={(e) => {
+                              let weathermap: Weathermap = value;
+                              weathermap.nodes[i].tooltipMetrics![mi].label = e.currentTarget.value;
+                              onChange(weathermap);
+                            }}
+                            placeholder={'e.g. Latency, Packet Loss, CPU'}
+                            type={'text'}
+                          />
+                        </InlineField>
+                      </InlineFieldRow>
+                      <InlineField grow label={`Metric ${mi + 1} Query`} style={{ width: '100%' }}>
+                        <Select
+                          onChange={(v) => {
+                            let weathermap: Weathermap = value;
+                            weathermap.nodes[i].tooltipMetrics![mi].query = v ? v.value : undefined;
+                            onChange(weathermap);
+                          }}
+                          value={dataWithIds.find((p) => p === metric.query) ?? null}
+                          options={dataWithIds.map((d) => ({ value: d, label: d }))}
+                          placeholder={'Select query'}
+                          isClearable
+                          menuShouldPortal
+                        />
+                      </InlineField>
+                      <InlineField grow label={`Metric ${mi + 1} Units`} style={{ width: '100%' }}>
+                        <UnitPicker
+                          onChange={(val) => {
+                            let weathermap: Weathermap = value;
+                            weathermap.nodes[i].tooltipMetrics![mi].units = val;
+                            onChange(weathermap);
+                          }}
+                          value={metric.units}
+                        />
+                      </InlineField>
+                      <InlineFieldRow>
+                        <Button
+                          variant="secondary"
+                          icon="trash-alt"
+                          size="sm"
+                          onClick={() => {
+                            let weathermap: Weathermap = value;
+                            weathermap.nodes[i].tooltipMetrics!.splice(mi, 1);
+                            onChange(weathermap);
+                          }}
+                          style={{ marginBottom: '8px' }}
+                        >
+                          Remove Metric {mi + 1}
+                        </Button>
+                      </InlineFieldRow>
+                    </React.Fragment>
+                  ))}
+                  <Button
+                    variant="secondary"
+                    icon="plus"
+                    size="sm"
+                    onClick={() => {
+                      let weathermap: Weathermap = value;
+                      weathermap.nodes[i].tooltipMetrics = [
+                        ...(weathermap.nodes[i].tooltipMetrics || []),
+                        { label: '', query: undefined },
+                      ];
+                      onChange(weathermap);
+                    }}
+                    style={{ marginBottom: '8px' }}
+                  >
+                    Add Metric
                   </Button>
                 </ControlledCollapse>
               </InlineFieldRow>

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,12 @@ export interface NodeStatusValueMapping {
   color: string;
 }
 
+export interface NodeTooltipMetric {
+  label: string;
+  query?: string;
+  units?: string;
+}
+
 export interface Node {
   id: string;
   position: [number, number];
@@ -69,6 +75,7 @@ export interface Node {
   showLabel?: boolean;
   dashboardLink?: string;
   openInSameTab?: boolean;
+  tooltipMetrics?: NodeTooltipMetric[];
   anchors: {
     [Anchor.Center]: NodeAnchor;
     [Anchor.Top]: NodeAnchor;
@@ -175,6 +182,12 @@ export interface DrawnLink extends Link {
 export interface HoveredLink {
   link: DrawnLink;
   side: 'A' | 'Z';
+  mouseX: number;
+  mouseY: number;
+}
+
+export interface HoveredNode {
+  node: DrawnNode;
   mouseX: number;
   mouseY: number;
 }


### PR DESCRIPTION
Closes #72.

Adds node hover tooltips that display additional metric values (latency, packet loss, CPU usage, or any bound query value) — the node equivalent of the existing link tooltip extra-metrics feature (#73).

## Changes
- **types**: `NodeTooltipMetric` + `HoveredNode`; optional `Node.tooltipMetrics` (backward compatible — no state migration needed).
- **NodeForm**: new **Tooltip** collapse to add/remove metrics, each with a Label, a Query selector, and a Unit formatter.
- **MapNode**: optional `onMouseMove` / `onMouseLeave` handlers on the node group.
- **WeathermapPanel**: tracks `hoveredNode` and renders a tooltip resolving each configured metric from the existing per-render `dataFrameMap`, formatted with the metric's units. Suppressed while dragging and when a node has no metrics configured.

## Security
Metric labels and values render as **escaped JSX text** — no `dangerouslySetInnerHTML`, and no new URL/navigation/HTML-injection surface. Tooltip is `pointer-events: none`. Values come from already-resolved query frames.

## Verification (run locally)
- `npm run typecheck` → pass
- `npm run test:ci` → **26/26 pass** (2 new: tooltip-on-hover, no-tooltip-without-metrics)
- `npm run lint` → pass
- `npm run build` → success
- `npm audit` → 0 high / 0 critical

## Release
Branch is stacked on `main` (which already contains #144), so this is ready to ride in the next release alongside it. **Not for immediate merge** — hold with #144 for the next release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds node hover tooltips that show extra metric values (latency, loss, CPU, or any bound query), matching the existing link tooltip behavior. Implements #72 and hides the tooltip while dragging or when a node has no metrics.

- **New Features**
  - NodeForm: new Tooltip section to add metrics per node (label, query, units).
  - WeathermapPanel: tracks hovered node and renders a styled tooltip; resolves values from the existing data map and formats by units; text is safely escaped.
  - MapNode: exposes onMouseMove/onMouseLeave to drive hover state.
  - Types: adds NodeTooltipMetric and HoveredNode; optional Node.tooltipMetrics (backward compatible).

<sup>Written for commit 0e2d5f92b2d7543db737868ff7e3b51d1da37b0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

