### PR TITLE
docs: comprehensive step-by-step user guide and use cases

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -1,45 +1,105 @@
 # FAQ
 
-## Installation
+New to the plugin? See the **[Tutorial → Getting Started](guide/getting-started.md)** first. This page answers common questions.
+
+## Installation & versions
 
 - **Q: Is this the same plugin as `knightss27-weathermap-panel`?**
-    - This is a continuation fork. The original plugin was archived in 2023. This fork (`tamirsuliman-weathermap-panel`) is modernized for Grafana 12+ and actively maintained. Config exported from the original plugin is compatible.
+    - This is a continuation fork. The original plugin was archived in 2023. This fork (`tamirsuliman-weathermap-panel`, display name **Network Weathermap NG**) is modernized and actively maintained. Config exported from the original plugin is compatible.
 
 - **Q: What is the minimum Grafana version?**
     - Grafana **11.0.0**. The plugin uses `@grafana/*` SDK v11 APIs. API compatibility is verified against Grafana 11.x and 12.x in CI.
 
+- **Q: Why does Grafana say the plugin is "unsigned"?**
+    - During the initial review a new plugin is unsigned — this is expected. Grafana signs it on approval. To allow an unsigned build in the meantime, add its ID to `allow_loading_unsigned_plugins` in `grafana.ini`. Every release is built via GitHub Actions with a verifiable **provenance attestation**.
+
 ## Data / Queries
 
 - **Q: My links show `n/a` even though the query is returning data.**
-    - Make sure your query's display name in the dropdown exactly matches what Grafana shows. With Prometheus wildcard queries returning multiple series, each series gets a unique label-qualified name (e.g. `value {instance="host1"}`). Re-open the link editor and re-select the query from the dropdown to pick up the correct name.
+    - Weathermap matches a series by its **display name**. Make sure the name in the dropdown exactly matches what Grafana shows. With Prometheus wildcard queries returning multiple series, each series gets a unique label-qualified name (e.g. `value {instance="host1"}`). Re-open the link editor and re-select the query from the dropdown.
 
-- **Q: I am unable to select one of my data queries, even though it shows up in the query selection dropdown.**
-    - Queries with identical display names are deduplicated in the dropdown. If two queries share the same field name and label set, only one entry appears. See [Adding Data](/#adding-data) for details.
+- **Q: How should I pick the A-side and Z-side queries for a link?**
+    - **A side = outbound (A→Z)**, **Z side = inbound (Z→A)**. For a link between two devices, use the A device's *bits sent* for the A side, and either the Z device's *bits sent* or the A device's *bits received* for the Z side (both represent Z→A). See [Links](guide/links.md).
 
-- **Q: I am using the Zabbix datasource and the only option in the query selection dropdown is "wide".**
-    - In the Zabbix datasource settings, try turning off the **data alignment** property. You can also disable it per-query under the query's **Options** section.
+- **Q: The link tooltip shows the same value for the A and Z side.**
+    - That usually means both sides point at the same series/direction. Give each side the correct directional counter (see above), and optionally set per-side **[Direction Labels](guide/links.md#direction-labels-inbound-outbound)** so the tooltip clearly names each direction.
 
-- **Q: I am using the Zabbix datasource and can only select one of my queries (but it is labeled properly).**
-    - Try selecting multiple Zabbix **Items** through one Grafana query by using Regex in the **Item** area of the query editor.
+- **Q: I can't select one of my queries, even though it's in the dropdown.**
+    - Queries with identical display names are deduplicated. If two queries share the same field name and label set, only one entry appears — give them distinct names.
 
-- **Q: Prometheus `rate()` or `increase()` queries show 0 or n/a on the first data point.**
-    - This is expected — `rate()` and `increase()` return `NaN` on the first sample and may return negative values on counter resets. The plugin walks back to find the last valid non-NaN, non-negative value automatically.
+- **Q: I'm using the Zabbix datasource and the only option is "wide".**
+    - In the Zabbix datasource settings, turn off the **data alignment** property (or disable it per-query under the query's **Options** section).
+
+- **Q: Zabbix — I can only select one of my queries (but it's labeled properly).**
+    - Select multiple Zabbix **Items** through one Grafana query using Regex in the **Item** area of the query editor.
+
+- **Q: Prometheus `rate()` / `increase()` shows 0 or n/a on the first point.**
+    - Expected — those functions return `NaN` on the first sample and can go negative on counter resets. The plugin walks back to the last valid non-NaN, non-negative value automatically.
+
+## Features & how-to
+
+- **Q: Can I show the average, peak, or 95th percentile instead of just the latest value?**
+    - Yes — **Panel Options → Value Display Mode**: choose **Last, Average, Min, Max, or 95th Percentile** across the selected time range. See [Panel Options](guide/panel-options.md#value-display-mode).
+
+- **Q: Can I replay how the network looked in the past?**
+    - Enable **Panel Options → Timeline Slider**, then drag the scrubber at the bottom of the panel to move through the time range. Link values update to that moment; press **Live** to return. See [Timeline Slider](guide/panel-options.md#timeline-slider).
+
+- **Q: How do I add a bend/waypoint (VIA) to a link?**
+    - In edit mode, **double-click** a link to insert a VIA, **drag** it to position, and **right-click** it to remove. See [Interactions](guide/interactions.md#editing-vias-on-the-canvas).
+
+- **Q: Can the background image move and zoom with the map?**
+    - Yes — set a background image, then enable **Move With Map**. See [Panel Options → Background](guide/panel-options.md#background).
+
+- **Q: How do I color a node by health (CPU, temperature, up/down)?**
+    - Use the node's **Status** section: set a query, add threshold mappings, and pick a Color Target (Border/Background/Both). See [Nodes → Status coloring](guide/nodes.md#status-coloring-node-health).
+
+- **Q: How do I show extra metrics (latency, packet loss) when hovering a node?**
+    - Add them in the node's **Tooltip** section. See [Nodes → Node tooltips](guide/nodes.md#node-tooltips-extra-metrics).
+
+- **Q: How do I draw multiple links between the same two devices?**
+    - Give each link a different **Link Offset (parallel links)** value so they spread apart. See [Links → Parallel links](guide/links.md#parallel-links-link-offset).
+
+- **Q: How do I make a node clickable to another dashboard?**
+    - Set the node's **Dashboard Link** (and optionally **Open Link in Same Tab**). URLs are validated and opened with `noopener,noreferrer`.
+
+- **Q: Can I use dashboard/template variables?**
+    - Yes — `$var` / `${var}` are resolved at draw time in labels, queries, status queries, dashboard links, and bandwidth queries. Build one reusable, multi-site panel.
+
+- **Q: My thresholds go above 100% (oversubscribed links). Is that supported?**
+    - Yes — color-scale thresholds above 100% are supported and the legend scales accordingly.
+
+- **Q: How do I export or share a map?**
+    - Use **Panel Options → Export**: **Export SVG** (image for docs) or **Export JSON** (portable config). See [Interactions → Exporting](guide/interactions.md#exporting-a-map).
+
+## Interactions
+
+- **Q: Pan/zoom/select don't work on my Mac.**
+    - Fixed in v1.5.7+. On macOS use **⌘ Cmd** where Linux/Windows use **Ctrl** (Cmd+drag to pan, Cmd+click to multi-select); Shift+scroll zooms. Full gesture table: [Interactions](guide/interactions.md#gesture-reference).
+
+- **Q: How do I zoom in view mode without scrolling the dashboard?**
+    - Hold **Shift** and scroll over the panel. In edit mode, plain scroll zooms.
 
 ## Appearance
 
 - **Q: Can I upload an image as a background or node icon?**
-    - Yes. Host the image at any publicly accessible URL and paste it into the background image or icon URL field in the panel settings.
+    - Yes. Host the image at any publicly accessible URL and paste it into the background image or icon URL field.
+
+- **Q: Are the URLs I paste safe?**
+    - User-provided URLs (dashboard links, icon URLs, background images) are sanitized — only relative Grafana paths and `http`/`https` are allowed; `javascript:`, `data:`, `file:`, and similar schemes are rejected.
 
 - **Q: The tooltip mini graph shows a flat line or the time axis looks wrong.**
-    - This was a known bug fixed in v1.2.0. Upgrade to the latest release.
+    - A known bug fixed in v1.2.0. Upgrade to the latest release.
 
-## Other
+## Troubleshooting & migrating
 
 - **Q: Plugin is throwing `toReturn.source is undefined`.**
-    - Reload the page. This can occur immediately after saving config changes and is resolved with a page reload.
+    - Reload the page. This can occur immediately after saving config changes.
 
-- **Q: I exported my weathermap config from the original `knightss27-weathermap-panel`. Will it import here?**
-    - Yes. The JSON config format is backward-compatible. Use **Export / Import** in the panel editor to migrate your config.
+- **Q: On the latest Grafana it crashed with `ReactDOM.findDOMNode is not a function`.**
+    - Fixed in v1.5.0+ (React 19 compatibility). Upgrade to the latest release.
+
+- **Q: I exported my config from the original `knightss27-weathermap-panel`. Will it import here?**
+    - Yes — the JSON config format is backward-compatible. Use **Export / Import** in the panel editor.
 
 ---
 

--- a/website/docs/guide/getting-started.md
+++ b/website/docs/guide/getting-started.md
@@ -1,0 +1,84 @@
+# Getting Started — Your First Weathermap
+
+This guide walks you from an empty dashboard to a live weathermap showing traffic between two devices. It should take about 10 minutes.
+
+!!! info "Prerequisites"
+    - **Grafana 11.0.0 or later** with the *Network Weathermap NG* panel installed (see [Installation](../index.md#installation)).
+    - At least one data source (Prometheus, InfluxDB, Zabbix, or any Grafana-compatible source) returning **time-series interface counters** (e.g. bits/sec in and out of an interface).
+
+---
+
+## 1. Create the panel
+
+1. Open or create a dashboard and click **Add → Visualization**.
+2. In the visualization picker, search for **Network Weathermap** and select it.
+3. You now have an empty weathermap canvas and, on the right, the panel options.
+
+The map has two states:
+
+| State | How you get there | What you can do |
+|---|---|---|
+| **Edit mode** | The panel edit screen (where you are now) | Add/move/delete nodes and links, drag VIAs, zoom |
+| **View mode** | A saved dashboard | Hover for tooltips, click nodes/links that have dashboard links |
+
+---
+
+## 2. Add your data queries
+
+Weathermap doesn't query data itself — it *reuses the panel's queries*. In the **Queries** tab (below the panel), add the metrics you want to visualize. A typical link needs two series:
+
+- **Outbound (A → Z)** — e.g. interface bits sent
+- **Inbound (Z → A)** — e.g. interface bits received
+
+!!! tip "Give queries readable names"
+    Weathermap identifies a series by its **display name**. Use a query `refId` or a transform/legend so each series has a clear, unique name — you'll pick it from a dropdown later.
+
+---
+
+## 3. Add your devices (nodes)
+
+1. In the panel options, open the **Nodes** section.
+2. Click **Add Node**. A node appears in the middle of the canvas.
+3. Set its **Label** (e.g. `SW-CORE`).
+4. Drag the node on the canvas to position it. (Hold nothing — just click-drag in edit mode.)
+5. Repeat for a second device (e.g. `BKB-CARPINA`).
+
+See [Nodes (Devices)](nodes.md) for icons, status coloring, and per-node tooltips.
+
+---
+
+## 4. Connect them with a link
+
+1. Open the **Links** section and click **Add Link**.
+2. Set **A Side** to your first node and **Z Side** to the second.
+3. Under **A Side Options**, set **A Side Query** to your *outbound* series and, optionally, **A Bandwidth #** (or **A Bandwidth Query**) to the link capacity so utilization can be shown as a percentage.
+4. Under **Z Side Options**, set **Z Side Query** to your *inbound* series and its bandwidth.
+
+The link now colors itself according to utilization, and arrows show direction. See [Links](links.md) for units, direction labels, and more.
+
+---
+
+## 5. Set the color scale
+
+1. Open the **Color Scale / Thresholds** section (panel options).
+2. Add thresholds mapping a **percentage** (or absolute value) to a color — for example `0% → green`, `50% → yellow`, `80% → orange`, `95% → red`.
+
+Links and the legend now reflect these bands.
+
+---
+
+## 6. Save and use it
+
+1. Click **Apply / Save dashboard**.
+2. In view mode, **hover a link** to see a tooltip with usage, bandwidth, throughput %, and a mini time-series graph.
+3. **Hover a node** to see any extra metrics you configured.
+
+---
+
+## Where to go next
+
+- **[Nodes (Devices)](nodes.md)** — icons, status colors, node tooltips, dashboard links
+- **[Links](links.md)** — queries, units, direction labels, port labels, parallel links, VIAs
+- **[Panel Options](panel-options.md)** — background image, value display modes, timeline slider, tooltips
+- **[Interactions & Editing](interactions.md)** — pan/zoom/select on every OS, VIA editing, export
+- **[Use Cases](use-cases.md)** — end-to-end scenarios (capacity planning, incident retros, floor plans)

--- a/website/docs/guide/interactions.md
+++ b/website/docs/guide/interactions.md
@@ -1,0 +1,64 @@
+# Interactions & Editing
+
+How to navigate and edit the map with mouse, trackpad, and keyboard — on **Linux, Windows, and macOS**.
+
+---
+
+## Edit mode vs. view mode
+
+- **Edit mode** — the panel edit screen. You can add/move/delete nodes and links, drag VIAs, and zoom freely.
+- **View mode** — a saved dashboard. Hover for tooltips; click nodes/links that have dashboard links.
+
+Some gestures (adding VIAs, free zoom) are **edit-mode only** to avoid interfering with normal dashboard use.
+
+---
+
+## Gesture reference
+
+| Action | Linux / Windows | macOS |
+|---|---|---|
+| **Move a node** | Click-drag the node | Click-drag the node |
+| **Pan the map** | **Ctrl**+drag, **Shift**+drag, or middle-mouse drag | **⌘ Cmd**+drag or **Shift**+drag |
+| **Zoom** | Scroll (edit mode); **Shift**+scroll (view mode) | Scroll (edit mode); **Shift**+scroll (view mode) |
+| **Multi-select nodes** | **Ctrl**+click each node | **⌘ Cmd**+click each node |
+| **Add a VIA** | **Double-click** a link (edit mode) | **Double-click** a link (edit mode) |
+| **Move a VIA** | Drag the VIA | Drag the VIA |
+| **Delete a VIA** | **Right-click** the VIA (edit mode) | **Right-click** (or Ctrl-click) the VIA |
+
+!!! tip "macOS"
+    macOS uses **⌘ Cmd** where Linux/Windows use **Ctrl** (Ctrl-click is a right-click on a Mac). Zoom uses the dominant scroll axis, so a Mac's Shift+scroll (which the OS remaps to horizontal) still zooms.
+
+---
+
+## Editing VIAs on the canvas
+
+VIAs (waypoints) let a link bend through intermediate points.
+
+1. **Double-click** anywhere on a link to insert a VIA at its midpoint. The link splits into two segments, and the A-side and Z-side query data are preserved on the correct halves.
+2. **Drag** the VIA handle to route the link where you want.
+3. **Right-click** a VIA to remove it — the two segments merge back into a single link.
+
+Under the hood a VIA is a lightweight *connection node*; you can also toggle a node into a VIA with **Use As Connection** in the node's Advanced options.
+
+---
+
+## Selecting and aligning multiple nodes
+
+- Hold **Ctrl** (Linux/Windows) or **⌘ Cmd** (macOS) and click nodes to build a selection.
+- Drag any selected node to move the whole group.
+- Enable the **Grid** (Panel Options) to snap positions for clean alignment.
+
+---
+
+## Exporting a map
+
+Open **Panel options → Export**:
+
+- **Export SVG** — download the current map as an SVG image (icons are inlined). Useful for documentation and diagrams.
+- **Export JSON** — download the full weathermap configuration as JSON. You can version-control it or import it into another panel.
+
+---
+
+## Timeline scrubbing
+
+If the [Timeline Slider](panel-options.md#timeline-slider) is enabled, drag the slider at the bottom of the panel to move through history; press **Live** to return to the latest state.

--- a/website/docs/guide/links.md
+++ b/website/docs/guide/links.md
@@ -1,0 +1,102 @@
+# Links
+
+A **link** connects two nodes and visualizes the traffic between them. Each link has two **sides** — **A** and **Z** — so it can show bidirectional flow (A → Z outbound, Z → A inbound).
+
+Open **Panel options → Links**, select a link from the dropdown, or click **Add Link**.
+
+---
+
+## A / Z sides and endpoints
+
+- **A Side** / **Z Side** — the two nodes the link connects.
+- Each side has its own query, bandwidth, anchor, and labels, so inbound and outbound can be independent.
+
+**Anchor Point** controls where the link attaches to a node (Center, Top, Bottom, Left, Right) — useful for routing links cleanly around a busy map.
+
+---
+
+## Queries and bandwidth
+
+For each side:
+
+| Field | Purpose |
+|---|---|
+| **Side Query** | The series whose value drives this side's color/label (e.g. bits sent). |
+| **Bandwidth #** | A fixed capacity (e.g. `20000000000` for 20 Gbps) so utilization can show as a percentage. |
+| **Bandwidth Query** | Use a series for capacity instead of a fixed number (e.g. interface speed). |
+
+With bandwidth set, the tooltip and coloring can express **throughput %** (current ÷ bandwidth), which is how the color scale bands are matched by default.
+
+---
+
+## Units and decimals
+
+- **Link Units** — a per-link unit formatter (bps, Bps, packets/s, …). Falls back to the panel's **Default Link Units**.
+- **Link Value Decimal Places** (panel option) — fixes the number of decimals on all link labels; leave blank for automatic precision.
+
+---
+
+## Labels and label offset
+
+- **Label Offset** — slide the value text along the link (0–100%). Handy when two labels overlap.
+- **Port Label** — a per-side interface name (e.g. `ge-0/0/1`) rendered next to the link at 25% from each endpoint, rotated to follow the line.
+
+---
+
+## Direction labels (inbound / outbound)
+
+By default the tooltip labels values as generic *Inbound / Outbound*. Set an explicit **Direction Label** per side (e.g. `TX-UPLINK`, `RX-DOWNLINK`, `To WAN`) and the tooltip uses your wording instead — removing the implicit A/Z ambiguity. Because each value is labeled by its own side, the naming stays correct no matter which side you hover.
+
+Leave the fields blank to keep the classic Inbound/Outbound behavior.
+
+---
+
+## Arrow meeting point
+
+The two directional arrows meet at the midpoint of a link by default. Use the **Arrow Meeting Point (%)** slider (Link Options) to shift where they meet — lower values move the junction toward the **A** side, higher toward **Z**. Great for asymmetric links and for maps that use VIAs.
+
+---
+
+## Parallel links (link offset)
+
+To draw **multiple links between the same two nodes** without overlap, set a different **Link Offset (parallel links)** on each. The offset shifts the line perpendicular to its A→Z direction; arrows, labels, and coloring all follow the offset line. Zero (default) keeps the straight line.
+
+---
+
+## Link status (up / down)
+
+Give a link a **Status Query** so it can render as *down*:
+
+- When the status value is `0` or absent, the link uses a configurable **down color** and a **dashed** stroke.
+- Optional **blink** animation draws attention to down links.
+- While down, status rendering overrides gradient/flow-animation.
+
+---
+
+## Tooltip extra metrics
+
+Add extra rows to the link's hover tooltip (errors, discards, drops, latency, …). In the link's **Tooltip Extra Metrics** section, **Add Metric** with a **Label**, an optional **Inbound Query** and **Outbound Query**, and a **Units** formatter. These rows use your [direction labels](#direction-labels-inbound-outbound) when set.
+
+---
+
+## Stroke and arrows
+
+Under **Stroke and Arrow**:
+
+- **Link Stroke Width** — line thickness.
+- **Arrow Width / Height / Offset** — arrow geometry.
+- (Panel-level) **Dynamic Stroke** can scale stroke width with utilization, and **Flow Animation** can animate dashes in the direction of flow.
+
+---
+
+## VIAs (waypoints)
+
+A **VIA** is an intermediate bend point on a link — useful to route a link around obstacles or to represent a multi-hop path. VIAs use lightweight *connection nodes* under the hood.
+
+**Edit a VIA directly on the canvas (edit mode):**
+
+- **Add** — **double-click** a link. A VIA is inserted at the link midpoint (the link splits into A→C and C→Z, preserving each side's query data).
+- **Move** — **drag** the VIA like any node.
+- **Delete** — **right-click** the VIA; the two segments merge back into one link.
+
+See [Interactions & Editing](interactions.md) for the full gesture reference.

--- a/website/docs/guide/nodes.md
+++ b/website/docs/guide/nodes.md
@@ -1,0 +1,100 @@
+# Nodes (Devices)
+
+A **node** represents a device on your map — a switch, router, firewall, server, site, or any logical entity. This page covers every node option.
+
+Open **Panel options → Nodes** to manage nodes. Select a node from the dropdown to edit it, or click **Add Node**.
+
+---
+
+## Add, position, duplicate, and remove
+
+- **Add Node** — creates a node in the centre of the canvas.
+- **Move** — in edit mode, click and drag the node on the canvas.
+- **Duplicate** — copies a node (including its colors and icon) next to the original.
+- **Remove** — deletes the node and any links attached to it.
+
+!!! tip "Snap to a grid"
+    Enable **Panel Options → Grid** to make dragging snap to a fixed grid for tidy alignment.
+
+---
+
+## Label
+
+The **Label** is the text shown on/under the node. Leave it blank (and use an icon) for an icon-only node. You can also hide the label with **Show Label** while keeping the node interactive.
+
+---
+
+## Icons
+
+Under a node's options you can choose an **icon**:
+
+- **Preset icons** — Cisco, generic networking, database, and computer icon sets are bundled.
+- **Custom Icon** — choose *Custom Icon* and paste an image URL.
+
+!!! warning "Custom icon URLs are validated"
+    Only safe relative Grafana paths (e.g. `public/img/...`) and `http`/`https` URLs are allowed. `javascript:`, `data:`, `file:`, and similar schemes are rejected for security.
+
+Icon options:
+
+| Option | Purpose |
+|---|---|
+| **Size (W×H)** | Icon dimensions. Toggle **lock aspect ratio** to scale proportionally. |
+| **Padding** | Space between the icon and the label/box. |
+| **Draw Inside** | Draw the icon inside the node rectangle instead of above the label. |
+| **Use Icon Boundary For Links** | Attach links to the icon edge rather than the text box. |
+
+---
+
+## Dashboard link
+
+Give a node a **Dashboard Link** to make it clickable in view mode — clicking navigates to that URL (e.g. a device detail dashboard `/d/abc/switch-detail`).
+
+- **Open Link in Same Tab** — navigate in the current tab (`_self`) instead of a new one.
+
+!!! warning "URLs are validated and opened safely"
+    Node dashboard links are sanitized (relative Grafana paths and `http`/`https` only) and opened with `noopener,noreferrer`.
+
+---
+
+## Status coloring (node health)
+
+Color a node based on a metric to show device health.
+
+Open the node's **Status** section:
+
+1. **Query** — pick the series whose value drives the color (e.g. `up`, CPU %, temperature).
+2. **StatusDown Color** — the color used when the value indicates "down".
+3. **Color Target** — apply the status color to the **Border**, **Background**, or **Both**.
+4. **Threshold Mappings** — add `value ≥ threshold → color` rules. The **highest matching threshold wins**. This overrides the default "value < 1 = down" rule and lets you color by CPU utilization, temperature, availability score, etc.
+
+**Example — CPU heat:** `0 → green`, `60 → yellow`, `85 → red`, Color Target = *Background*.
+
+---
+
+## Node tooltips (extra metrics)
+
+Show additional values when hovering a node (latency, packet loss, CPU, or any bound query).
+
+Open the node's **Tooltip** section and **Add Metric**. For each metric set:
+
+- **Label** — e.g. `Latency`, `Packet Loss`, `CPU`
+- **Query** — the series to read
+- **Units** — a unit formatter (e.g. seconds, percent, bytes)
+
+On hover, the node shows its label plus each metric and value. Values follow the panel's [Value Display Mode](panel-options.md#value-display-mode) and the [timeline slider](panel-options.md#timeline-slider).
+
+---
+
+## Advanced
+
+| Option | Purpose |
+|---|---|
+| **Constant Spacing** | Keep uniform spacing between multiple links on a side. |
+| **Compact Vertical Links** | Tighten vertically stacked links. |
+| **Use As Connection (BETA)** | Turn the node into a **VIA / waypoint** (a bend point on a link rather than a device). See [Links → VIAs](links.md#vias-waypoints). |
+
+---
+
+## Colors
+
+Each node has **Font**, **Background**, **Border**, and **StatusDown** colors. Use **Apply to All** to copy one node's colors to every node for a consistent theme.

--- a/website/docs/guide/panel-options.md
+++ b/website/docs/guide/panel-options.md
@@ -1,0 +1,92 @@
+# Panel Options
+
+Panel-level options apply to the whole weathermap. Open the panel options sidebar and look under **Panel** and **Link Options**.
+
+---
+
+## Background
+
+- **Color** — the canvas background color.
+- **Image** — set a background image by URL (floor plan, geographic map, building outline, network zones). Choose an **Image Fit** (contain / cover / auto).
+- **Move With Map** — when enabled, the background image is drawn *inside* the map canvas so it **pans and zooms together** with the nodes and links. When off (default), the image stays fixed like a wallpaper.
+
+!!! warning "Image URLs are validated"
+    Only relative Grafana paths and `http`/`https` URLs are allowed; unsafe schemes are rejected.
+
+---
+
+## Canvas size, zoom, and offset
+
+| Option | Purpose |
+|---|---|
+| **Viewbox Width / Height (px)** | The logical size of the drawing area. |
+| **Zoom Scale** | Current zoom level (also controlled by scroll — see [Interactions](interactions.md)). |
+| **View Offset X / Y** | Current pan offset. |
+| **Display Timestamp** | Show the time-range end timestamp in the corner. |
+
+---
+
+## Grid
+
+Enable **Grid** to snap node dragging to a fixed grid, set the **grid size**, and optionally show **guides**. Great for aligning large maps.
+
+---
+
+## Value Display Mode
+
+Controls how each metric is resolved from the data points **across the selected dashboard time range**:
+
+| Mode | Meaning |
+|---|---|
+| **Last** | The most recent data point (default). |
+| **Average** | Mean of all points in the range. |
+| **Min** | Smallest value in the range. |
+| **Max** | Largest value in the range. |
+| **95th Percentile** | 95th percentile over the range. |
+
+Use **Average / 95th Percentile** for capacity-planning views where a single-point snapshot is misleading; **Max** to catch peaks.
+
+---
+
+## Timeline Slider
+
+Enable **Timeline Slider** to add a scrubber at the bottom of the panel. Drag it to move through the selected time range and see **link values as they were at that moment** — the whole map updates retroactively.
+
+- A **timestamp label** shows the selected time.
+- The **Live** button returns to the latest/aggregate value.
+- Off by default; enabling it changes nothing until you scrub.
+
+Perfect for **incident retrospectives** (replay an outage), **trend analysis**, and comparing **peak vs. baseline** periods.
+
+!!! note "Scope"
+    The slider currently scrubs **link values**. Node status coloring follows the latest value.
+
+---
+
+## Default link units and decimals
+
+- **Default Link Units** — the unit formatter used by links that don't set their own.
+- **Link Value Decimal Places** — fixes decimal precision on link labels (blank = automatic).
+
+---
+
+## Coloring behavior
+
+| Option | Purpose |
+|---|---|
+| **Color Scale Mode** | Match thresholds by **percent** (current ÷ bandwidth) or by absolute **value**. |
+| **Gradient Color** | Blend the link color between its A and Z endpoint colors. |
+| **Dynamic Stroke** | Scale link stroke width with utilization (min/max width). |
+| **Flow Animation** | Animate the link's dashes in the direction of flow (with a speed setting). |
+
+---
+
+## Color scale / thresholds
+
+Define the **Color Scale** — a list of `threshold → color` stops. Depending on **Color Scale Mode**, thresholds are matched against utilization **percent** or the raw **value**. The legend at the bottom of the panel reflects these bands. Thresholds above 100% are supported for oversubscribed links.
+
+---
+
+## Tooltip settings
+
+Customize the hover tooltip: **font size**, **text/background colors**, **inbound/outbound line colors**, and whether the mini graph scales to bandwidth.

--- a/website/docs/guide/panel-options.md
+++ b/website/docs/guide/panel-options.md
@@ -50,7 +50,7 @@ Use **Average / 95th Percentile** for capacity-planning views where a single-poi
 
 ## Timeline Slider
 
-Enable **Timeline Slider** to add a scrubber at the bottom of the panel. Drag it to move through the selected time range and see **link values as they were at that moment** — the whole map updates retroactively.
+Enable **Timeline Slider** to add a scrubber at the bottom of the panel. Drag it to move through the selected time range and see **link values as they were at that moment** — the map's link values update retroactively.
 
 - A **timestamp label** shows the selected time.
 - The **Live** button returns to the latest/aggregate value.

--- a/website/docs/guide/use-cases.md
+++ b/website/docs/guide/use-cases.md
@@ -1,0 +1,103 @@
+# Use Cases & Scenarios
+
+End-to-end recipes that combine the options into real dashboards. Each assumes you've completed [Getting Started](getting-started.md).
+
+---
+
+## 1. WAN link utilization (two sites)
+
+**Goal:** show a core uplink between two sites, colored by utilization, with clear inbound/outbound labels.
+
+1. Add nodes `SW-CORE` and `BKB-CARPINA`.
+2. Add a link A=`SW-CORE`, Z=`BKB-CARPINA`.
+   - **A Side Query** = interface *bits sent*; **A Bandwidth #** = link capacity (e.g. `20000000000`).
+   - **Z Side Query** = interface *bits received*; **Z Bandwidth #** = same capacity.
+3. Set **A Direction Label** = `Outbound`, **Z Direction Label** = `Inbound`.
+4. Add **Port Labels** (e.g. `Eth-Trunk12`) so the physical interface is visible.
+5. Color scale: `0→green, 50→yellow, 80→orange, 95→red` with **Color Scale Mode = percent**.
+
+Hovering the link shows usage, bandwidth, throughput %, and a mini graph.
+
+---
+
+## 2. Capacity planning (avg / 95th percentile)
+
+**Goal:** compare typical vs. peak load over a period, not just the instantaneous value.
+
+1. Build the map as in scenario 1.
+2. Set the dashboard time range to the period of interest (e.g. *last 30 days*).
+3. **Panel Options → Value Display Mode:**
+   - Choose **95th Percentile** to size links for sustained peaks, or **Average** for typical load.
+   - Switch to **Max** to spot the worst-case moment.
+4. Compare against your color-scale bands to find links that are hot at p95.
+
+---
+
+## 3. Incident retrospective (timeline replay)
+
+**Goal:** replay how the network looked during an outage window.
+
+1. Enable **Panel Options → Timeline Slider**.
+2. Set the dashboard time range to span the incident.
+3. In view mode, **drag the slider** to the moment the incident began and step forward — link colors and values update to that time.
+4. Use the timestamp label to correlate with alerts/logs. Press **Live** to return to now.
+
+---
+
+## 4. Data-center floor plan (background follows the map)
+
+**Goal:** overlay devices on a floor plan or rack layout that zooms/pans with the map.
+
+1. **Panel Options → Background → Image**: paste the floor-plan image URL; set **Image Fit** to `contain`.
+2. Enable **Move With Map** so the image scales and pans with the nodes.
+3. Place nodes on top of the plan at their physical locations; use the **Grid** for alignment.
+4. Add links to show inter-rack or inter-room traffic.
+
+---
+
+## 5. Multi-hop path with VIAs
+
+**Goal:** draw a link that routes around other elements or represents a multi-hop path.
+
+1. Create the A and Z nodes and a direct link.
+2. In edit mode, **double-click** the link to drop a VIA, then **drag** it to the bend point.
+3. Repeat to add more bends. Use **Arrow Meeting Point (%)** to place the direction arrows on the most meaningful segment.
+4. **Right-click** any VIA to remove it later.
+
+---
+
+## 6. Device health overview (status coloring)
+
+**Goal:** at-a-glance device health without reading numbers.
+
+1. For each node, open **Status** and set a **Query** (e.g. `up`, CPU %, temperature).
+2. Add **Threshold Mappings** (`value ≥ threshold → color`) and pick a **Color Target** (Border / Background / Both).
+3. Optionally add **node Tooltip** metrics (latency, packet loss, CPU) so hovering shows the detail behind the color.
+
+---
+
+## 7. Parallel links between the same nodes
+
+**Goal:** show a LAG/port-channel or redundant paths as separate lines.
+
+1. Add multiple links between the same two nodes.
+2. Give each a different **Link Offset (parallel links)** value (e.g. `-8`, `0`, `+8`) so they spread apart.
+3. Set each link's own query so the members are individually visible.
+
+---
+
+## 8. Clickable drill-down map
+
+**Goal:** click a device to open its detailed dashboard.
+
+1. Give each node a **Dashboard Link** (e.g. `/d/abc/switch-detail?var-host=$host`).
+2. Use `${var}` template variables in labels, queries, and links for dynamic, reusable maps.
+3. In view mode, clicking the node navigates to the target (safely, in a new tab by default).
+
+---
+
+## Tips that apply everywhere
+
+- **Template variables** (`$var`, `${var}`) are resolved at draw time in labels, queries, status queries, dashboard links, and bandwidth queries — build one panel that serves many sites.
+- **Export SVG/JSON** from the Export section to share diagrams or move a map between panels.
+- Keep series **display names unique and readable** — that's how weathermap matches queries to links/nodes.

--- a/website/docs/guide/use-cases.md
+++ b/website/docs/guide/use-cases.md
@@ -10,8 +10,8 @@ End-to-end recipes that combine the options into real dashboards. Each assumes y
 
 1. Add nodes `SW-CORE` and `BKB-CARPINA`.
 2. Add a link A=`SW-CORE`, Z=`BKB-CARPINA`.
-   - **A Side Query** = interface *bits sent*; **A Bandwidth #** = link capacity (e.g. `20000000000`).
-   - **Z Side Query** = interface *bits received*; **Z Bandwidth #** = same capacity.
+   - **A Side Query** = the outbound direction A→Z — `SW-CORE`'s interface *bits sent*; **A Bandwidth #** = link capacity (e.g. `20000000000`).
+   - **Z Side Query** = the reverse direction Z→A. Use either `BKB-CARPINA`'s *bits sent* **or** `SW-CORE`'s *bits received* (both represent Z→A) — not `BKB-CARPINA`'s *bits received*, which is the same A→Z direction as the A side; **Z Bandwidth #** = same capacity.
 3. Set **A Direction Label** = `Outbound`, **Z Direction Label** = `Inbound`.
 4. Add **Port Labels** (e.g. `Eth-Trunk12`) so the physical interface is visible.
 5. Color scale: `0→green, 50→yellow, 80→orange, 95→red` with **Color Scale Mode = percent**.

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -134,7 +134,7 @@ By default, the panel will start completely blank, looking something like this:
 - You probably want this number in `bits/sec`, unless your links are expecting something else (each link has customizable units, and default units are customizable in the global settings for the panel).
 - The weathermap will always choose the most recent data point available. If you want your links graphs to have data, make sure your queries are ranges and not "Instant" queries, as this will mean there is no data to show on each graph.
 - Once you have added a query in the panel editor, you can can see all queries and select one from the dropdown in the Query fields of the links.
-- See the [FAQ](/faq) or [Github issues](https://github.com/allamiro/grafana-network-weathermap-ng/issues) if you are having issues adding data (especially Zabbix datasource users).
+- See the [FAQ](faq.md) or [Github issues](https://github.com/allamiro/grafana-network-weathermap-ng/issues) if you are having issues adding data (especially Zabbix datasource users).
 
 **PLEASE NOTE:** _Queries with the exact same labels will be considered as such. If you have multiple queries and are unable to select the one that you want, double check to make sure it is labeled uniquely._
 

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -11,6 +11,19 @@ Maintained by <a href="https://github.com/allamiro">Tamir Suliman</a> — Plugin
 
 ---
 
+## 📖 Documentation
+
+New here? Start with the step-by-step guide:
+
+- **[Getting Started](guide/getting-started.md)** — from an empty panel to a live traffic map in ~10 minutes
+- **[Nodes (Devices)](guide/nodes.md)** — labels, icons, status coloring, node tooltips, dashboard links
+- **[Links](guide/links.md)** — queries & bandwidth, units, direction labels, port labels, parallel links, VIAs
+- **[Panel Options](guide/panel-options.md)** — background image, value display modes, timeline slider, color scale, tooltips
+- **[Interactions & Editing](guide/interactions.md)** — pan/zoom/select on Linux, Windows & macOS; VIA editing; export
+- **[Use Cases](guide/use-cases.md)** — capacity planning, incident retros, floor plans, multi-hop paths, and more
+
+---
+
 ## About This Fork
 
 This plugin is a continuation of the original [knightss27/grafana-network-weathermap](https://github.com/knightss27/grafana-network-weathermap) which was archived in 2023. The goal of this fork is to keep the plugin working with current Grafana releases and to fix outstanding bugs.

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -30,13 +30,13 @@ markdown_extensions:
       permalink: true
 nav:
   - Home: index.md
-  - Getting Started: guide/getting-started.md
-  - User Guide:
+  - Tutorial:
+      - Getting Started: guide/getting-started.md
       - Nodes (Devices): guide/nodes.md
       - Links: guide/links.md
       - Panel Options: guide/panel-options.md
       - Interactions & Editing: guide/interactions.md
-  - Use Cases: guide/use-cases.md
+      - Use Cases: guide/use-cases.md
   - Customization: customization.md
   - Reference: reference.md
   - FAQ: faq.md

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -21,8 +21,22 @@ theme:
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - tables
+  - toc:
+      permalink: true
 nav:
   - Home: index.md
+  - Getting Started: guide/getting-started.md
+  - User Guide:
+      - Nodes (Devices): guide/nodes.md
+      - Links: guide/links.md
+      - Panel Options: guide/panel-options.md
+      - Interactions & Editing: guide/interactions.md
+  - Use Cases: guide/use-cases.md
   - Customization: customization.md
   - Reference: reference.md
   - FAQ: faq.md


### PR DESCRIPTION
Adds a full user guide to the docs site (mkdocs-material) covering every option, plus scenario walkthroughs — from creating a panel to advanced use cases.

## New pages (`website/docs/guide/`)
- **Getting Started** — empty panel → live traffic map, step by step (queries, nodes, links, color scale, save).
- **Nodes (Devices)** — labels, icons (+ custom icon URLs), status coloring & thresholds, node tooltips, dashboard links, advanced, colors.
- **Links** — A/Z sides, queries & bandwidth, units/decimals, label offset, port labels, **direction labels**, **arrow meeting point**, **parallel links**, link status, tooltip extra metrics, stroke/arrows, **VIAs**.
- **Panel Options** — background image (+ **Move With Map**), grid, **Value Display Modes** (last/avg/min/max/p95), **Timeline Slider**, coloring behavior, color scale/thresholds, tooltip settings.
- **Interactions & Editing** — pan/zoom/select gesture table for **Linux, Windows, and macOS**; VIA canvas editing (double-click add / drag / right-click delete); SVG/JSON export.
- **Use Cases** — WAN utilization, capacity planning (avg/p95), incident retrospective (timeline replay), floor-plan background, multi-hop VIAs, device health, parallel links, clickable drill-down.

## Also
- Adds a **Documentation** quick-links block to the home page.
- Wires everything into the mkdocs `nav` (Getting Started, a "User Guide" section, Use Cases) and enables the markdown extensions the pages use (admonition, details, superfences, tables, toc).

## Verification
- Built locally with `mkdocs build --strict` → success; no warnings on the new pages.
- The docs workflow auto-deploys to GitHub Pages on merge to `main` (paths: `website/**`).

Docs-only change — no plugin code touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a comprehensive user guide with step-by-step setup and real-world scenarios, consolidates docs under a new Tutorial menu, and expands the FAQ with practical how‑tos and security/version notes. Updates nav and home quick-links; docs-only change.

- **New Features**
  - New guide pages: Getting Started, Nodes, Links, Panel Options, Interactions & Editing, Use Cases.
  - Navigation consolidated under a single “Tutorial” menu; added Documentation quick-links on the home page.
  - Enabled markdown extensions in `mkdocs.yml` (admonition, details, superfences, tables, toc); verified with `mkdocs build --strict`.

- **Bug Fixes**
  - FAQ expanded and corrected: Grafana min version is 11, plus how‑tos (value display modes, timeline slider, VIAs, direction labels), macOS gestures, unsigned/provenance, and URL safety, with links into the guide.
  - Guide tweaks: clarify WAN Z-side must be the reverse (Z→A) direction; note timeline scrubbing updates link values only.
  - Fixed a stale `/faq` link on the home page.

<sup>Written for commit bf160f4cb71ccaf14408e284e3de30614366edf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

