### PR TITLE
feat(#62): configurable arrow/junction meeting point on links

### DIFF
--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -87,6 +87,25 @@ test('Creating a weathermap', () => {
   // TODO: find a working way to check node dragging
 });
 
+test('Renders a link with a custom arrow meeting point without breaking geometry', () => {
+  let testProps = { ...mPanelProps };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  weathermap.links[0].arrowMeetPercent = 90;
+  // Fresh options object so we don't mutate the shared mock props.
+  testProps.options = { weathermap };
+  testProps.onOptionsChange = (options: SimpleOptions) => {
+    testProps.options = options;
+  };
+
+  render(<WeathermapPanel {...testProps} />);
+
+  const link = screen.getByTestId('link');
+  expect(link).not.toBeNull();
+  // A shifted meeting point must still produce finite coordinates
+  // (no divide-by-zero / NaN in the arrow geometry).
+  expect(link.innerHTML).not.toContain('NaN');
+});
+
 // Tests plays badly with new deps
 // test('Editing a weathermap', () => {
 //   let testProps = { ...mPanelProps };

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -132,23 +132,23 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
     return ds.minWidth + (ds.maxWidth - ds.minWidth) * pct;
   }
 
-  // Get the middle point between two nodes
-  function getMiddlePoint(source: Position, target: Position, offset: number): Position {
-    const x = (source.x + target.x) / 2;
-    const y = (source.y + target.y) / 2;
-    const a = target.x - source.x;
-    const b = target.y - source.y;
-    const dist = Math.sqrt(a * a + b * b);
-    const newX = x - (offset * (target.x - source.x)) / dist;
-    const newY = y - (offset * (target.y - source.y)) / dist;
-    return { x: newX, y: newY };
-  }
-
   // Get a point a percentage of the way between two nodes
   function getPercentPoint(source: Position, target: Position, percent: number): Position {
     const newX = target.x + (source.x - target.x) * percent;
     const newY = target.y + (source.y - target.y) * percent;
     return { x: newX, y: newY };
+  }
+
+  // Shift a base point along the (from -> to) direction by `offset`. Lets the
+  // arrow "meeting point" sit at an arbitrary base rather than the fixed midpoint.
+  function shiftAlong(base: Position, from: Position, to: Position, offset: number): Position {
+    const a = to.x - from.x;
+    const b = to.y - from.y;
+    const dist = Math.sqrt(a * a + b * b);
+    if (dist === 0) {
+      return { x: base.x, y: base.y };
+    }
+    return { x: base.x - (offset * a) / dist, y: base.y - (offset * b) / dist };
   }
 
   // Find the points that create the two other points of a triangle for the arrow's tip
@@ -397,7 +397,17 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
       }
     }
 
-    toReturn.lineEndA = getMiddlePoint(
+    // The point where the two directional arrows meet. Defaults to the midpoint
+    // (50%) but can be shifted along the A->Z line via arrowMeetPercent (#62).
+    // Clamped to keep the junction from overlapping either node box.
+    const meetPercent = Math.min(95, Math.max(5, d.arrowMeetPercent ?? 50)) / 100;
+    const meetPoint: Position = {
+      x: toReturn.lineStartA.x + (toReturn.lineStartZ.x - toReturn.lineStartA.x) * meetPercent,
+      y: toReturn.lineStartA.y + (toReturn.lineStartZ.y - toReturn.lineStartA.y) * meetPercent,
+    };
+
+    toReturn.lineEndA = shiftAlong(
+      meetPoint,
       toReturn.lineStartZ,
       toReturn.lineStartA,
       -toReturn.arrows.offset - toReturn.arrows.height
@@ -408,7 +418,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
       toReturn.lineEndZ = toReturn.lineStartZ;
     }
 
-    toReturn.arrowCenterA = getMiddlePoint(toReturn.lineStartZ, toReturn.lineStartA, -toReturn.arrows.offset);
+    toReturn.arrowCenterA = shiftAlong(meetPoint, toReturn.lineStartZ, toReturn.lineStartA, -toReturn.arrows.offset);
     toReturn.arrowPolygonA = getArrowPolygon(
       toReturn.lineStartA,
       toReturn.arrowCenterA,
@@ -416,12 +426,13 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
       toReturn.arrows.width
     );
 
-    toReturn.lineEndZ = getMiddlePoint(
+    toReturn.lineEndZ = shiftAlong(
+      meetPoint,
       toReturn.lineStartZ,
       toReturn.lineStartA,
       toReturn.arrows.offset + toReturn.arrows.height
     );
-    toReturn.arrowCenterZ = getMiddlePoint(toReturn.lineStartZ, toReturn.lineStartA, toReturn.arrows.offset);
+    toReturn.arrowCenterZ = shiftAlong(meetPoint, toReturn.lineStartZ, toReturn.lineStartA, toReturn.arrows.offset);
     toReturn.arrowPolygonZ = getArrowPolygon(
       toReturn.lineStartZ,
       toReturn.arrowCenterZ,

--- a/src/forms/LinkForm.tsx
+++ b/src/forms/LinkForm.tsx
@@ -407,6 +407,24 @@ export const LinkForm = (props: Props) => {
                   name={'linkOffset'}
                 />
               </InlineField>
+              <InlineField
+                grow
+                label={'Arrow Meeting Point (%)'}
+                className={styles.inlineField}
+                tooltip={'Where along the A→Z line the two directional arrows meet. 50% is the midpoint (default); lower values move the junction toward the A side, higher toward the Z side.'}
+              >
+                <Slider
+                  min={5}
+                  max={95}
+                  step={1}
+                  value={link.arrowMeetPercent ?? 50}
+                  onChange={(num) => {
+                    let options = value;
+                    options.links[i].arrowMeetPercent = num;
+                    onChange(options);
+                  }}
+                />
+              </InlineField>
               <ControlledCollapse label="Stroke and Arrow">
                 <InlineField grow label="Link Stroke Width" className={styles.inlineField}>
                   <Slider

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,6 +125,9 @@ export interface Link {
   stroke: number;
   showThroughputPercentage: boolean;
   linkOffset?: number;
+  // Percentage (0-100) along the A->Z line where the two directional arrows
+  // meet. Defaults to 50 (the midpoint) when unset.
+  arrowMeetPercent?: number;
   tooltipMetrics?: LinkTooltipMetric[];
   statusQuery?: string;
   statusDownColor?: string;


### PR DESCRIPTION
Closes #62.

Adds a per-link **Arrow Meeting Point (%)** so users can shift where the two directional arrows meet along a link, instead of the fixed 50% midpoint — useful for asymmetric links and for readability with vias/connecting nodes (knightss27/grafana-network-weathermap#76).

## Changes
- **types**: optional `Link.arrowMeetPercent` (0–100, default 50).
- **WeathermapPanel**: the arrow junction is now computed at the configured percentage along the A→Z line via a new `shiftAlong()` helper (which places the line ends and arrow centers relative to that point). Replaces the hardcoded `getMiddlePoint` midpoint.
- **LinkForm**: an "Arrow Meeting Point (%)" slider (5–95) in Link Options.

## Regression safety (important)
When `arrowMeetPercent` is unset, `meetPercent = 0.5`, so the meeting point is **exactly the midpoint** and `shiftAlong(midpoint, Z, A, offset)` is **mathematically identical** to the previous `getMiddlePoint(Z, A, offset)`. Existing links render byte-for-byte the same.
- The full existing test suite (including default link geometry and connected-link tests) passes unchanged — **25/25**.
- `getMiddlePoint` removed with no remaining callers; connection-node handling preserved.
- `shiftAlong` adds a divide-by-zero guard the old helper lacked (robustness improvement).

## Verification (run locally)
- `npm run typecheck` → pass
- `npm run test:ci` → **25/25 pass** (1 new: custom meeting point renders with finite/non-NaN geometry)
- `npm run lint` → pass
- `npm run build` → success
- `npm audit` → 0 high / 0 critical

## Release
Branched off `main`; independent of #144 (merged), #146 (node tooltips), #147 (direction labels). **Not for immediate merge** — hold for the next release alongside them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-link “Arrow Meeting Point (%)” to control where the two directional arrows meet along a link, addressing #62. Default is 50%, so existing maps render exactly the same.

- **New Features**
  - Optional `Link.arrowMeetPercent` to set the junction along A→Z (UI slider 5–95; defaults to 50).
  - Replaced fixed midpoint math with a computed meeting point and `shiftAlong()` helper (with zero-length guard) for arrow centers and line ends.
  - Test added to verify custom meeting points produce valid geometry.

<sup>Written for commit d019a280d75cacc4f48507ee14b932ba0a7d9b66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

