### PR TITLE
chore(release): bump version to 1.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.5.5](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.5) (2026-07-02)
+
+### Features
+
+* **value-display-modes**: the panel's "Value Display Mode" can now resolve each metric as an aggregate across the selected dashboard time range — **Average**, **Min**, **Max**, and **95th Percentile** are available alongside the existing **Last** (most recent point). Useful for capacity-planning views where a single-point snapshot is misleading ([#58](https://github.com/allamiro/grafana-network-weathermap-ng/issues/58), PR [#151](https://github.com/allamiro/grafana-network-weathermap-ng/pull/151))
+
 ## [1.5.4](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.4) (2026-07-02)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamirsuliman-weathermap-panel",
-      "version": "1.5.4",
+      "version": "1.5.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Releases the value display modes feature (average/min/max/95th percentile over the selected time range, #58 / PR #151) as **v1.5.5**. No plugin runtime changes beyond #151; bumps version and changelog.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish v1.5.5 to ship Value Display Modes that aggregate over the selected time range (Average, Min, Max, 95th percentile) alongside Last. No code changes beyond PR #151; this only bumps versions and updates the changelog to deliver #58.

<sup>Written for commit 8cef3641d42d4ef2da0fed3cae6a95fca4d10d33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

