### PR TITLE
release: v1.5.4 (node tooltips, direction labels, arrow meeting point, background follows map)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.5.4](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.4) (2026-07-02)
+
+### Features
+
+* **node-tooltips**: nodes now support hover tooltips showing additional metric values (latency, packet loss, CPU, or any bound query) — configure per-node metrics (label, query, units) in the node editor's Tooltip section ([#72](https://github.com/allamiro/grafana-network-weathermap-ng/issues/72), PR [#146](https://github.com/allamiro/grafana-network-weathermap-ng/pull/146))
+* **link-direction-labels**: optional per-side "Direction Label" lets you explicitly name which side of a link is inbound vs outbound; the label is used in the hover tooltip, removing the implicit A/Z ambiguity ([#70](https://github.com/allamiro/grafana-network-weathermap-ng/issues/70), PR [#147](https://github.com/allamiro/grafana-network-weathermap-ng/pull/147))
+* **arrow-meeting-point**: new per-link "Arrow Meeting Point (%)" slider shifts where the two directional arrows meet along a link, instead of the fixed 50% midpoint — useful for asymmetric links and vias ([#62](https://github.com/allamiro/grafana-network-weathermap-ng/issues/62), PR [#148](https://github.com/allamiro/grafana-network-weathermap-ng/pull/148))
+* **background-follow-map**: new "Move With Map" toggle attaches the panel background image to the map canvas so it pans and zooms with the nodes and links, for backgrounds depicting buildings, zones, or floor plans ([#64](https://github.com/allamiro/grafana-network-weathermap-ng/issues/64), PR [#149](https://github.com/allamiro/grafana-network-weathermap-ng/pull/149))
+
 ## [1.5.3](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.3) (2026-07-02)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamirsuliman-weathermap-panel",
-      "version": "1.5.3",
+      "version": "1.5.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -200,6 +200,50 @@ test('Shows no notice for a topology-only map with no queries', () => {
   expect(screen.queryByTestId('weathermap-data-notice')).toBeNull();
 });
 
+test('Shows a node tooltip with configured metrics on hover', () => {
+  let testProps = { ...mPanelProps };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  weathermap.nodes[0].tooltipMetrics = [{ label: 'Latency', query: 'latency-series', units: 's' }];
+  testProps.options.weathermap = weathermap;
+  testProps.onOptionsChange = (options: SimpleOptions) => {
+    testProps.options = options;
+  };
+
+  render(<WeathermapPanel {...testProps} />);
+
+  // No tooltip until we hover.
+  expect(screen.queryByTestId('weathermap-node-tooltip')).toBeNull();
+
+  // Hover the node that has metrics configured.
+  const nodeGroup = screen.getByText(weathermap.nodes[0].label!).closest('g')!;
+  fireEvent.mouseMove(nodeGroup);
+
+  const tooltip = screen.getByTestId('weathermap-node-tooltip');
+  expect(tooltip.textContent).toContain('Latency');
+  // With no matching series the value resolves to n/a rather than crashing.
+  expect(tooltip.textContent).toContain('n/a');
+
+  // Leaving the node hides the tooltip again.
+  fireEvent.mouseLeave(nodeGroup);
+  expect(screen.queryByTestId('weathermap-node-tooltip')).toBeNull();
+});
+
+test('Shows no node tooltip when the node has no configured metrics', () => {
+  let testProps = { ...mPanelProps };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  testProps.options.weathermap = weathermap;
+  testProps.onOptionsChange = (options: SimpleOptions) => {
+    testProps.options = options;
+  };
+
+  render(<WeathermapPanel {...testProps} />);
+
+  const nodeGroup = screen.getByText(weathermap.nodes[0].label!).closest('g')!;
+  fireEvent.mouseMove(nodeGroup);
+
+  expect(screen.queryByTestId('weathermap-node-tooltip')).toBeNull();
+});
+
 test('Check edit mode display', () => {
   let testProps = { ...mPanelProps };
   testProps.options.weathermap = handleVersionedStateUpdates(getConnectedLinkData(theme), theme);

--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -87,6 +87,28 @@ test('Creating a weathermap', () => {
   // TODO: find a working way to check node dragging
 });
 
+test('Uses explicit per-side direction labels in the link tooltip when set', () => {
+  let testProps = { ...mPanelProps };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  weathermap.links[0].sides.A.directionLabel = 'TX-UPLINK';
+  weathermap.links[0].sides.Z.directionLabel = 'RX-DOWNLINK';
+  testProps.options.weathermap = weathermap;
+  testProps.onOptionsChange = (options: SimpleOptions) => {
+    testProps.options = options;
+  };
+
+  render(<WeathermapPanel {...testProps} />);
+
+  // Hover the link to open its tooltip.
+  fireEvent.mouseMove(screen.getByTestId('link').firstChild!);
+
+  // Both explicit labels replace the generic Inbound/Outbound wording.
+  expect(screen.getAllByText(/TX-UPLINK/).length).toBeGreaterThan(0);
+  expect(screen.getAllByText(/RX-DOWNLINK/).length).toBeGreaterThan(0);
+
+  fireEvent.mouseLeave(screen.getByTestId('link').firstChild!);
+});
+
 // Tests plays badly with new deps
 // test('Editing a weathermap', () => {
 //   let testProps = { ...mPanelProps };

--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -87,6 +87,43 @@ test('Creating a weathermap', () => {
   // TODO: find a working way to check node dragging
 });
 
+test('Draws the background image inside the canvas when Move With Map is enabled', () => {
+  let testProps = { ...mPanelProps };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  weathermap.settings.panel.backgroundImage = {
+    url: 'https://example.com/bg.png',
+    fit: 'contain',
+    attachToCanvas: true,
+  };
+  testProps.options = { weathermap };
+  testProps.onOptionsChange = (options: SimpleOptions) => {
+    testProps.options = options;
+  };
+
+  const { container } = render(<WeathermapPanel {...testProps} />);
+
+  const images = Array.from(container.querySelectorAll('image'));
+  expect(images.some((im) => im.getAttribute('href') === 'https://example.com/bg.png')).toBe(true);
+});
+
+test('Keeps the background image static (no in-canvas image) when Move With Map is off', () => {
+  let testProps = { ...mPanelProps };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  weathermap.settings.panel.backgroundImage = {
+    url: 'https://example.com/bg.png',
+    fit: 'contain',
+  };
+  testProps.options = { weathermap };
+  testProps.onOptionsChange = (options: SimpleOptions) => {
+    testProps.options = options;
+  };
+
+  const { container } = render(<WeathermapPanel {...testProps} />);
+
+  const images = Array.from(container.querySelectorAll('image'));
+  expect(images.some((im) => im.getAttribute('href') === 'https://example.com/bg.png')).toBe(false);
+});
+
 // Tests plays badly with new deps
 // test('Editing a weathermap', () => {
 //   let testProps = { ...mPanelProps };

--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -87,6 +87,25 @@ test('Creating a weathermap', () => {
   // TODO: find a working way to check node dragging
 });
 
+test('Renders a link with a custom arrow meeting point without breaking geometry', () => {
+  let testProps = { ...mPanelProps };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  weathermap.links[0].arrowMeetPercent = 90;
+  // Fresh options object so we don't mutate the shared mock props.
+  testProps.options = { weathermap };
+  testProps.onOptionsChange = (options: SimpleOptions) => {
+    testProps.options = options;
+  };
+
+  render(<WeathermapPanel {...testProps} />);
+
+  const link = screen.getByTestId('link');
+  expect(link).not.toBeNull();
+  // A shifted meeting point must still produce finite coordinates
+  // (no divide-by-zero / NaN in the arrow geometry).
+  expect(link.innerHTML).not.toContain('NaN');
+});
+
 // Tests plays badly with new deps
 // test('Editing a weathermap', () => {
 //   let testProps = { ...mPanelProps };

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -931,13 +931,18 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
             top: 0,
             left: 0,
             backgroundImage:
-              wm.settings.panel.backgroundImage && sanitizeUrl(wm.settings.panel.backgroundImage.url)
+              wm.settings.panel.backgroundImage &&
+              !wm.settings.panel.backgroundImage.attachToCanvas &&
+              sanitizeUrl(wm.settings.panel.backgroundImage.url)
                 ? `url(${sanitizeUrl(wm.settings.panel.backgroundImage.url)})`
                 : 'none',
             backgroundSize: wm.settings.panel.backgroundImage?.fit,
             backgroundPosition: 'center',
             backgroundRepeat: 'no-repeat',
-            backgroundColor: wm.settings.panel.backgroundImage ? 'none' : wm.settings.panel.backgroundColor,
+            backgroundColor:
+              wm.settings.panel.backgroundImage && !wm.settings.panel.backgroundImage.attachToCanvas
+                ? 'none'
+                : wm.settings.panel.backgroundColor,
           }}
           id={`nw-${wm.id}${isEditMode ? '_' : ''}`}
           width={width2}
@@ -1046,6 +1051,26 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
             })`}
             overflow="visible"
           >
+            {wm.settings.panel.backgroundImage &&
+            wm.settings.panel.backgroundImage.attachToCanvas &&
+            sanitizeUrl(wm.settings.panel.backgroundImage.url) ? (
+              <image
+                href={sanitizeUrl(wm.settings.panel.backgroundImage.url)}
+                x={0}
+                y={0}
+                width={wm.settings.panel.panelSize.width}
+                height={wm.settings.panel.panelSize.height}
+                preserveAspectRatio={
+                  wm.settings.panel.backgroundImage.fit === 'cover'
+                    ? 'xMidYMid slice'
+                    : wm.settings.panel.backgroundImage.fit === 'auto'
+                    ? 'none'
+                    : 'xMidYMid meet'
+                }
+              />
+            ) : (
+              ''
+            )}
             {wm.settings.panel.grid.guidesEnabled ? (
               <>
                 <rect

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -12,6 +12,8 @@ import {
   Position,
   Weathermap,
   HoveredLink,
+  HoveredNode,
+  NodeTooltipMetric,
   Threshold,
 } from 'types';
 import { css, cx } from '@emotion/css';
@@ -630,6 +632,31 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
     setHoveredLink(null as unknown as HoveredLink);
   };
 
+  const [hoveredNode, setHoveredNode] = useState(null as unknown as HoveredNode);
+
+  const handleNodeHover = (d: DrawnNode, e: React.MouseEvent<SVGElement>) => {
+    // Only show a tooltip when the node actually has metrics configured, and
+    // never while a node is being dragged in edit mode.
+    if (e.shiftKey || draggedNode || !d.tooltipMetrics || d.tooltipMetrics.length === 0) {
+      return;
+    }
+    let mouseX = e.clientX;
+    let mouseY = e.clientY;
+    if (wrapperRef.current) {
+      const rect = wrapperRef.current.getBoundingClientRect();
+      mouseX = e.clientX - rect.left;
+      mouseY = e.clientY - rect.top;
+    }
+    setHoveredNode({ node: d, mouseX, mouseY });
+  };
+
+  const handleNodeHoverLoss = (e: React.MouseEvent<SVGElement>) => {
+    if (e.shiftKey) {
+      return;
+    }
+    setHoveredNode(null as unknown as HoveredNode);
+  };
+
   // Navigate to a user-provided dashboard link only if it passes URL validation.
   // Values may have been produced by template-variable substitution at runtime,
   // so they are re-sanitized here before ever reaching window.open.
@@ -920,6 +947,59 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
             ) : (
               ''
             )}
+          </div>
+        ) : (
+          ''
+        )}
+        {hoveredNode && hoveredNode.node.tooltipMetrics && hoveredNode.node.tooltipMetrics.length > 0 ? (
+          <div
+            data-testid="weathermap-node-tooltip"
+            className={css`
+              position: absolute;
+              top: ${hoveredNode.mouseY - 10}px;
+              left: ${hoveredNode.mouseX + 14}px;
+              transform: translate(
+                ${hoveredNode.mouseX > width2 * 0.65 ? '-100%' : '0%'},
+                ${hoveredNode.mouseY < 120 ? '0%' : '-100%'}
+              );
+              pointer-events: none;
+              background-color: ${wm.settings.tooltip.backgroundColor};
+              color: ${wm.settings.tooltip.textColor} !important;
+              font-size: ${wm.settings.tooltip.fontSize} !important;
+              z-index: 10000;
+              display: flex;
+              flex-direction: column;
+              padding: ${wm.settings.tooltip.fontSize}px;
+              border-radius: 4px;
+              border: 1px solid ${theme.colors.border.medium};
+            `}
+          >
+            <div
+              style={{
+                fontSize: wm.settings.tooltip.fontSize,
+                borderBottom: `1px solid ${theme.colors.border.medium}`,
+                marginBottom: '4px',
+                display: 'flex',
+                justifyContent: 'center',
+              }}
+            >
+              {hoveredNode.node.label}
+            </div>
+            {hoveredNode.node.tooltipMetrics.map((metric: NodeTooltipMetric, idx: number) => {
+              const fmt = getlinkValueFormatter(metric.units || 'none');
+              const raw = metric.query ? dataFrameMap.get(metric.query) : undefined;
+              let valueText = 'n/a';
+              if (raw !== undefined) {
+                const formatted = fmt(raw, wm.settings.link.linkDecimals);
+                valueText = `${formatted.text} ${formatted.suffix}`.trim();
+              }
+              return (
+                <div key={idx} style={{ fontSize: wm.settings.tooltip.fontSize }}>
+                  {metric.label ? `${metric.label}: ` : ''}
+                  {valueText}
+                </div>
+              );
+            })}
           </div>
         ) : (
           ''
@@ -1503,6 +1583,8 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                       // Force an update
                       onOptionsChange(options);
                     },
+                    onMouseMove: (e) => handleNodeHover(d, e),
+                    onMouseLeave: (e) => handleNodeHoverLoss(e),
                     disabled: !isEditMode,
                     data: data,
                   }}

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -132,23 +132,23 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
     return ds.minWidth + (ds.maxWidth - ds.minWidth) * pct;
   }
 
-  // Get the middle point between two nodes
-  function getMiddlePoint(source: Position, target: Position, offset: number): Position {
-    const x = (source.x + target.x) / 2;
-    const y = (source.y + target.y) / 2;
-    const a = target.x - source.x;
-    const b = target.y - source.y;
-    const dist = Math.sqrt(a * a + b * b);
-    const newX = x - (offset * (target.x - source.x)) / dist;
-    const newY = y - (offset * (target.y - source.y)) / dist;
-    return { x: newX, y: newY };
-  }
-
   // Get a point a percentage of the way between two nodes
   function getPercentPoint(source: Position, target: Position, percent: number): Position {
     const newX = target.x + (source.x - target.x) * percent;
     const newY = target.y + (source.y - target.y) * percent;
     return { x: newX, y: newY };
+  }
+
+  // Shift a base point along the (from -> to) direction by `offset`. Lets the
+  // arrow "meeting point" sit at an arbitrary base rather than the fixed midpoint.
+  function shiftAlong(base: Position, from: Position, to: Position, offset: number): Position {
+    const a = to.x - from.x;
+    const b = to.y - from.y;
+    const dist = Math.sqrt(a * a + b * b);
+    if (dist === 0) {
+      return { x: base.x, y: base.y };
+    }
+    return { x: base.x - (offset * a) / dist, y: base.y - (offset * b) / dist };
   }
 
   // Find the points that create the two other points of a triangle for the arrow's tip
@@ -397,7 +397,17 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
       }
     }
 
-    toReturn.lineEndA = getMiddlePoint(
+    // The point where the two directional arrows meet. Defaults to the midpoint
+    // (50%) but can be shifted along the A->Z line via arrowMeetPercent (#62).
+    // Clamped to keep the junction from overlapping either node box.
+    const meetPercent = Math.min(95, Math.max(5, d.arrowMeetPercent ?? 50)) / 100;
+    const meetPoint: Position = {
+      x: toReturn.lineStartA.x + (toReturn.lineStartZ.x - toReturn.lineStartA.x) * meetPercent,
+      y: toReturn.lineStartA.y + (toReturn.lineStartZ.y - toReturn.lineStartA.y) * meetPercent,
+    };
+
+    toReturn.lineEndA = shiftAlong(
+      meetPoint,
       toReturn.lineStartZ,
       toReturn.lineStartA,
       -toReturn.arrows.offset - toReturn.arrows.height
@@ -408,7 +418,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
       toReturn.lineEndZ = toReturn.lineStartZ;
     }
 
-    toReturn.arrowCenterA = getMiddlePoint(toReturn.lineStartZ, toReturn.lineStartA, -toReturn.arrows.offset);
+    toReturn.arrowCenterA = shiftAlong(meetPoint, toReturn.lineStartZ, toReturn.lineStartA, -toReturn.arrows.offset);
     toReturn.arrowPolygonA = getArrowPolygon(
       toReturn.lineStartA,
       toReturn.arrowCenterA,
@@ -416,12 +426,13 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
       toReturn.arrows.width
     );
 
-    toReturn.lineEndZ = getMiddlePoint(
+    toReturn.lineEndZ = shiftAlong(
+      meetPoint,
       toReturn.lineStartZ,
       toReturn.lineStartA,
       toReturn.arrows.offset + toReturn.arrows.height
     );
-    toReturn.arrowCenterZ = getMiddlePoint(toReturn.lineStartZ, toReturn.lineStartA, toReturn.arrows.offset);
+    toReturn.arrowCenterZ = shiftAlong(meetPoint, toReturn.lineStartZ, toReturn.lineStartA, toReturn.arrows.offset);
     toReturn.arrowPolygonZ = getArrowPolygon(
       toReturn.lineStartZ,
       toReturn.arrowCenterZ,

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -630,6 +630,13 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
     setHoveredLink(null as unknown as HoveredLink);
   };
 
+  // Resolve the tooltip label for a given link side, preferring an explicit
+  // per-side direction label (#70) and falling back to the generic wording.
+  const sideDirectionLabel = (link: DrawnLink, side: 'A' | 'Z', fallback: string): string => {
+    const label = link.sides[side].directionLabel;
+    return label && label.trim() !== '' ? label : fallback;
+  };
+
   // Navigate to a user-provided dashboard link only if it passes URL validation.
   // Values may have been produced by template-variable substitution at runtime,
   // so they are re-sanitized here before ever reaching window.open.
@@ -767,15 +774,21 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
               {hoveredLink.link.target.label}
             </div>
             <div style={{ fontSize: wm.settings.tooltip.fontSize }}>
-              Usage - Inbound: {hoveredLink.link.sides[hoveredLink.side === 'A' ? 'Z' : 'A'].currentValueText}, Outbound:{' '}
+              Usage - {sideDirectionLabel(hoveredLink.link, hoveredLink.side === 'A' ? 'Z' : 'A', 'Inbound')}:{' '}
+              {hoveredLink.link.sides[hoveredLink.side === 'A' ? 'Z' : 'A'].currentValueText},{' '}
+              {sideDirectionLabel(hoveredLink.link, hoveredLink.side, 'Outbound')}:{' '}
               {hoveredLink.link.sides[hoveredLink.side === 'A' ? 'A' : 'Z'].currentValueText}
             </div>
             <div style={{ fontSize: wm.settings.tooltip.fontSize }}>
-              Bandwidth - Inbound: {hoveredLink.link.sides[hoveredLink.side === 'A' ? 'Z' : 'A'].currentBandwidthText}, Outbound:{' '}
+              Bandwidth - {sideDirectionLabel(hoveredLink.link, hoveredLink.side === 'A' ? 'Z' : 'A', 'Inbound')}:{' '}
+              {hoveredLink.link.sides[hoveredLink.side === 'A' ? 'Z' : 'A'].currentBandwidthText},{' '}
+              {sideDirectionLabel(hoveredLink.link, hoveredLink.side, 'Outbound')}:{' '}
               {hoveredLink.link.sides[hoveredLink.side === 'A' ? 'A' : 'Z'].currentBandwidthText}
             </div>
             <div style={{ fontSize: wm.settings.tooltip.fontSize }}>
-              Throughput (%) - Inbound: {hoveredLink.link.sides[hoveredLink.side === 'A' ? 'Z' : 'A'].currentPercentageText}, Outbound:{' '}
+              Throughput (%) - {sideDirectionLabel(hoveredLink.link, hoveredLink.side === 'A' ? 'Z' : 'A', 'Inbound')}:{' '}
+              {hoveredLink.link.sides[hoveredLink.side === 'A' ? 'Z' : 'A'].currentPercentageText},{' '}
+              {sideDirectionLabel(hoveredLink.link, hoveredLink.side, 'Outbound')}:{' '}
               {hoveredLink.link.sides[hoveredLink.side === 'A' ? 'A' : 'Z'].currentPercentageText}
             </div>
             {hoveredLink.link.tooltipMetrics && hoveredLink.link.tooltipMetrics.length > 0 && (
@@ -898,7 +911,9 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                       marginRight: '4px',
                     }}
                   ></div>
-                  <div style={{ fontSize: wm.settings.tooltip.fontSize }}>Inbound</div>
+                  <div style={{ fontSize: wm.settings.tooltip.fontSize }}>
+                    {sideDirectionLabel(hoveredLink.link, 'Z', 'Inbound')}
+                  </div>
                   <div
                     style={{
                       width: '10px',
@@ -913,7 +928,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                       fontSize: wm.settings.tooltip.fontSize,
                     }}
                   >
-                    Outbound
+                    {sideDirectionLabel(hoveredLink.link, 'A', 'Outbound')}
                   </div>
                 </div>
               </React.Fragment>

--- a/src/components/MapNode.tsx
+++ b/src/components/MapNode.tsx
@@ -22,6 +22,8 @@ interface NodeProps {
   onDrag: DraggableEventHandler;
   onStop: DraggableEventHandler;
   onClick: React.MouseEventHandler<SVGGElement>;
+  onMouseMove?: React.MouseEventHandler<SVGGElement>;
+  onMouseLeave?: React.MouseEventHandler<SVGGElement>;
   disabled: boolean;
   data: PanelData;
 }
@@ -46,7 +48,8 @@ function calculateRectY(d: DrawnNode, wm: Weathermap) {
 }
 
 const MapNode: React.FC<NodeProps> = (props: NodeProps) => {
-  const { node, draggedNode, selectedNodes, wm, onDrag, onStop, onClick, disabled, data } = props;
+  const { node, draggedNode, selectedNodes, wm, onDrag, onStop, onClick, onMouseMove, onMouseLeave, disabled, data } =
+    props;
   const styles = useStyles2(getStyles);
 
   // React 19 removed ReactDOM.findDOMNode, which react-draggable falls back to
@@ -104,6 +107,8 @@ const MapNode: React.FC<NodeProps> = (props: NodeProps) => {
         cursor={disabled ? (node.dashboardLink ? 'pointer' : '') : 'move'}
         display={node.label !== undefined ? 'inline' : 'none'}
         onClick={onClick}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
         transform={`translate(${
           wm.settings.panel.grid.enabled &&
           draggedNode &&

--- a/src/forms/LinkForm.tsx
+++ b/src/forms/LinkForm.tsx
@@ -407,6 +407,24 @@ export const LinkForm = (props: Props) => {
                   name={'linkOffset'}
                 />
               </InlineField>
+              <InlineField
+                grow
+                label={'Arrow Meeting Point (%)'}
+                className={styles.inlineField}
+                tooltip={'Where along the A→Z line the two directional arrows meet. 50% is the midpoint (default); lower values move the junction toward the A side, higher toward the Z side.'}
+              >
+                <Slider
+                  min={5}
+                  max={95}
+                  step={1}
+                  value={link.arrowMeetPercent ?? 50}
+                  onChange={(num) => {
+                    let options = value;
+                    options.links[i].arrowMeetPercent = num;
+                    onChange(options);
+                  }}
+                />
+              </InlineField>
               <ControlledCollapse label="Stroke and Arrow">
                 <InlineField grow label="Link Stroke Width" className={styles.inlineField}>
                   <Slider

--- a/src/forms/LinkForm.tsx
+++ b/src/forms/LinkForm.tsx
@@ -359,6 +359,21 @@ export const LinkForm = (props: Props) => {
                             name={`${sName}portLabel`}
                           />
                         </InlineField>
+                        <InlineField grow label={`${sName} Direction Label`} style={{ width: '100%' }}>
+                          <Input
+                            value={side.directionLabel ?? ''}
+                            onChange={(e) => {
+                              let weathermap: Weathermap = value;
+                              weathermap.links[i].sides[sName].directionLabel =
+                                e.currentTarget.value || undefined;
+                              onChange(weathermap);
+                            }}
+                            placeholder={sName === 'A' ? 'e.g. Outbound' : 'e.g. Inbound'}
+                            type={'text'}
+                            className={styles.nodeLabel}
+                            name={`${sName}directionLabel`}
+                          />
+                        </InlineField>
                       </React.Fragment>
                     )}
                   </React.Fragment>

--- a/src/forms/NodeForm.tsx
+++ b/src/forms/NodeForm.tsx
@@ -14,10 +14,11 @@ import {
   ColorPicker,
   Slider,
   useTheme2,
+  UnitPicker,
 } from '@grafana/ui';
 import { SelectableValue, StandardEditorProps } from '@grafana/data';
 import { v4 as uuidv4 } from 'uuid';
-import { Weathermap, Node, NodeStatusValueMapping } from 'types';
+import { Weathermap, Node, NodeStatusValueMapping, NodeTooltipMetric } from 'types';
 import { CiscoIcons, NetworkingIcons, DatabaseIcons, ComputerIcons } from './iconOptions';
 import { getDataFrameName, sanitizeUrl } from 'utils';
 
@@ -604,6 +605,86 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                     style={{ marginTop: '4px' }}
                   >
                     Add Mapping
+                  </Button>
+                </ControlledCollapse>
+              </InlineFieldRow>
+              <InlineFieldRow className={styles.inlineRow}>
+                <ControlledCollapse label="Tooltip">
+                  <p style={{ margin: '0 0 6px', fontSize: '11px', opacity: 0.7 }}>
+                    Show additional metric values (latency, packet loss, CPU, etc.) when hovering over this node.
+                  </p>
+                  {(node.tooltipMetrics ?? []).map((metric: NodeTooltipMetric, mi: number) => (
+                    <React.Fragment key={mi}>
+                      <InlineFieldRow>
+                        <InlineField grow label={`Metric ${mi + 1} Label`} style={{ width: '100%' }}>
+                          <Input
+                            value={metric.label}
+                            onChange={(e) => {
+                              let weathermap: Weathermap = value;
+                              weathermap.nodes[i].tooltipMetrics![mi].label = e.currentTarget.value;
+                              onChange(weathermap);
+                            }}
+                            placeholder={'e.g. Latency, Packet Loss, CPU'}
+                            type={'text'}
+                          />
+                        </InlineField>
+                      </InlineFieldRow>
+                      <InlineField grow label={`Metric ${mi + 1} Query`} style={{ width: '100%' }}>
+                        <Select
+                          onChange={(v) => {
+                            let weathermap: Weathermap = value;
+                            weathermap.nodes[i].tooltipMetrics![mi].query = v ? v.value : undefined;
+                            onChange(weathermap);
+                          }}
+                          value={dataWithIds.find((p) => p === metric.query) ?? null}
+                          options={dataWithIds.map((d) => ({ value: d, label: d }))}
+                          placeholder={'Select query'}
+                          isClearable
+                          menuShouldPortal
+                        />
+                      </InlineField>
+                      <InlineField grow label={`Metric ${mi + 1} Units`} style={{ width: '100%' }}>
+                        <UnitPicker
+                          onChange={(val) => {
+                            let weathermap: Weathermap = value;
+                            weathermap.nodes[i].tooltipMetrics![mi].units = val;
+                            onChange(weathermap);
+                          }}
+                          value={metric.units}
+                        />
+                      </InlineField>
+                      <InlineFieldRow>
+                        <Button
+                          variant="secondary"
+                          icon="trash-alt"
+                          size="sm"
+                          onClick={() => {
+                            let weathermap: Weathermap = value;
+                            weathermap.nodes[i].tooltipMetrics!.splice(mi, 1);
+                            onChange(weathermap);
+                          }}
+                          style={{ marginBottom: '8px' }}
+                        >
+                          Remove Metric {mi + 1}
+                        </Button>
+                      </InlineFieldRow>
+                    </React.Fragment>
+                  ))}
+                  <Button
+                    variant="secondary"
+                    icon="plus"
+                    size="sm"
+                    onClick={() => {
+                      let weathermap: Weathermap = value;
+                      weathermap.nodes[i].tooltipMetrics = [
+                        ...(weathermap.nodes[i].tooltipMetrics || []),
+                        { label: '', query: undefined },
+                      ];
+                      onChange(weathermap);
+                    }}
+                    style={{ marginBottom: '8px' }}
+                  >
+                    Add Metric
                   </Button>
                 </ControlledCollapse>
               </InlineFieldRow>

--- a/src/forms/PanelForm.tsx
+++ b/src/forms/PanelForm.tsx
@@ -118,6 +118,24 @@ export const PanelForm = ({ value, onChange }: Props) => {
                 placeholder={'Select image fit'}
               ></Select>
             </InlineField>
+            <InlineField
+              grow
+              label="Move With Map"
+              className={styles.inlineField}
+              style={{ marginLeft: '24px' }}
+              tooltip={'Attach the background image to the map canvas so it pans and zooms with the nodes and links instead of staying fixed.'}
+            >
+              <InlineSwitch
+                value={value.settings.panel.backgroundImage.attachToCanvas ?? false}
+                onChange={(e) => {
+                  let options = value;
+                  if (options.settings.panel.backgroundImage) {
+                    options.settings.panel.backgroundImage.attachToCanvas = e.currentTarget.checked;
+                  }
+                  onChange(options);
+                }}
+              />
+            </InlineField>
           </>
         ) : (
           ''

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,6 +104,10 @@ export interface LinkSide {
   anchor: Anchor;
   dashboardLink: string;
   portLabel?: string;
+  // Optional explicit direction label for this side (e.g. "Inbound", "Outbound",
+  // "To WAN"). When set, the hover tooltip labels this side's value with it
+  // instead of the generic Inbound/Outbound wording.
+  directionLabel?: string;
 }
 
 export interface LinkTooltipMetric {

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,6 +125,9 @@ export interface Link {
   stroke: number;
   showThroughputPercentage: boolean;
   linkOffset?: number;
+  // Percentage (0-100) along the A->Z line where the two directional arrows
+  // meet. Defaults to 50 (the midpoint) when unset.
+  arrowMeetPercent?: number;
   tooltipMetrics?: LinkTooltipMetric[];
   statusQuery?: string;
   statusDownColor?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,9 @@ export interface PanelOptions {
 export interface BGImageOptions {
   url: string;
   fit: string;
+  // When true, the background image is drawn inside the map canvas so it pans
+  // and zooms together with the nodes/links instead of staying static.
+  attachToCanvas?: boolean;
 }
 
 export interface TooltipOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,12 @@ export interface NodeStatusValueMapping {
   color: string;
 }
 
+export interface NodeTooltipMetric {
+  label: string;
+  query?: string;
+  units?: string;
+}
+
 export interface Node {
   id: string;
   position: [number, number];
@@ -69,6 +75,7 @@ export interface Node {
   showLabel?: boolean;
   dashboardLink?: string;
   openInSameTab?: boolean;
+  tooltipMetrics?: NodeTooltipMetric[];
   anchors: {
     [Anchor.Center]: NodeAnchor;
     [Anchor.Top]: NodeAnchor;
@@ -175,6 +182,12 @@ export interface DrawnLink extends Link {
 export interface HoveredLink {
   link: DrawnLink;
   side: 'A' | 'Z';
+  mouseX: number;
+  mouseY: number;
+}
+
+export interface HoveredNode {
+  node: DrawnNode;
   mouseX: number;
   mouseY: number;
 }


### PR DESCRIPTION
Bundles the four features held for this release into **v1.5.4**:

- **#146** node hover tooltips with additional metrics (closes #72)
- **#147** explicit per-side inbound/outbound direction labels (closes #70)
- **#148** configurable arrow/junction meeting point on links (closes #62)
- **#149** option to make the background image move/zoom with the map (closes #64)

Integrated on a release branch with conflicts resolved (all four touch `types.ts` / `WeathermapPanel.tsx` / the shared test file). Bumps version to 1.5.4.

## Combined verification (run locally)
- `npm run typecheck` → pass
- `npm run test:ci` → **30/30 pass**
- `npm run lint` → pass
- `npm run build` → success
- `npm audit` → 0 high / 0 critical

Merging with a merge commit so the feature-branch commits land in `main` and PRs #146–#149 auto-close as merged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.5.4 adds node hover tooltips, per-side link direction labels, an adjustable arrow meeting point, and a background image that can move with the map. Defaults preserve current behavior.

- **New Features**
  - Node tooltips: show extra metrics on hover; configure per node (label, query, units).
  - Link direction labels: set per-side labels used in tooltips and legend to remove A/Z ambiguity.
  - Arrow meeting point: set where directional arrows meet along a link (percent, default 50%).
  - Background follows map: “Move With Map” option to pan/zoom the background with the canvas.

<sup>Written for commit ca52d214cfc339166154524ad5c158ded6b1b02b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

