### PR TITLE
feat(#58): value display modes — average/min/max/95th percentile over time range

### DIFF
--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -37,6 +37,7 @@ import {
   getDataFrameName,
   getValueField,
   sanitizeUrl,
+  aggregateFieldValues,
 } from 'utils';
 import MapNode from './components/MapNode';
 import ColorScale from 'components/ColorScale';
@@ -455,37 +456,15 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
   // Build the data-frame value map once per data/mode change instead of once per link.
   // Key: display name (from getDataFrameName). Value: resolved numeric value.
   const dataFrameMap = useMemo(() => {
-    const useAvg = wm.settings.link.valueMappingMode === 'avg';
+    const mode = wm.settings.link.valueMappingMode;
     const map = new Map<string, number>();
     data.series.forEach((frame) => {
       if (frame.fields.length < 2) {
         return;
       }
       try {
-        const fieldValues = getValueField(frame).values;
-        let resolvedValue: number;
-        if (useAvg && fieldValues.length > 0) {
-          let sum = 0;
-          let count = 0;
-          for (let vi = 0; vi < fieldValues.length; vi++) {
-            const v = fieldValues[vi];
-            if (v !== null && !isNaN(v)) {
-              sum += Math.max(0, v);
-              count++;
-            }
-          }
-          resolvedValue = count > 0 ? sum / count : 0;
-        } else {
-          let lastValid = 0;
-          for (let vi = fieldValues.length - 1; vi >= 0; vi--) {
-            const v = fieldValues[vi];
-            if (v !== null && !isNaN(v)) {
-              lastValid = Math.max(0, v);
-              break;
-            }
-          }
-          resolvedValue = lastValid;
-        }
+        const fieldValues = getValueField(frame).values as Array<number | null | undefined>;
+        const resolvedValue = aggregateFieldValues(fieldValues, mode);
         map.set(getDataFrameName(frame, data.series), resolvedValue);
       } catch (e) {
         console.warn('Network Weathermap: Error while attempting to access query data.', e);

--- a/src/forms/PanelForm.tsx
+++ b/src/forms/PanelForm.tsx
@@ -13,7 +13,7 @@ import {
   UnitPicker,
 } from '@grafana/ui';
 import { GrafanaTheme2, StandardEditorProps } from '@grafana/data';
-import { Weathermap } from 'types';
+import { Weathermap, ValueMappingMode } from 'types';
 import { FormDivider } from './FormDivider';
 import { css } from '@emotion/css';
 import { sanitizeUrl } from 'utils';
@@ -223,16 +223,23 @@ export const PanelForm = ({ value, onChange }: Props) => {
             }}
           />
         </InlineField>
-        <InlineField grow label={'Value Display Mode'} tooltip={'Last: show the most recent value. Average: show the mean over the selected time range.'}>
+        <InlineField
+          grow
+          label={'Value Display Mode'}
+          tooltip={'How each metric value is resolved across the selected dashboard time range: the most recent point, or an aggregate (average, minimum, maximum, or 95th percentile) over the whole range.'}
+        >
           <Select
             options={[
               { label: 'Last', value: 'last', description: 'Use the most recent data point' },
-              { label: 'Average', value: 'avg', description: 'Average all data points in the time range' },
+              { label: 'Average', value: 'avg', description: 'Mean of all data points in the time range' },
+              { label: 'Min', value: 'min', description: 'Smallest value in the time range' },
+              { label: 'Max', value: 'max', description: 'Largest value in the time range' },
+              { label: '95th Percentile', value: 'p95', description: '95th percentile over the time range' },
             ]}
             value={value.settings.link.valueMappingMode ?? 'last'}
             onChange={(selected) => {
               let wm = value;
-              wm.settings.link.valueMappingMode = selected.value as 'last' | 'avg';
+              wm.settings.link.valueMappingMode = selected.value as ValueMappingMode;
               onChange(wm);
             }}
           />

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,10 @@ export interface AreaSize {
   height: number;
 }
 
+// How a metric value is resolved from the data points within the selected
+// dashboard time range.
+export type ValueMappingMode = 'last' | 'avg' | 'min' | 'max' | 'p95';
+
 export enum Anchor {
   Center = 0,
   Top,
@@ -225,7 +229,7 @@ export interface WeathermapSettings {
     showAllWithPercentage: boolean;
     defaultUnits?: string;
     linkDecimals?: number;
-    valueMappingMode?: 'last' | 'avg';
+    valueMappingMode?: ValueMappingMode;
     dynamicStroke?: {
       enabled: boolean;
       minWidth: number;

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,6 +1,7 @@
 import { defaultNodes, getData, theme } from 'testData';
 import { DrawnNode, Weathermap } from 'types';
 import {
+  aggregateFieldValues,
   calculateRectangleAutoHeight,
   calculateRectangleAutoWidth,
   CURRENT_VERSION,
@@ -110,5 +111,43 @@ describe('sanitizeUrl', () => {
     expect(sanitizeUrl('//evil.com')).toBe('');
     expect(sanitizeUrl(undefined)).toBe('');
     expect(sanitizeUrl(null)).toBe('');
+  });
+});
+
+describe('aggregateFieldValues', () => {
+  const vals = [10, 20, 30, 40, 100];
+
+  test('last returns the most recent valid value', () => {
+    expect(aggregateFieldValues(vals, 'last')).toBe(100);
+    expect(aggregateFieldValues(vals, undefined)).toBe(100);
+  });
+
+  test('avg returns the mean', () => {
+    expect(aggregateFieldValues([10, 20, 30], 'avg')).toBe(20);
+  });
+
+  test('min and max', () => {
+    expect(aggregateFieldValues(vals, 'min')).toBe(10);
+    expect(aggregateFieldValues(vals, 'max')).toBe(100);
+  });
+
+  test('p95 uses nearest-rank', () => {
+    // 20 points 1..20 -> ceil(0.95*20)=19 -> value 19
+    const twenty = Array.from({ length: 20 }, (_, i) => i + 1);
+    expect(aggregateFieldValues(twenty, 'p95')).toBe(19);
+  });
+
+  test('skips null/NaN and clamps negatives to 0', () => {
+    expect(aggregateFieldValues([null, 10, NaN, -5, 20], 'max')).toBe(20);
+    // negative clamped to 0, so min is 0
+    expect(aggregateFieldValues([10, -5, 20], 'min')).toBe(0);
+    // last valid value is 20 (nulls skipped)
+    expect(aggregateFieldValues([10, 20, null], 'last')).toBe(20);
+  });
+
+  test('returns 0 for empty or all-invalid input', () => {
+    expect(aggregateFieldValues([], 'avg')).toBe(0);
+    expect(aggregateFieldValues([null, NaN], 'max')).toBe(0);
+    expect(aggregateFieldValues(undefined, 'last')).toBe(0);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import { DataFrame, Field, FieldType, GrafanaTheme2, getFieldDisplayName } from '@grafana/data';
 import merge from 'lodash.merge';
-import { Anchor, DrawnNode, Link, Node, Weathermap } from 'types';
+import { Anchor, DrawnNode, Link, Node, ValueMappingMode, Weathermap } from 'types';
 import { v4 as uuidv4 } from 'uuid';
 
 export const CURRENT_VERSION = 14;
@@ -450,4 +450,78 @@ export function sanitizeUrl(raw: string | undefined | null): string {
 
   const trimmed = raw.trim();
   return isSafeUrl(trimmed) ? trimmed : '';
+}
+
+/**
+ * Resolve a single display value from a field's data points according to the
+ * chosen value-mapping mode. Null/NaN entries are skipped and negative values
+ * are clamped to 0 (matching how the panel treats throughput). Returns 0 when
+ * there are no valid data points.
+ *
+ * - last: the most recent valid value (default, original behaviour)
+ * - avg:  arithmetic mean of the valid values
+ * - min:  smallest valid value
+ * - max:  largest valid value
+ * - p95:  95th percentile (nearest-rank) of the valid values
+ */
+export function aggregateFieldValues(
+  values: Array<number | null | undefined> | null | undefined,
+  mode: ValueMappingMode | undefined
+): number {
+  if (!values || values.length === 0) {
+    return 0;
+  }
+
+  const valid: number[] = [];
+  let lastValid = 0;
+  for (let i = 0; i < values.length; i++) {
+    const v = values[i];
+    if (v !== null && v !== undefined && !isNaN(v)) {
+      const clamped = Math.max(0, v);
+      valid.push(clamped);
+      lastValid = clamped;
+    }
+  }
+
+  if (valid.length === 0) {
+    return 0;
+  }
+
+  switch (mode) {
+    case 'avg': {
+      let sum = 0;
+      for (const v of valid) {
+        sum += v;
+      }
+      return sum / valid.length;
+    }
+    case 'min': {
+      let m = valid[0];
+      for (const v of valid) {
+        if (v < m) {
+          m = v;
+        }
+      }
+      return m;
+    }
+    case 'max': {
+      let m = valid[0];
+      for (const v of valid) {
+        if (v > m) {
+          m = v;
+        }
+      }
+      return m;
+    }
+    case 'p95': {
+      const sorted = [...valid].sort((a, b) => a - b);
+      // Nearest-rank method: smallest value >= 95% of the data.
+      const rank = Math.ceil(0.95 * sorted.length);
+      const idx = Math.min(sorted.length - 1, Math.max(0, rank - 1));
+      return sorted[idx];
+    }
+    case 'last':
+    default:
+      return lastValid;
+  }
 }


### PR DESCRIPTION
Closes #58. (Originally requested upstream in knightss27/grafana-network-weathermap#88.)

Extends the panel's **Value Display Mode** so metric values can be resolved as an aggregate across the selected dashboard time range, not just the most recent data point. The existing **Last** and **Average** modes are joined by **Min**, **Max**, and **95th Percentile** — useful for capacity-planning views where a single-point snapshot is misleading.

## Changes
- **types**: `valueMappingMode` widened to `'last' | 'avg' | 'min' | 'max' | 'p95'` via a new `ValueMappingMode` alias.
- **utils**: new pure `aggregateFieldValues(values, mode)` helper — skips null/NaN, clamps negatives to 0, returns 0 when there are no valid points; `p95` uses the nearest-rank method.
- **WeathermapPanel**: `dataFrameMap` now delegates to the helper (simplifies the inline logic). `last`/`avg` outputs are unchanged.
- **PanelForm**: Min / Max / 95th Percentile added to the selector.

## Regression safety
The `last` and `avg` code paths were extracted into the helper with identical semantics; the full existing suite passes unchanged. No new URL/DOM/HTML surface — pure numeric aggregation.

## Verification (run locally)
- `npm run typecheck` → pass
- `npm run test:ci` → **36/36 pass** (6 new: last/avg/min/max/p95, null-NaN/clamp, empty input)
- `npm run lint` → pass
- `npm run build` → success
- `npm audit` → 0 high / 0 critical

## Release
Branched off `main` (post-v1.5.4). Left open for the next release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds new value display modes so link values can be aggregated over the selected time range instead of only the last point. Implements #58 with Min, Max, and 95th percentile to improve capacity-planning views.

- **New Features**
  - Extended `valueMappingMode` to include 'min', 'max', and 'p95' alongside 'last' and 'avg'.
  - Centralized aggregation in `aggregateFieldValues` (skips null/NaN, clamps negatives to 0; keeps previous 'last'/'avg' behavior).
  - `WeathermapPanel` now uses the helper; `PanelForm` adds the new selector options and tooltips.

<sup>Written for commit 2a71fa9045a59add9aed42d1a8ed89ca2867c147. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

