### PR TITLE
chore(release): bump version to 1.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.5.8](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.8) (2026-07-02)
+
+### Features
+
+* **timeline-slider**: an optional timeline slider (Panel Options → Link Options → "Timeline Slider") lets viewers scrub through the selected dashboard time range and see link values as they were at that moment — for incident retrospectives, trend analysis, and capacity planning. Off by default; a "Live" button returns to the latest/aggregate value ([#158](https://github.com/allamiro/grafana-network-weathermap-ng/issues/158), PR [#159](https://github.com/allamiro/grafana-network-weathermap-ng/pull/159))
+
 ## [1.5.7](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.7) (2026-07-02)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamirsuliman-weathermap-panel",
-      "version": "1.5.7",
+      "version": "1.5.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Releases the timeline slider feature (scrub historical link state; #158 / PR #159) as **v1.5.8**. Cubic review addressed. No plugin changes beyond #159.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.5.8, shipping an optional timeline slider to scrub the selected time range and view historical link values (enable in Panel Options → Link Options; off by default). Updates `package.json`, `package-lock.json`, and `CHANGELOG.md`; no other plugin changes.

<sup>Written for commit 633f8d5863a2145a1479797bb7b24949840d07cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

