### PR TITLE
chore(release): bump version to 1.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.5.7](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.7) (2026-07-02)
+
+### Bug Fixes
+
+* **macos-interactions**: pan, zoom, and multi-select now work on macOS. The Cmd (⌘) key is accepted everywhere Ctrl was used (viewport pan, node-drag suppression, multi-select), and zoom uses the dominant scroll axis so macOS Shift+scroll (remapped to horizontal) and trackpad gestures still zoom. Linux/Windows behaviour (Ctrl/Shift/middle-mouse, vertical scroll) is unchanged ([#57](https://github.com/allamiro/grafana-network-weathermap-ng/issues/57), PR [#156](https://github.com/allamiro/grafana-network-weathermap-ng/pull/156))
+
 ## [1.5.6](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.6) (2026-07-02)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamirsuliman-weathermap-panel",
-      "version": "1.5.6",
+      "version": "1.5.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Releases the macOS interaction fix (Cmd-key pan/zoom/select, horizontal-scroll zoom; #57 / PR #156) as **v1.5.7**. Cubic review: no issues found. No plugin changes beyond #156.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.5.7 with a macOS interaction fix: pan, zoom, and multi-select now work with Cmd (⌘), and zoom follows the dominant scroll axis for Shift+scroll and trackpad gestures. No behavior changes on Linux or Windows.

<sup>Written for commit a3b78ddffe586fe94f3156d570340976aa802363. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

