### PR TITLE
fix: address outstanding cubic review findings (node tooltip, direction labels, arrow meeting)

### DIFF
--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -92,6 +92,9 @@ test('Uses explicit per-side direction labels in the link tooltip when set', () 
   const weathermap = handleVersionedStateUpdates(getData(theme), theme);
   weathermap.links[0].sides.A.directionLabel = 'TX-UPLINK';
   weathermap.links[0].sides.Z.directionLabel = 'RX-DOWNLINK';
+  // A custom tooltip metric row must use the same per-side labels, not the
+  // generic Inbound/Outbound wording.
+  weathermap.links[0].tooltipMetrics = [{ label: 'Errors', queryA: 'a-series', queryZ: 'z-series' }];
   testProps.options.weathermap = weathermap;
   testProps.onOptionsChange = (options: SimpleOptions) => {
     testProps.options = options;
@@ -105,6 +108,12 @@ test('Uses explicit per-side direction labels in the link tooltip when set', () 
   // Both explicit labels replace the generic Inbound/Outbound wording.
   expect(screen.getAllByText(/TX-UPLINK/).length).toBeGreaterThan(0);
   expect(screen.getAllByText(/RX-DOWNLINK/).length).toBeGreaterThan(0);
+  // The custom metric row uses the direction labels and not "Inbound"/"Outbound".
+  const metricRow = screen.getByText(/Errors/).textContent || '';
+  expect(metricRow).toContain('TX-UPLINK');
+  expect(metricRow).toContain('RX-DOWNLINK');
+  expect(metricRow).not.toContain('Inbound');
+  expect(metricRow).not.toContain('Outbound');
 
   fireEvent.mouseLeave(screen.getByTestId('link').firstChild!);
 });

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -626,8 +626,10 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
 
   const handleNodeHover = (d: DrawnNode, e: React.MouseEvent<SVGElement>) => {
     // Only show a tooltip when the node actually has metrics configured, and
-    // never while a node is being dragged in edit mode.
+    // never while a node is being dragged in edit mode. Clear any stale tooltip
+    // on the early-return path so it doesn't linger once a drag begins.
     if (e.shiftKey || draggedNode || !d.tooltipMetrics || d.tooltipMetrics.length === 0) {
+      setHoveredNode(null as unknown as HoveredNode);
       return;
     }
     let mouseX = e.clientX;
@@ -824,10 +826,10 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                   };
                   const parts: string[] = [];
                   if (metric.queryA !== undefined && metric.queryA !== '') {
-                    parts.push(`Inbound: ${fmtVal(inboundVal)}`);
+                    parts.push(`${sideDirectionLabel(hoveredLink.link, 'A', 'Inbound')}: ${fmtVal(inboundVal)}`);
                   }
                   if (metric.queryZ !== undefined && metric.queryZ !== '') {
-                    parts.push(`Outbound: ${fmtVal(outboundVal)}`);
+                    parts.push(`${sideDirectionLabel(hoveredLink.link, 'Z', 'Outbound')}: ${fmtVal(outboundVal)}`);
                   }
                   return (
                     <div key={idx} style={{ fontSize: wm.settings.tooltip.fontSize }}>

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,8 +143,10 @@ export interface Link {
   stroke: number;
   showThroughputPercentage: boolean;
   linkOffset?: number;
-  // Percentage (0-100) along the A->Z line where the two directional arrows
-  // meet. Defaults to 50 (the midpoint) when unset.
+  // Percentage along the A->Z line where the two directional arrows meet.
+  // Defaults to 50 (the midpoint) when unset. The renderer clamps the effective
+  // value to 5-95 to keep the junction from overlapping either node box, so
+  // values outside that range render at the nearest bound.
   arrowMeetPercent?: number;
   tooltipMetrics?: LinkTooltipMetric[];
   statusQuery?: string;


### PR DESCRIPTION
Resolves the three P2 findings cubic raised on already-merged/released PRs:

- **#146 (node tooltips)** — clear `hoveredNode` on the `handleNodeHover` early-return path so a tooltip shown just before a drag begins no longer lingers with stale data while dragging.
- **#147 (direction labels)** — the custom tooltip-metric rows now use the per-side `sideDirectionLabel` instead of hardcoded "Inbound"/"Outbound", so the whole tooltip is consistent when direction labels are set.
- **#148 (arrow meeting point)** — document the effective **5–95** clamp on the `arrowMeetPercent` type so type/docs match the renderer (a stored value outside 5–95 renders at the nearest bound; the UI slider already enforces 5–95).

The three #153 findings were already fixed on that branch (link-nav gating in edit mode, self-loop guard, test isolation).

## Verification
- `npm run typecheck` → pass
- `npm run test:ci` → **36/36 pass** (extended direction-label test asserts the metric row uses the labels, not the generic wording)
- `npm run lint` → pass
- `npm run build` → success

Branched off `main`; left open for the next release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a lingering node tooltip during drag, makes tooltip metric rows respect per-side direction labels, and documents the 5–95 clamp for `arrowMeetPercent` to match the renderer. Improves tooltip consistency and prevents stale data while editing.

- **Bug Fixes**
  - Clear `hoveredNode` on early-return in `handleNodeHover` so a pre-drag node tooltip doesn’t persist while dragging.
  - Use `sideDirectionLabel` for custom tooltip metric rows instead of hardcoded "Inbound"/"Outbound".
  - Clarify `arrowMeetPercent` docs/type: effective range is clamped to 5–95; values outside render at the nearest bound.

<sup>Written for commit ad3a82e9cbc3a59b6c9cd63f3ce3c2a985423125. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

