### PR TITLE
feat(#158): timeline slider for historical network state

### DIFF
--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -255,6 +255,38 @@ test('Zoom responds to horizontal scroll (macOS Shift+scroll remap)', () => {
   expect(testProps.options.weathermap.settings.panel.zoomScale).not.toEqual(0);
 });
 
+test('Shows the timeline slider when enabled', () => {
+  let testProps = { ...mPanelProps };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  weathermap.settings.link.timeline = { enabled: true };
+  testProps.options = { weathermap };
+  // A valid (ascending) time range so the slider bounds are well-formed.
+  testProps.timeRange = {
+    from: { valueOf: () => 1_000_000 },
+    to: { valueOf: () => 2_000_000, toLocaleString: () => '2M' },
+  } as unknown as PanelProps<SimpleOptions>['timeRange'];
+  testProps.onOptionsChange = (o: SimpleOptions) => {
+    testProps.options = o;
+  };
+
+  render(<WeathermapPanel {...testProps} />);
+  const timeline = screen.getByTestId('weathermap-timeline');
+  expect(timeline).not.toBeNull();
+  // Starts in the live state.
+  expect(timeline.textContent).toContain('Live');
+});
+
+test('Hides the timeline slider when disabled', () => {
+  let testProps = { ...mPanelProps };
+  testProps.options = { weathermap: handleVersionedStateUpdates(getData(theme), theme) };
+  testProps.onOptionsChange = (o: SimpleOptions) => {
+    testProps.options = o;
+  };
+
+  render(<WeathermapPanel {...testProps} />);
+  expect(screen.queryByTestId('weathermap-timeline')).toBeNull();
+});
+
 // Tests plays badly with new deps
 // test('Editing a weathermap', () => {
 //   let testProps = { ...mPanelProps };

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -120,7 +120,13 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
   // null means "live" — resolve values with the normal value-mapping mode.
   const timelineEnabled = Boolean(wm?.settings?.link?.timeline?.enabled);
   const [scrubTime, setScrubTime] = useState<number | null>(null);
-  const useTimeline = timelineEnabled && scrubTime !== null;
+  // Clamp the scrub position into the current dashboard range so the label and
+  // the resolved data stay in sync even after the time range changes.
+  const timeFromMs = timeRange.from.valueOf();
+  const timeToMs = timeRange.to.valueOf();
+  const effectiveScrub =
+    scrubTime === null ? null : Math.min(timeToMs, Math.max(timeFromMs, scrubTime));
+  const useTimeline = timelineEnabled && effectiveScrub !== null;
 
   function getScaleColor(current: number, max: number) {
     const defaultColor = getSolidFromAlphaColor(wm.settings.link.stroke.color, wm.settings.panel.backgroundColor);
@@ -486,11 +492,11 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
       try {
         const fieldValues = getValueField(frame).values as Array<number | null | undefined>;
         const resolvedValue =
-          useTimeline && scrubTime !== null
+          useTimeline && effectiveScrub !== null
             ? valueAtTime(
                 getTimeField(frame)?.values as Array<number | null | undefined>,
                 fieldValues,
-                scrubTime
+                effectiveScrub
               )
             : aggregateFieldValues(fieldValues, mode);
         map.set(getDataFrameName(frame, data.series), resolvedValue);
@@ -500,7 +506,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
     });
     return map;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, wm.settings.link.valueMappingMode, useTimeline, scrubTime]);
+  }, [data, wm.settings.link.valueMappingMode, useTimeline, effectiveScrub]);
 
   // Minimize uneeded state changes
   const mounted = useRef(false);
@@ -1702,13 +1708,13 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
         </div>
         {timelineEnabled &&
           (() => {
-            const fromMs = timeRange.from.valueOf();
-            const toMs = timeRange.to.valueOf();
+            const fromMs = timeFromMs;
+            const toMs = timeToMs;
             // Guard against a degenerate/inverted range (would make an invalid slider).
             if (!(toMs > fromMs)) {
               return null;
             }
-            const current = Math.min(toMs, Math.max(fromMs, scrubTime ?? toMs));
+            const current = effectiveScrub ?? toMs;
             const step = Math.max(1, Math.round((toMs - fromMs) / 500));
             return (
               <div

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -1,5 +1,14 @@
 import React, { useEffect, useState, useRef, useMemo } from 'react';
-import { DataFrame, Field, FieldType, getTimeZone, getValueFormat, LoadingState, PanelProps } from '@grafana/data';
+import {
+  DataFrame,
+  dateTimeFormat,
+  Field,
+  FieldType,
+  getTimeZone,
+  getValueFormat,
+  LoadingState,
+  PanelProps,
+} from '@grafana/data';
 import {
   Anchor,
   DrawnLink,
@@ -18,7 +27,9 @@ import {
 } from 'types';
 import { css, cx } from '@emotion/css';
 import {
+  Button,
   LegendDisplayMode,
+  Slider,
   TimeSeries,
   TooltipDisplayMode,
   TooltipPlugin,
@@ -38,6 +49,8 @@ import {
   getValueField,
   sanitizeUrl,
   aggregateFieldValues,
+  getTimeField,
+  valueAtTime,
   addViaToLink,
   removeVia,
 } from 'utils';
@@ -102,6 +115,12 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
 
   const [draggedNode, setDraggedNode] = useState(null as unknown as DrawnNode);
   const [selectedNodes, setSelectedNodes] = useState([] as DrawnNode[]);
+
+  // Timeline slider (#158): when scrubbing, holds the selected timestamp (ms).
+  // null means "live" — resolve values with the normal value-mapping mode.
+  const timelineEnabled = Boolean(wm?.settings?.link?.timeline?.enabled);
+  const [scrubTime, setScrubTime] = useState<number | null>(null);
+  const useTimeline = timelineEnabled && scrubTime !== null;
 
   function getScaleColor(current: number, max: number) {
     const defaultColor = getSolidFromAlphaColor(wm.settings.link.stroke.color, wm.settings.panel.backgroundColor);
@@ -466,7 +485,14 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
       }
       try {
         const fieldValues = getValueField(frame).values as Array<number | null | undefined>;
-        const resolvedValue = aggregateFieldValues(fieldValues, mode);
+        const resolvedValue =
+          useTimeline && scrubTime !== null
+            ? valueAtTime(
+                getTimeField(frame)?.values as Array<number | null | undefined>,
+                fieldValues,
+                scrubTime
+              )
+            : aggregateFieldValues(fieldValues, mode);
         map.set(getDataFrameName(frame, data.series), resolvedValue);
       } catch (e) {
         console.warn('Network Weathermap: Error while attempting to access query data.', e);
@@ -474,7 +500,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
     });
     return map;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, wm.settings.link.valueMappingMode]);
+  }, [data, wm.settings.link.valueMappingMode, useTimeline, scrubTime]);
 
   // Minimize uneeded state changes
   const mounted = useRef(false);
@@ -1674,6 +1700,50 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
         >
           {wm.settings.panel.showTimestamp ? timeRange.to.toLocaleString() : ''}
         </div>
+        {timelineEnabled &&
+          (() => {
+            const fromMs = timeRange.from.valueOf();
+            const toMs = timeRange.to.valueOf();
+            // Guard against a degenerate/inverted range (would make an invalid slider).
+            if (!(toMs > fromMs)) {
+              return null;
+            }
+            const current = Math.min(toMs, Math.max(fromMs, scrubTime ?? toMs));
+            const step = Math.max(1, Math.round((toMs - fromMs) / 500));
+            return (
+              <div
+                data-testid="weathermap-timeline"
+                className={css`
+                  position: absolute;
+                  bottom: 0;
+                  left: 0;
+                  right: 0;
+                  display: flex;
+                  align-items: center;
+                  gap: 8px;
+                  padding: 6px 10px;
+                  background-color: ${theme.colors.background.secondary};
+                  border-top: 1px solid ${theme.colors.border.weak};
+                `}
+              >
+                <span style={{ fontSize: '12px', whiteSpace: 'nowrap', minWidth: '128px' }}>
+                  {useTimeline ? dateTimeFormat(current, { timeZone: getTimeZone() }) : 'Live (latest)'}
+                </span>
+                <div style={{ flex: '1 1 auto' }}>
+                  <Slider
+                    min={fromMs}
+                    max={toMs}
+                    step={step}
+                    value={current}
+                    onChange={(v) => setScrubTime(v)}
+                  />
+                </div>
+                <Button variant="secondary" size="sm" disabled={!useTimeline} onClick={() => setScrubTime(null)}>
+                  Live
+                </Button>
+              </div>
+            );
+          })()}
       </div>
     );
   } else {

--- a/src/forms/PanelForm.tsx
+++ b/src/forms/PanelForm.tsx
@@ -244,6 +244,20 @@ export const PanelForm = ({ value, onChange }: Props) => {
             }}
           />
         </InlineField>
+        <InlineField
+          grow
+          label={'Timeline Slider'}
+          tooltip={'Show a slider at the bottom of the panel to scrub through the selected time range and view link values as they were at that moment.'}
+        >
+          <InlineSwitch
+            value={value.settings.link.timeline?.enabled ?? false}
+            onChange={(e) => {
+              let wm = value;
+              wm.settings.link.timeline = { enabled: e.currentTarget.checked };
+              onChange(wm);
+            }}
+          />
+        </InlineField>
         <InlineField grow label={'Default Link Units'}>
           <UnitPicker
             onChange={(val) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -232,6 +232,11 @@ export interface WeathermapSettings {
     defaultUnits?: string;
     linkDecimals?: number;
     valueMappingMode?: ValueMappingMode;
+    // When enabled, a timeline slider lets the viewer scrub through the selected
+    // time range and see link values as they were at that moment.
+    timeline?: {
+      enabled: boolean;
+    };
     dynamicStroke?: {
       enabled: boolean;
       minWidth: number;

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -11,8 +11,10 @@ import {
   isSafeUrl,
   measureText,
   nearestMultiple,
+  getTimeField,
   removeVia,
   sanitizeUrl,
+  valueAtTime,
 } from 'utils';
 
 test('getSolidFromAlphaColor', () => {
@@ -223,5 +225,43 @@ describe('VIA helpers (addViaToLink / removeVia)', () => {
     expect(wm.links).toHaveLength(1);
     expect(wm.links[0].id).toBe('self');
     expect(wm.nodes.some((n) => n.id === conn.id)).toBe(true);
+  });
+});
+
+describe('timeline helpers (valueAtTime / getTimeField)', () => {
+  const times = [1000, 2000, 3000];
+  const values = [10, 20, 30];
+
+  test('exact and step-hold (most recent sample at or before time)', () => {
+    expect(valueAtTime(times, values, 2000)).toBe(20);
+    expect(valueAtTime(times, values, 2500)).toBe(20); // hold previous
+  });
+
+  test('before the first sample uses the first point', () => {
+    expect(valueAtTime(times, values, 500)).toBe(10);
+  });
+
+  test('after the last sample uses the last point', () => {
+    expect(valueAtTime(times, values, 9999)).toBe(30);
+  });
+
+  test('skips null/NaN backwards and clamps negatives', () => {
+    expect(valueAtTime([1000, 2000, 3000], [10, null, 30], 2500)).toBe(10);
+    expect(valueAtTime([1000, 2000], [-5, 20], 1500)).toBe(0); // -5 clamped
+  });
+
+  test('returns 0 for empty or missing input', () => {
+    expect(valueAtTime([], [], 1000)).toBe(0);
+    expect(valueAtTime(undefined, undefined, 1000)).toBe(0);
+  });
+
+  test('getTimeField returns the time field', () => {
+    const frame: any = {
+      fields: [
+        { name: 'Time', type: 'time', values: [1, 2] },
+        { name: 'Value', type: 'number', values: [3, 4] },
+      ],
+    };
+    expect(getTimeField(frame)?.name).toBe('Time');
   });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -264,4 +264,14 @@ describe('timeline helpers (valueAtTime / getTimeField)', () => {
     };
     expect(getTimeField(frame)?.name).toBe('Time');
   });
+
+  test('getTimeField does not fall back to a non-numeric first field', () => {
+    const frame: any = {
+      fields: [
+        { name: 'Host', type: 'string', values: ['a', 'b'] },
+        { name: 'Value', type: 'number', values: [3, 4] },
+      ],
+    };
+    expect(getTimeField(frame)).toBeUndefined();
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -376,14 +376,19 @@ export function getValueField(frame: DataFrame): Field {
   throw new Error(`No value field found in frame "${frame.name}"`);
 }
 
-// Find the time field of a data frame (used by the timeline slider). Falls back
-// to the first field for standard time-series frames (time at index 0).
+// Find the time field of a data frame (used by the timeline slider). Prefers a
+// FieldType.time field; only falls back to the first field when it is numeric
+// (epoch-ms style), never to a string/category/unrelated field.
 export function getTimeField(frame: DataFrame): Field | undefined {
   const timeField = frame.fields.find((f) => f.type === FieldType.time);
   if (timeField) {
     return timeField;
   }
-  return frame.fields.length > 0 ? frame.fields[0] : undefined;
+  const first = frame.fields[0];
+  if (first && first.type === FieldType.number) {
+    return first;
+  }
+  return undefined;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -376,6 +376,59 @@ export function getValueField(frame: DataFrame): Field {
   throw new Error(`No value field found in frame "${frame.name}"`);
 }
 
+// Find the time field of a data frame (used by the timeline slider). Falls back
+// to the first field for standard time-series frames (time at index 0).
+export function getTimeField(frame: DataFrame): Field | undefined {
+  const timeField = frame.fields.find((f) => f.type === FieldType.time);
+  if (timeField) {
+    return timeField;
+  }
+  return frame.fields.length > 0 ? frame.fields[0] : undefined;
+}
+
+/**
+ * Resolve the value of a series at a specific point in time (timeline slider).
+ * Uses a step-hold: returns the value of the most recent sample at or before
+ * `timeMs`. Times are assumed ascending. Null/NaN samples are skipped (walking
+ * backwards to the previous valid one) and negatives are clamped to 0, matching
+ * the panel's throughput handling. Returns 0 when there is no usable value.
+ */
+export function valueAtTime(
+  times: Array<number | null | undefined> | null | undefined,
+  values: Array<number | null | undefined> | null | undefined,
+  timeMs: number
+): number {
+  if (!times || !values || times.length === 0) {
+    return 0;
+  }
+
+  // Index of the most recent sample at or before timeMs.
+  let idx = -1;
+  for (let i = 0; i < times.length; i++) {
+    const t = times[i];
+    if (t == null) {
+      continue;
+    }
+    if (t <= timeMs) {
+      idx = i;
+    } else {
+      break;
+    }
+  }
+  // Before the first sample: fall back to the first available point.
+  if (idx === -1) {
+    idx = 0;
+  }
+
+  for (let i = idx; i >= 0; i--) {
+    const v = values[i];
+    if (v !== null && v !== undefined && !isNaN(v)) {
+      return Math.max(0, v);
+    }
+  }
+  return 0;
+}
+
 export const getDataFrameName = (frame: DataFrame, allFrames: DataFrame[]): string => {
   return getFieldDisplayName(getValueField(frame), frame, allFrames);
 };


### PR DESCRIPTION
Closes #158.

Adds an optional **timeline slider** at the bottom of the panel. When enabled, dragging it scrubs through the selected dashboard time range and re-resolves every **link value** to the sample at (or most recently before) that moment — so the whole map shows its historical state. Addresses the issue's use cases: incident retrospectives, trend analysis, capacity planning.

## How it works
- **PanelForm**: "Timeline Slider" toggle (off by default).
- **Slider overlay**: appears at the bottom when enabled — a timestamp label, the slider (spanning the dashboard time range), and a **Live** button to return to the latest/aggregate value.
- **Resolution**: `dataFrameMap` calls a new pure helper `valueAtTime(times, values, t)` (step-hold to the most recent sample ≤ t; null/NaN skipped; negatives clamped) instead of the value-mapping aggregate — but **only while the toggle is on and the viewer is actively scrubbing**.

## Safety — nothing else changes
- **Off by default.** With the toggle off, or while "Live", value resolution is the **exact existing `aggregateFieldValues` path** — no behavioral change.
- Risky logic isolated in pure, unit-tested helpers (`valueAtTime`, `getTimeField`).
- Degenerate/inverted time range is guarded (no invalid slider).
- No new URL/DOM/injection surface.
- **Full existing suite passes** (link rendering, drag, zoom, VIA, tooltips, macOS gestures) → no regression.

## Verification
- typecheck ✓ · test:ci **52/52** ✓ (8 new) · lint ✓ · build ✓ · audit 0 high/0 critical

## Scope note
This version scrubs **link values** (the core "flows & link utilization" ask). Node status coloring is computed separately in `MapNode` from the frame's latest value and does not follow the slider yet — a clean follow-up. Branched off `main` (post-v1.5.7).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional timeline slider to scrub the dashboard time range and see historical link values at a specific moment. Implements #158 and clamps scrubbing to the current range for consistent labels and data.

- New Features
  - Toggle in PanelForm: "Timeline Slider" (off by default).
  - Bottom overlay with timestamp, slider, and a "Live" reset.
  - While scrubbing, link values resolve at the selected time via `valueAtTime(getTimeField(frame))`; otherwise the existing aggregate path is unchanged.
  - Guards invalid time ranges; pure helpers `getTimeField` and `valueAtTime` with tests.
  - Scope: link values only; node status follows later.

- Bug Fixes
  - Clamp the scrub position into the current dashboard time range so the label and resolved data stay in sync as the range changes.
  - Stricter `getTimeField`: prefer `FieldType.time`; only fall back to a numeric first field (ignore string/categorical).

<sup>Written for commit 980e6cde0cce628b0afb0f20bbf3be5a3240fce8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

