### PR TITLE
feat(#70): explicit inbound/outbound direction labels per link side

### DIFF
--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -87,6 +87,28 @@ test('Creating a weathermap', () => {
   // TODO: find a working way to check node dragging
 });
 
+test('Uses explicit per-side direction labels in the link tooltip when set', () => {
+  let testProps = { ...mPanelProps };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  weathermap.links[0].sides.A.directionLabel = 'TX-UPLINK';
+  weathermap.links[0].sides.Z.directionLabel = 'RX-DOWNLINK';
+  testProps.options.weathermap = weathermap;
+  testProps.onOptionsChange = (options: SimpleOptions) => {
+    testProps.options = options;
+  };
+
+  render(<WeathermapPanel {...testProps} />);
+
+  // Hover the link to open its tooltip.
+  fireEvent.mouseMove(screen.getByTestId('link').firstChild!);
+
+  // Both explicit labels replace the generic Inbound/Outbound wording.
+  expect(screen.getAllByText(/TX-UPLINK/).length).toBeGreaterThan(0);
+  expect(screen.getAllByText(/RX-DOWNLINK/).length).toBeGreaterThan(0);
+
+  fireEvent.mouseLeave(screen.getByTestId('link').firstChild!);
+});
+
 // Tests plays badly with new deps
 // test('Editing a weathermap', () => {
 //   let testProps = { ...mPanelProps };

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -630,6 +630,13 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
     setHoveredLink(null as unknown as HoveredLink);
   };
 
+  // Resolve the tooltip label for a given link side, preferring an explicit
+  // per-side direction label (#70) and falling back to the generic wording.
+  const sideDirectionLabel = (link: DrawnLink, side: 'A' | 'Z', fallback: string): string => {
+    const label = link.sides[side].directionLabel;
+    return label && label.trim() !== '' ? label : fallback;
+  };
+
   // Navigate to a user-provided dashboard link only if it passes URL validation.
   // Values may have been produced by template-variable substitution at runtime,
   // so they are re-sanitized here before ever reaching window.open.
@@ -767,15 +774,21 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
               {hoveredLink.link.target.label}
             </div>
             <div style={{ fontSize: wm.settings.tooltip.fontSize }}>
-              Usage - Inbound: {hoveredLink.link.sides[hoveredLink.side === 'A' ? 'Z' : 'A'].currentValueText}, Outbound:{' '}
+              Usage - {sideDirectionLabel(hoveredLink.link, hoveredLink.side === 'A' ? 'Z' : 'A', 'Inbound')}:{' '}
+              {hoveredLink.link.sides[hoveredLink.side === 'A' ? 'Z' : 'A'].currentValueText},{' '}
+              {sideDirectionLabel(hoveredLink.link, hoveredLink.side, 'Outbound')}:{' '}
               {hoveredLink.link.sides[hoveredLink.side === 'A' ? 'A' : 'Z'].currentValueText}
             </div>
             <div style={{ fontSize: wm.settings.tooltip.fontSize }}>
-              Bandwidth - Inbound: {hoveredLink.link.sides[hoveredLink.side === 'A' ? 'Z' : 'A'].currentBandwidthText}, Outbound:{' '}
+              Bandwidth - {sideDirectionLabel(hoveredLink.link, hoveredLink.side === 'A' ? 'Z' : 'A', 'Inbound')}:{' '}
+              {hoveredLink.link.sides[hoveredLink.side === 'A' ? 'Z' : 'A'].currentBandwidthText},{' '}
+              {sideDirectionLabel(hoveredLink.link, hoveredLink.side, 'Outbound')}:{' '}
               {hoveredLink.link.sides[hoveredLink.side === 'A' ? 'A' : 'Z'].currentBandwidthText}
             </div>
             <div style={{ fontSize: wm.settings.tooltip.fontSize }}>
-              Throughput (%) - Inbound: {hoveredLink.link.sides[hoveredLink.side === 'A' ? 'Z' : 'A'].currentPercentageText}, Outbound:{' '}
+              Throughput (%) - {sideDirectionLabel(hoveredLink.link, hoveredLink.side === 'A' ? 'Z' : 'A', 'Inbound')}:{' '}
+              {hoveredLink.link.sides[hoveredLink.side === 'A' ? 'Z' : 'A'].currentPercentageText},{' '}
+              {sideDirectionLabel(hoveredLink.link, hoveredLink.side, 'Outbound')}:{' '}
               {hoveredLink.link.sides[hoveredLink.side === 'A' ? 'A' : 'Z'].currentPercentageText}
             </div>
             {hoveredLink.link.tooltipMetrics && hoveredLink.link.tooltipMetrics.length > 0 && (
@@ -898,7 +911,9 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                       marginRight: '4px',
                     }}
                   ></div>
-                  <div style={{ fontSize: wm.settings.tooltip.fontSize }}>Inbound</div>
+                  <div style={{ fontSize: wm.settings.tooltip.fontSize }}>
+                    {sideDirectionLabel(hoveredLink.link, 'Z', 'Inbound')}
+                  </div>
                   <div
                     style={{
                       width: '10px',
@@ -913,7 +928,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                       fontSize: wm.settings.tooltip.fontSize,
                     }}
                   >
-                    Outbound
+                    {sideDirectionLabel(hoveredLink.link, 'A', 'Outbound')}
                   </div>
                 </div>
               </React.Fragment>

--- a/src/forms/LinkForm.tsx
+++ b/src/forms/LinkForm.tsx
@@ -359,6 +359,21 @@ export const LinkForm = (props: Props) => {
                             name={`${sName}portLabel`}
                           />
                         </InlineField>
+                        <InlineField grow label={`${sName} Direction Label`} style={{ width: '100%' }}>
+                          <Input
+                            value={side.directionLabel ?? ''}
+                            onChange={(e) => {
+                              let weathermap: Weathermap = value;
+                              weathermap.links[i].sides[sName].directionLabel =
+                                e.currentTarget.value || undefined;
+                              onChange(weathermap);
+                            }}
+                            placeholder={sName === 'A' ? 'e.g. Outbound' : 'e.g. Inbound'}
+                            type={'text'}
+                            className={styles.nodeLabel}
+                            name={`${sName}directionLabel`}
+                          />
+                        </InlineField>
                       </React.Fragment>
                     )}
                   </React.Fragment>

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,6 +104,10 @@ export interface LinkSide {
   anchor: Anchor;
   dashboardLink: string;
   portLabel?: string;
+  // Optional explicit direction label for this side (e.g. "Inbound", "Outbound",
+  // "To WAN"). When set, the hover tooltip labels this side's value with it
+  // instead of the generic Inbound/Outbound wording.
+  directionLabel?: string;
 }
 
 export interface LinkTooltipMetric {


### PR DESCRIPTION
Closes #70.

Adds an optional per-side **Direction Label** so operators can explicitly name which side of a link is inbound vs outbound — resolving the implicit A/Z convention that confused users upstream (knightss27/grafana-network-weathermap#55).

## Changes
- **types**: optional `LinkSide.directionLabel` (backward compatible — no state migration).
- **LinkForm**: an **A/Z Direction Label** input under each side's options (placeholder "Outbound"/"Inbound").
- **WeathermapPanel**: the hover tooltip — Usage / Bandwidth / Throughput lines and the graph legend — now labels each side's value with its explicit direction label when set, falling back to the current "Inbound"/"Outbound" wording otherwise. Each value is labeled by *its own side*, so the naming stays correct regardless of which side is hovered (fixing the ambiguity in #55).

## Security
`directionLabel` is a plain string rendered as **escaped JSX text** — no `dangerouslySetInnerHTML`, no URL/navigation/HTML-injection surface. When unset, tooltip behavior is unchanged.

## Verification (run locally)
- `npm run typecheck` → pass
- `npm run test:ci` → **25/25 pass** (1 new: explicit labels appear in the tooltip on hover)
- `npm run lint` → pass
- `npm run build` → success
- `npm audit` → 0 high / 0 critical

## Release
Branched off `main`; independent of #144 (merged) and #146 (node tooltips). **Not for immediate merge** — hold for the next release alongside them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional per-side direction labels for links so operators can name inbound/outbound explicitly in tooltips and legends. Implements #70 and removes A/Z ambiguity.

- **New Features**
  - Optional `LinkSide.directionLabel` (backward compatible).
  - Link editor: new "Direction Label" field on both A and Z sides.
  - Tooltip and legend: use each side’s label when set; fall back to "Inbound"/"Outbound". Labels stay correct regardless of hover side.

- **Migration**
  - No changes required. Existing maps behave the same until labels are added.

<sup>Written for commit 822e8d79102728fd08d858ea68b9ae21faec31c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

