### PR TITLE
feat(#57): macOS-compatible interaction controls (pan, zoom, multi-select)

### DIFF
--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -222,6 +222,39 @@ test('Right-clicking a VIA in edit mode removes it', () => {
   expect(captured!.weathermap.links.length).toBe(1);
 });
 
+test('Panning the viewport works with the Cmd key (macOS)', () => {
+  let testProps = { ...mPanelProps };
+  testProps.options = { weathermap: handleVersionedStateUpdates(getData(theme), theme) };
+  testProps.onOptionsChange = (o: SimpleOptions) => {
+    testProps.options = o;
+  };
+
+  const { container } = render(<WeathermapPanel {...testProps} />);
+  const svg = container.querySelector('#nw-testing')!;
+  const prev = container.querySelector('g')!.getAttribute('transform');
+
+  // Cmd (metaKey) + drag should pan just like Ctrl/middle-mouse on other OSes.
+  fireEvent.mouseDown(svg);
+  fireEvent(svg, new MouseMoveEvent({ movementX: 10, movementY: 10, metaKey: true, bubbles: true }));
+  fireEvent.mouseUp(svg);
+
+  expect(container.querySelector('g')!.getAttribute('transform')).not.toEqual(prev);
+});
+
+test('Zoom responds to horizontal scroll (macOS Shift+scroll remap)', () => {
+  getSearchSpy = jest.spyOn(locationService, 'getSearch').mockReturnValue(new URLSearchParams('editPanel=1'));
+  let testProps = { ...mPanelProps };
+  testProps.options = { weathermap: handleVersionedStateUpdates(getConnectedLinkData(theme), theme) };
+  testProps.onOptionsChange = (o: SimpleOptions) => {
+    testProps.options = o;
+  };
+
+  const { container } = render(<WeathermapPanel {...testProps} />);
+  // macOS remaps Shift+scroll to the horizontal axis; only deltaX is set.
+  fireEvent.wheel(container.querySelector('#nw-testing_')!, { deltaX: 1, deltaY: 0 });
+  expect(testProps.options.weathermap.settings.panel.zoomScale).not.toEqual(0);
+});
+
 // Tests plays badly with new deps
 // test('Editing a weathermap', () => {
 //   let testProps = { ...mPanelProps };

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -511,7 +511,14 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
       return;
     }
 
-    const delta = e.deltaY > 0 ? 1 : -1;
+    // Use the dominant scroll axis so macOS Shift+scroll (which the OS remaps to
+    // horizontal/deltaX) and trackpad gestures still zoom reliably.
+    const scroll = Math.abs(e.deltaY) >= Math.abs(e.deltaX) ? e.deltaY : e.deltaX;
+    if (scroll === 0) {
+      return;
+    }
+
+    const delta = scroll > 0 ? 1 : -1;
     onOptionsChange({
       weathermap: {
         ...wm,
@@ -538,7 +545,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
   const [offset, setOffset] = useState(wm.settings.panel.offset);
 
   const drag = (e: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
-    if (e.ctrlKey || e.buttons === 4 || e.shiftKey) {
+    if (e.ctrlKey || e.metaKey || e.buttons === 4 || e.shiftKey) {
       e.nativeEvent.preventDefault();
       const zoomAmt = Math.pow(1.2, wm.settings.panel.zoomScale);
 
@@ -1074,7 +1081,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
             setDragging(true);
           }}
           onMouseMove={(e) => {
-            if (isDragging && (e.ctrlKey || e.buttons === 4 || e.shiftKey)) {
+            if (isDragging && (e.ctrlKey || e.metaKey || e.buttons === 4 || e.shiftKey)) {
               drag(e);
             }
           }}
@@ -1565,7 +1572,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                     wm: wm,
                     onDrag: (e, position) => {
                       // Return early if we actually want to just pan the whole weathermap.
-                      if (e.ctrlKey) {
+                      if (e.ctrlKey || e.metaKey) {
                         return;
                       }
 
@@ -1626,7 +1633,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                       });
                     },
                     onClick: (e) => {
-                      if (e.ctrlKey && isEditMode) {
+                      if ((e.ctrlKey || e.metaKey) && isEditMode) {
                         setSelectedNodes((v) => {
                           let cIndex = v.findIndex((n) => n.id === tempNodes[i].id);
                           if (cIndex > -1) {


### PR DESCRIPTION
Closes #57. (Upstream: knightss27/grafana-network-weathermap#89.)

Fixes the interaction controls on macOS. As verified in the issue, the gestures relied on `ctrlKey` and middle-mouse and never checked `metaKey`, which breaks on macOS:
- **Ctrl+click is a secondary (right) click** on macOS, so Ctrl+drag opened the context menu instead of panning.
- Mac trackpads / Magic Mouse have **no middle button**, so `buttons === 4` pan was unavailable.
- macOS **remaps Shift+scroll to the horizontal axis (`deltaX`)**, so the zoom handler (which only read `deltaY`) barely responded.

## Changes (Linux/Windows behavior unchanged — inputs are only *widened*)
- Accept **Cmd (`metaKey`)** everywhere `ctrlKey` was used: viewport pan (`drag` + svg `onMouseMove`), node-drag suppression (pan-instead-of-move), and multi-select.
- Zoom now uses the **dominant scroll axis** (`deltaX` or `deltaY`) so macOS Shift+scroll and trackpad gestures zoom reliably; ignores zero-delta events.

Result — works on all three platforms:
- **Linux/Windows:** Ctrl/Shift+drag or middle-mouse pan, scroll/Shift+scroll zoom, Ctrl+click multi-select — all unchanged.
- **macOS:** Cmd/Shift+drag pan, Shift+scroll (horizontal) zoom, Cmd+click multi-select now work.

## Verification (run locally)
- `npm run typecheck` → pass
- `npm run test:ci` → **44/44 pass** (2 new: Cmd+drag pans the viewport; horizontal-only scroll changes zoom)
- `npm run lint` → pass
- `npm run build` → success
- `npm audit` → 0 high / 0 critical

Branched off `main` (post-v1.5.6); left open for the next release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix macOS interaction controls for the weathermap: pan, zoom, and multi-select now work with Cmd and trackpad gestures. Closes #57.

- **Bug Fixes**
  - Accept Cmd (`metaKey`) wherever Ctrl was used: viewport pan drag, node-drag suppression, and multi-select.
  - Zoom uses the dominant scroll axis (`deltaX` or `deltaY`) and ignores zero-delta events.

<sup>Written for commit 92bd51d98a81e1266280d8ac98aa9f755f08a906. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

