### PR TITLE
feat(#67): direct canvas VIA editing — double-click to add, right-click to remove

### DIFF
--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -46,6 +46,16 @@ class MouseMoveEvent extends MouseEvent {
   }
 }
 
+// Restore the editPanel location spy after every test — even if an assertion
+// throws mid-test — so `editPanel=1` never leaks into subsequent tests. Scoped
+// to this spy only so global scaffolding mocks (e.g. canvas measureText) stay
+// intact.
+let getSearchSpy: jest.SpyInstance | undefined;
+afterEach(() => {
+  getSearchSpy?.mockRestore();
+  getSearchSpy = undefined;
+});
+
 test('Creating a weathermap', () => {
   let testProps = { ...mPanelProps };
   testProps.options.weathermap = handleVersionedStateUpdates(getData(theme), theme);
@@ -166,7 +176,7 @@ test('Keeps the background image static (no in-canvas image) when Move With Map 
 });
 
 test('Double-clicking a link in edit mode inserts a VIA', () => {
-  const getSearchSpy = jest.spyOn(locationService, 'getSearch').mockReturnValue(new URLSearchParams('editPanel=1'));
+  getSearchSpy = jest.spyOn(locationService, 'getSearch').mockReturnValue(new URLSearchParams('editPanel=1'));
   let captured: SimpleOptions | null = null;
   let testProps = { ...mPanelProps };
   testProps.options = { weathermap: handleVersionedStateUpdates(getData(theme), theme) };
@@ -181,11 +191,10 @@ test('Double-clicking a link in edit mode inserts a VIA', () => {
   expect(captured!.weathermap.nodes.length).toBe(3); // A, B, and the new VIA
   expect(captured!.weathermap.nodes.some((n) => n.isConnection)).toBe(true);
   expect(captured!.weathermap.links.length).toBe(2);
-  getSearchSpy.mockRestore();
 });
 
 test('Right-clicking a VIA in edit mode removes it', () => {
-  const getSearchSpy = jest.spyOn(locationService, 'getSearch').mockReturnValue(new URLSearchParams('editPanel=1'));
+  getSearchSpy = jest.spyOn(locationService, 'getSearch').mockReturnValue(new URLSearchParams('editPanel=1'));
   let captured: SimpleOptions | null = null;
   let testProps = { ...mPanelProps };
   testProps.options = { weathermap: handleVersionedStateUpdates(getConnectedLinkData(theme), theme) };
@@ -202,7 +211,6 @@ test('Right-clicking a VIA in edit mode removes it', () => {
   expect(captured!.weathermap.nodes.some((n) => n.isConnection)).toBe(false);
   expect(captured!.weathermap.nodes.length).toBe(2);
   expect(captured!.weathermap.links.length).toBe(1);
-  getSearchSpy.mockRestore();
 });
 
 // Tests plays badly with new deps
@@ -369,7 +377,7 @@ test('Check edit mode display', () => {
     testProps.options = options;
   };
 
-  const getSearchSpy = jest.spyOn(locationService, 'getSearch').mockReturnValue(new URLSearchParams('editPanel=1'));
+  getSearchSpy = jest.spyOn(locationService, 'getSearch').mockReturnValue(new URLSearchParams('editPanel=1'));
 
   // Render the panel
   const { container, rerender } = render(<WeathermapPanel {...testProps} />);
@@ -392,5 +400,4 @@ test('Check edit mode display', () => {
   rerender(<WeathermapPanel {...testProps} />);
   fireEvent.wheel(container.querySelector('#nw-testing')!, { deltaY: -1 });
   expect(testProps.options.weathermap.settings.panel.zoomScale).toEqual(0);
-  getSearchSpy.mockRestore();
 });

--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -165,6 +165,46 @@ test('Keeps the background image static (no in-canvas image) when Move With Map 
   expect(images.some((im) => im.getAttribute('href') === 'https://example.com/bg.png')).toBe(false);
 });
 
+test('Double-clicking a link in edit mode inserts a VIA', () => {
+  const getSearchSpy = jest.spyOn(locationService, 'getSearch').mockReturnValue(new URLSearchParams('editPanel=1'));
+  let captured: SimpleOptions | null = null;
+  let testProps = { ...mPanelProps };
+  testProps.options = { weathermap: handleVersionedStateUpdates(getData(theme), theme) };
+  testProps.onOptionsChange = (o: SimpleOptions) => {
+    captured = o;
+  };
+
+  render(<WeathermapPanel {...testProps} />);
+  fireEvent.doubleClick(screen.getByTestId('link'));
+
+  expect(captured).not.toBeNull();
+  expect(captured!.weathermap.nodes.length).toBe(3); // A, B, and the new VIA
+  expect(captured!.weathermap.nodes.some((n) => n.isConnection)).toBe(true);
+  expect(captured!.weathermap.links.length).toBe(2);
+  getSearchSpy.mockRestore();
+});
+
+test('Right-clicking a VIA in edit mode removes it', () => {
+  const getSearchSpy = jest.spyOn(locationService, 'getSearch').mockReturnValue(new URLSearchParams('editPanel=1'));
+  let captured: SimpleOptions | null = null;
+  let testProps = { ...mPanelProps };
+  testProps.options = { weathermap: handleVersionedStateUpdates(getConnectedLinkData(theme), theme) };
+  testProps.onOptionsChange = (o: SimpleOptions) => {
+    captured = o;
+  };
+
+  render(<WeathermapPanel {...testProps} />);
+  // Connection nodes render their label in edit mode.
+  const viaGroup = screen.getByText('C0').closest('g')!;
+  fireEvent.contextMenu(viaGroup);
+
+  expect(captured).not.toBeNull();
+  expect(captured!.weathermap.nodes.some((n) => n.isConnection)).toBe(false);
+  expect(captured!.weathermap.nodes.length).toBe(2);
+  expect(captured!.weathermap.links.length).toBe(1);
+  getSearchSpy.mockRestore();
+});
+
 // Tests plays badly with new deps
 // test('Editing a weathermap', () => {
 //   let testProps = { ...mPanelProps };

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -1270,7 +1270,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                       }}
                       onMouseOut={handleLinkHoverLoss}
                       onClick={() => {
-                        if (d.sides.A.dashboardLink.length > 0) {
+                        if (!isEditMode && d.sides.A.dashboardLink.length > 0) {
                           openDashboardLink(d.sides.A.dashboardLink);
                         }
                       }}
@@ -1316,7 +1316,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                           }}
                           onMouseOut={handleLinkHoverLoss}
                           onClick={() => {
-                            if (d.sides.A.dashboardLink.length > 0) {
+                            if (!isEditMode && d.sides.A.dashboardLink.length > 0) {
                               openDashboardLink(d.sides.A.dashboardLink);
                             }
                           }}
@@ -1341,7 +1341,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                           }}
                           onMouseOut={handleLinkHoverLoss}
                           onClick={() => {
-                            if (d.sides.Z.dashboardLink.length > 0) {
+                            if (!isEditMode && d.sides.Z.dashboardLink.length > 0) {
                               openDashboardLink(d.sides.Z.dashboardLink);
                             }
                           }}
@@ -1372,7 +1372,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                           }}
                           onMouseOut={handleLinkHoverLoss}
                           onClick={() => {
-                            if (d.sides.Z.dashboardLink.length > 0) {
+                            if (!isEditMode && d.sides.Z.dashboardLink.length > 0) {
                               openDashboardLink(d.sides.Z.dashboardLink);
                             }
                           }}

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -38,6 +38,8 @@ import {
   getValueField,
   sanitizeUrl,
   aggregateFieldValues,
+  addViaToLink,
+  removeVia,
 } from 'utils';
 import MapNode from './components/MapNode';
 import ColorScale from 'components/ColorScale';
@@ -620,6 +622,29 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
       return;
     }
     setHoveredLink(null as unknown as HoveredLink);
+  };
+
+  // VIA editing on the canvas (#67): double-click a link to insert a waypoint
+  // (a connection node at the link midpoint, which can then be dragged), and
+  // right-click a VIA to remove it and merge the two segments back together.
+  const handleAddVia = (linkId: string, e: React.MouseEvent<SVGElement>) => {
+    if (!isEditMode) {
+      return;
+    }
+    e.preventDefault();
+    e.stopPropagation();
+    const updated = addViaToLink(wm, linkId, theme);
+    onOptionsChange({ ...options, weathermap: updated });
+  };
+
+  const handleRemoveVia = (node: DrawnNode, e: React.MouseEvent<SVGElement>) => {
+    if (!isEditMode || !node.isConnection) {
+      return;
+    }
+    e.preventDefault();
+    e.stopPropagation();
+    const updated = removeVia(wm, node.id);
+    onOptionsChange({ ...options, weathermap: updated });
   };
 
   const [hoveredNode, setHoveredNode] = useState(null as unknown as HoveredNode);
@@ -1223,6 +1248,8 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                     strokeOpacity={1}
                     width={Math.abs(d.target.x - d.source.x)}
                     height={Math.abs(d.target.y - d.source.y)}
+                    style={isEditMode ? { cursor: 'copy' } : undefined}
+                    onDoubleClick={(e) => handleAddVia(d.id, e)}
                   >
                     <line
                       strokeWidth={getLinkStroke(d.sides.A.currentValue, d.sides.A.bandwidth, d.stroke)}
@@ -1615,6 +1642,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                     },
                     onMouseMove: (e) => handleNodeHover(d, e),
                     onMouseLeave: (e) => handleNodeHoverLoss(e),
+                    onContextMenu: (e) => handleRemoveVia(d, e),
                     disabled: !isEditMode,
                     data: data,
                   }}

--- a/src/components/MapNode.tsx
+++ b/src/components/MapNode.tsx
@@ -24,6 +24,7 @@ interface NodeProps {
   onClick: React.MouseEventHandler<SVGGElement>;
   onMouseMove?: React.MouseEventHandler<SVGGElement>;
   onMouseLeave?: React.MouseEventHandler<SVGGElement>;
+  onContextMenu?: React.MouseEventHandler<SVGGElement>;
   disabled: boolean;
   data: PanelData;
 }
@@ -48,7 +49,7 @@ function calculateRectY(d: DrawnNode, wm: Weathermap) {
 }
 
 const MapNode: React.FC<NodeProps> = (props: NodeProps) => {
-  const { node, draggedNode, selectedNodes, wm, onDrag, onStop, onClick, onMouseMove, onMouseLeave, disabled, data } =
+  const { node, draggedNode, selectedNodes, wm, onDrag, onStop, onClick, onMouseMove, onMouseLeave, onContextMenu, disabled, data } =
     props;
   const styles = useStyles2(getStyles);
 
@@ -109,6 +110,7 @@ const MapNode: React.FC<NodeProps> = (props: NodeProps) => {
         onClick={onClick}
         onMouseMove={onMouseMove}
         onMouseLeave={onMouseLeave}
+        onContextMenu={onContextMenu}
         transform={`translate(${
           wm.settings.panel.grid.enabled &&
           draggedNode &&

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,6 +1,7 @@
 import { defaultNodes, getData, theme } from 'testData';
 import { DrawnNode, Weathermap } from 'types';
 import {
+  addViaToLink,
   aggregateFieldValues,
   calculateRectangleAutoHeight,
   calculateRectangleAutoWidth,
@@ -10,6 +11,7 @@ import {
   isSafeUrl,
   measureText,
   nearestMultiple,
+  removeVia,
   sanitizeUrl,
 } from 'utils';
 
@@ -149,5 +151,65 @@ describe('aggregateFieldValues', () => {
     expect(aggregateFieldValues([], 'avg')).toBe(0);
     expect(aggregateFieldValues([null, NaN], 'max')).toBe(0);
     expect(aggregateFieldValues(undefined, 'last')).toBe(0);
+  });
+});
+
+describe('VIA helpers (addViaToLink / removeVia)', () => {
+  test('addViaToLink splits a link and preserves endpoint data', () => {
+    const wm: Weathermap = getData(theme);
+    // Give each side a distinct query to verify data preservation.
+    wm.links[0].sides.A.query = 'A-query';
+    wm.links[0].sides.Z.query = 'Z-query';
+    const endNode = wm.links[0].nodes[1];
+    const linkId = wm.links[0].id;
+
+    addViaToLink(wm, linkId, theme);
+
+    // One new connection node and one new link segment.
+    expect(wm.nodes.filter((n) => n.isConnection)).toHaveLength(1);
+    expect(wm.links).toHaveLength(2);
+
+    const conn = wm.nodes.find((n) => n.isConnection)!;
+    expect(conn.anchors[0].numLinks).toBe(2);
+
+    const first = wm.links.find((l) => l.nodes[1].id === conn.id)!; // A <-> C
+    const second = wm.links.find((l) => l.nodes[0].id === conn.id)!; // C <-> B
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+
+    // A-side data stays on the first segment; B-side moves to the second.
+    expect(first.sides.A.query).toBe('A-query');
+    expect(first.sides.Z.query).toBeUndefined();
+    expect(second.sides.Z.query).toBe('Z-query');
+    expect(second.nodes[1].id).toBe(endNode.id);
+  });
+
+  test('removeVia merges the two segments back and preserves data', () => {
+    const wm: Weathermap = getData(theme);
+    const linkId = wm.links[0].id;
+    wm.links[0].sides.A.query = 'A-query';
+    wm.links[0].sides.Z.query = 'Z-query';
+    const aId = wm.links[0].nodes[0].id;
+    const bId = wm.links[0].nodes[1].id;
+
+    addViaToLink(wm, linkId, theme);
+    const conn = wm.nodes.find((n) => n.isConnection)!;
+
+    removeVia(wm, conn.id);
+
+    expect(wm.nodes.filter((n) => n.isConnection)).toHaveLength(0);
+    expect(wm.links).toHaveLength(1);
+    expect(wm.links[0].nodes[0].id).toBe(aId);
+    expect(wm.links[0].nodes[1].id).toBe(bId);
+    expect(wm.links[0].sides.A.query).toBe('A-query');
+    expect(wm.links[0].sides.Z.query).toBe('Z-query');
+  });
+
+  test('removeVia is a no-op for a non-connection node', () => {
+    const wm: Weathermap = getData(theme);
+    const before = { nodes: wm.nodes.length, links: wm.links.length };
+    removeVia(wm, wm.nodes[0].id);
+    expect(wm.nodes).toHaveLength(before.nodes);
+    expect(wm.links).toHaveLength(before.links);
   });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -212,4 +212,16 @@ describe('VIA helpers (addViaToLink / removeVia)', () => {
     expect(wm.nodes).toHaveLength(before.nodes);
     expect(wm.links).toHaveLength(before.links);
   });
+
+  test('removeVia is a no-op for a C->C self-loop (same in/out link)', () => {
+    const wm: Weathermap = getData(theme);
+    const conn = wm.nodes.find((n) => n.isConnection) ?? wm.nodes[0];
+    conn.isConnection = true;
+    // A single self-loop link would otherwise satisfy the one-in/one-out check.
+    wm.links = [{ ...wm.links[0], id: 'self', nodes: [conn, conn] }];
+    removeVia(wm, conn.id);
+    expect(wm.links).toHaveLength(1);
+    expect(wm.links[0].id).toBe('self');
+    expect(wm.nodes.some((n) => n.id === conn.id)).toBe(true);
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -534,7 +534,10 @@ export function removeVia(wm: Weathermap, connectionNodeId: string): Weathermap 
 
   const inLinks = wm.links.filter((l) => l.nodes[1].id === conn.id);
   const outLinks = wm.links.filter((l) => l.nodes[0].id === conn.id);
-  if (inLinks.length !== 1 || outLinks.length !== 1) {
+  // Require exactly one distinct incoming and one distinct outgoing link. A
+  // C->C self-loop would satisfy the length check with the same link on both
+  // sides, so reject that too and stay a no-op on malformed data.
+  if (inLinks.length !== 1 || outLinks.length !== 1 || inLinks[0].id === outLinks[0].id) {
     return wm;
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -453,6 +453,104 @@ export function sanitizeUrl(raw: string | undefined | null): string {
 }
 
 /**
+ * Insert a VIA (intermediate waypoint) into a link by the connection-node
+ * mechanism: the link A<->B is split into A<->C and C<->B, where C is a new
+ * connection node placed at the link's midpoint. The A-side query/data stays on
+ * the first segment and the B-side query/data moves to the second, so metrics
+ * are preserved. Returns the (mutated) weathermap; a no-op if the link is
+ * missing. The caller can then drag C to reposition the VIA.
+ */
+export function addViaToLink(wm: Weathermap, linkId: string, theme: GrafanaTheme2): Weathermap {
+  const link = wm.links.find((l) => l.id === linkId);
+  if (!link) {
+    return wm;
+  }
+
+  const aPos = link.nodes[0].position;
+  const bPos = link.nodes[1].position;
+  const midpoint: [number, number] = [Math.round((aPos[0] + bPos[0]) / 2), Math.round((aPos[1] + bPos[1]) / 2)];
+
+  const connCount = wm.nodes.filter((n) => n.isConnection).length;
+  const conn: Node = {
+    ...generateBasicNode('C' + connCount, midpoint, theme),
+    isConnection: true,
+    anchors: {
+      0: { numLinks: 2, numFilledLinks: 0 },
+      1: { numLinks: 0, numFilledLinks: 0 },
+      2: { numLinks: 0, numFilledLinks: 0 },
+      3: { numLinks: 0, numFilledLinks: 0 },
+      4: { numLinks: 0, numFilledLinks: 0 },
+    },
+  };
+
+  const endNode = link.nodes[1];
+  const zSide = link.sides.Z; // carries the B-side query/bandwidth/labels
+
+  const connectionSide = (labelOffset: number): typeof link.sides.A => ({
+    bandwidth: 0,
+    bandwidthQuery: undefined,
+    query: undefined,
+    labelOffset,
+    anchor: Anchor.Center,
+    dashboardLink: '',
+  });
+
+  // New link C <-> B keeps all link-level properties (units, arrows, stroke,
+  // status, tooltip metrics, etc.) and the original B-side data.
+  const newLink: Link = {
+    ...link,
+    id: uuidv4(),
+    nodes: [conn, endNode],
+    sides: {
+      A: connectionSide(zSide.labelOffset),
+      Z: zSide,
+    },
+  };
+
+  // Original link becomes A <-> C; its A-side data is untouched.
+  link.nodes = [link.nodes[0], conn];
+  link.sides = {
+    A: link.sides.A,
+    Z: connectionSide(zSide.labelOffset),
+  };
+
+  wm.nodes.push(conn);
+  const idx = wm.links.findIndex((l) => l.id === linkId);
+  wm.links.splice(idx + 1, 0, newLink);
+  return wm;
+}
+
+/**
+ * Remove a VIA connection node, merging its incoming (A<->C) and outgoing
+ * (C<->B) links back into a single A<->B link that keeps the endpoint data.
+ * No-op unless the node is a connection with exactly one incoming and one
+ * outgoing link (so malformed graphs are left untouched).
+ */
+export function removeVia(wm: Weathermap, connectionNodeId: string): Weathermap {
+  const conn = wm.nodes.find((n) => n.id === connectionNodeId && n.isConnection);
+  if (!conn) {
+    return wm;
+  }
+
+  const inLinks = wm.links.filter((l) => l.nodes[1].id === conn.id);
+  const outLinks = wm.links.filter((l) => l.nodes[0].id === conn.id);
+  if (inLinks.length !== 1 || outLinks.length !== 1) {
+    return wm;
+  }
+
+  const inLink = inLinks[0];
+  const outLink = outLinks[0];
+
+  // inLink (A<->C) now reaches outLink's target (B), keeping B-side data.
+  inLink.nodes = [inLink.nodes[0], outLink.nodes[1]];
+  inLink.sides = { A: inLink.sides.A, Z: outLink.sides.Z };
+
+  wm.links = wm.links.filter((l) => l.id !== outLink.id);
+  wm.nodes = wm.nodes.filter((n) => n.id !== conn.id);
+  return wm;
+}
+
+/**
  * Resolve a single display value from a field's data points according to the
  * chosen value-mapping mode. Null/NaN entries are skipped and negative values
  * are clamped to 0 (matching how the panel treats throughput). Returns 0 when


### PR DESCRIPTION
Closes #67. (Upstream request: knightss27/grafana-network-weathermap#64.)

Makes VIA (intermediate waypoint) management far easier — the pain points in the issue were "hard to discover how to add", "no visual handle to drag", and "deleting requires navigating into the link editor". This adds direct canvas interaction **without** changing the underlying connection-node data model (low risk):

- **Double-click a link** (edit mode) → inserts a VIA: the link `A<->B` is split into `A<->C` and `C<->B` with a new connection node `C` at the midpoint. The A-side and B-side query data are preserved on the correct segments. Cursor shows `copy` over links in edit mode as a hint.
- **Drag the VIA** → node dragging already works in edit mode; the VIA is a normal (connection) node with a visible handle.
- **Right-click a VIA** (edit mode) → removes it: the two segments merge back into a single `A<->B` link, restoring the endpoint data.

## Design / risk
The risky split/merge bookkeeping lives in **pure, unit-tested helpers** (`addViaToLink` / `removeVia`) that reproduce the exact connection-node structure the renderer already supports (same as `getConnectedLinkData`). The panel only adds an `onDoubleClick` on links and an `onContextMenu` on nodes — **no changes to link geometry**, so existing links and connections render identically. `removeVia` is a no-op unless the node is a connection with exactly one in + one out link, so malformed graphs are left untouched.

## Security
Pure data manipulation — no URL/DOM/HTML/injection surface.

## Verification (run locally)
- `npm run typecheck` → pass
- `npm run test:ci` → **41/41 pass** (helpers: split/merge/data-preservation/no-op; integration: double-click adds VIA, right-click removes VIA; all existing connection/drag/zoom tests still pass)
- `npm run lint` → pass
- `npm run build` → success
- `npm audit` → 0 high / 0 critical

## Scope note
This is the UX slice you selected. A deeper `Link.vias` waypoint data-model (bent polylines, bending radius) remains a possible larger follow-up. Branched off `main` (post-v1.5.5); left open for the next release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add direct canvas VIA editing in edit mode: double-click a link to add a waypoint; right-click a VIA to remove it. Addresses #67 and disables link navigation in edit mode to avoid accidental clicks.

- **New Features**
  - Double-click a link inserts a VIA at the midpoint and splits A<->B into A<->C and C<->B, preserving A- and Z-side queries.
  - Right-click a VIA removes it and merges back to A<->B; drag the VIA like any node; logic lives in unit-tested helpers (`addViaToLink`, `removeVia`); no link geometry changes.

- **Bug Fixes**
  - Disabled dashboard-link navigation while in edit mode.
  - `removeVia` now guards against C->C self-loops (no-op on malformed graphs).

<sup>Written for commit 9cd965b2b999e9d42494cadf7ec005de0b772745. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

