### PR TITLE
feat(#64): option to make the background image move/zoom with the map

### DIFF
--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -87,6 +87,43 @@ test('Creating a weathermap', () => {
   // TODO: find a working way to check node dragging
 });
 
+test('Draws the background image inside the canvas when Move With Map is enabled', () => {
+  let testProps = { ...mPanelProps };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  weathermap.settings.panel.backgroundImage = {
+    url: 'https://example.com/bg.png',
+    fit: 'contain',
+    attachToCanvas: true,
+  };
+  testProps.options = { weathermap };
+  testProps.onOptionsChange = (options: SimpleOptions) => {
+    testProps.options = options;
+  };
+
+  const { container } = render(<WeathermapPanel {...testProps} />);
+
+  const images = Array.from(container.querySelectorAll('image'));
+  expect(images.some((im) => im.getAttribute('href') === 'https://example.com/bg.png')).toBe(true);
+});
+
+test('Keeps the background image static (no in-canvas image) when Move With Map is off', () => {
+  let testProps = { ...mPanelProps };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  weathermap.settings.panel.backgroundImage = {
+    url: 'https://example.com/bg.png',
+    fit: 'contain',
+  };
+  testProps.options = { weathermap };
+  testProps.onOptionsChange = (options: SimpleOptions) => {
+    testProps.options = options;
+  };
+
+  const { container } = render(<WeathermapPanel {...testProps} />);
+
+  const images = Array.from(container.querySelectorAll('image'));
+  expect(images.some((im) => im.getAttribute('href') === 'https://example.com/bg.png')).toBe(false);
+});
+
 // Tests plays badly with new deps
 // test('Editing a weathermap', () => {
 //   let testProps = { ...mPanelProps };

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -931,13 +931,18 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
             top: 0,
             left: 0,
             backgroundImage:
-              wm.settings.panel.backgroundImage && sanitizeUrl(wm.settings.panel.backgroundImage.url)
+              wm.settings.panel.backgroundImage &&
+              !wm.settings.panel.backgroundImage.attachToCanvas &&
+              sanitizeUrl(wm.settings.panel.backgroundImage.url)
                 ? `url(${sanitizeUrl(wm.settings.panel.backgroundImage.url)})`
                 : 'none',
             backgroundSize: wm.settings.panel.backgroundImage?.fit,
             backgroundPosition: 'center',
             backgroundRepeat: 'no-repeat',
-            backgroundColor: wm.settings.panel.backgroundImage ? 'none' : wm.settings.panel.backgroundColor,
+            backgroundColor:
+              wm.settings.panel.backgroundImage && !wm.settings.panel.backgroundImage.attachToCanvas
+                ? 'none'
+                : wm.settings.panel.backgroundColor,
           }}
           id={`nw-${wm.id}${isEditMode ? '_' : ''}`}
           width={width2}
@@ -1046,6 +1051,26 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
             })`}
             overflow="visible"
           >
+            {wm.settings.panel.backgroundImage &&
+            wm.settings.panel.backgroundImage.attachToCanvas &&
+            sanitizeUrl(wm.settings.panel.backgroundImage.url) ? (
+              <image
+                href={sanitizeUrl(wm.settings.panel.backgroundImage.url)}
+                x={0}
+                y={0}
+                width={wm.settings.panel.panelSize.width}
+                height={wm.settings.panel.panelSize.height}
+                preserveAspectRatio={
+                  wm.settings.panel.backgroundImage.fit === 'cover'
+                    ? 'xMidYMid slice'
+                    : wm.settings.panel.backgroundImage.fit === 'auto'
+                    ? 'none'
+                    : 'xMidYMid meet'
+                }
+              />
+            ) : (
+              ''
+            )}
             {wm.settings.panel.grid.guidesEnabled ? (
               <>
                 <rect

--- a/src/forms/PanelForm.tsx
+++ b/src/forms/PanelForm.tsx
@@ -118,6 +118,24 @@ export const PanelForm = ({ value, onChange }: Props) => {
                 placeholder={'Select image fit'}
               ></Select>
             </InlineField>
+            <InlineField
+              grow
+              label="Move With Map"
+              className={styles.inlineField}
+              style={{ marginLeft: '24px' }}
+              tooltip={'Attach the background image to the map canvas so it pans and zooms with the nodes and links instead of staying fixed.'}
+            >
+              <InlineSwitch
+                value={value.settings.panel.backgroundImage.attachToCanvas ?? false}
+                onChange={(e) => {
+                  let options = value;
+                  if (options.settings.panel.backgroundImage) {
+                    options.settings.panel.backgroundImage.attachToCanvas = e.currentTarget.checked;
+                  }
+                  onChange(options);
+                }}
+              />
+            </InlineField>
           </>
         ) : (
           ''

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,9 @@ export interface PanelOptions {
 export interface BGImageOptions {
   url: string;
   fit: string;
+  // When true, the background image is drawn inside the map canvas so it pans
+  // and zooms together with the nodes/links instead of staying static.
+  attachToCanvas?: boolean;
 }
 
 export interface TooltipOptions {


### PR DESCRIPTION
Closes #64. (Originally requested upstream in knightss27/grafana-network-weathermap#69.)

Adds a **Move With Map** toggle for the panel background image. When enabled, the image is drawn inside the map canvas (as an SVG `<image>` within the pan/zoom group) so it pans and zooms with the nodes and links — ideal for backgrounds depicting buildings, network zones, or floor plans that must stay aligned with the topology.

## Changes
- **types**: optional `BGImageOptions.attachToCanvas`.
- **WeathermapPanel**: when `attachToCanvas` is set, render the (sanitized) image inside the transformed canvas group and disable the static CSS background; image `fit` maps to `preserveAspectRatio` (contain→meet, cover→slice, auto→none).
- **PanelForm**: "Move With Map" switch, shown when a background image is set.

## Security
The image URL is passed through `sanitizeUrl`, so `javascript:`/`data:`/`file:`/etc. are rejected before rendering — consistent with the existing URL-validation work.

## Regression safety
When the toggle is **off** (default), the static CSS background renders exactly as before. Verified by a dedicated test asserting no in-canvas `<image>` is produced when off, plus the full existing suite passing.

## Verification (run locally)
- `npm run typecheck` → pass
- `npm run test:ci` → **26/26 pass** (2 new: in-canvas image when attached; static when off)
- `npm run lint` → pass
- `npm run build` → success
- `npm audit` → 0 high / 0 critical

## Release
Branched off `main`; independent of #144 (merged), #146, #147, #148. Intended for the upcoming release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Move With Map” option for panel background images so they pan and zoom with the map instead of staying fixed. Implements #64; default behavior remains unchanged.

- **New Features**
  - New toggle in the panel form (visible when a background image is set).
  - When enabled, the sanitized image is drawn inside the SVG pan/zoom group; fit maps to SVG preserveAspectRatio (contain→meet, cover→slice, auto→none).
  - When disabled (default), the image stays as a static CSS background.

<sup>Written for commit 0efef998b80b8e898f4a3d0147072e8aa2522da5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

