### PR TITLE
fix(#162): Status Color Target radio group selection state and duplicate form field ids

### DIFF
--- a/jest-polyfills.js
+++ b/jest-polyfills.js
@@ -2,3 +2,14 @@
 const { TextEncoder, TextDecoder } = require('util');
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
+
+// Stub IntersectionObserver for jsdom (required by @grafana/ui ScrollContainer,
+// rendered by Select menus)
+global.IntersectionObserver = class IntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+};

--- a/src/forms/ColorForm.test.tsx
+++ b/src/forms/ColorForm.test.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { StandardEditorProps } from '@grafana/data';
+import { ColorForm } from './ColorForm';
+import { Weathermap } from 'types';
+import { getData, theme } from '../testData';
+
+// Stateful harness: the editor only re-renders when onChange delivers a new
+// options object, which is exactly the behavior under test (#162).
+const Harness = ({ initial, onChangeSpy }: { initial: Weathermap; onChangeSpy: jest.Mock }) => {
+  const [wm, setWm] = useState(initial);
+  const props = {
+    value: wm,
+    onChange: (v: Weathermap) => {
+      onChangeSpy(v);
+      setWm(v);
+    },
+    context: { data: [] },
+    item: { settings: { placeholder: '' } },
+  } as unknown as StandardEditorProps<Weathermap, { placeholder: string }>;
+  return <ColorForm {...props} />;
+};
+
+test('scale mode keeps its selected indicator after changing (#162)', () => {
+  const spy = jest.fn();
+  const initial = getData(theme);
+  render(<Harness initial={initial} onChangeSpy={spy} />);
+
+  expect(screen.getByRole('radio', { name: 'Percentage' })).toBeChecked();
+
+  const absolute = screen.getByRole('radio', { name: 'Absolute Value' });
+  fireEvent.click(absolute);
+
+  expect(absolute).toBeChecked();
+  expect(screen.getByRole('radio', { name: 'Percentage' })).not.toBeChecked();
+  // The editor must receive a new object, not a mutation of the rendered one,
+  // or the options pane can skip re-rendering on reference equality.
+  expect(spy.mock.calls[0][0]).not.toBe(initial);
+  expect(spy.mock.calls[0][0].settings.colorScaleMode).toBe('value');
+});
+
+test('scale mode radios have stable, deterministic ids', () => {
+  render(<Harness initial={getData(theme)} onChangeSpy={jest.fn()} />);
+
+  expect(screen.getByRole('radio', { name: 'Percentage' })).toHaveAttribute(
+    'id',
+    'option-percent-nwm-color-scale-mode'
+  );
+  expect(screen.getByRole('radio', { name: 'Absolute Value' })).toHaveAttribute(
+    'id',
+    'option-value-nwm-color-scale-mode'
+  );
+});

--- a/src/forms/ColorForm.tsx
+++ b/src/forms/ColorForm.tsx
@@ -71,9 +71,9 @@ export const ColorForm = (props: Props) => {
   const currentMode = value.settings.colorScaleMode ?? 'percent';
 
   const handleModeChange = (mode: 'percent' | 'value') => {
-    let weathermap: Weathermap = value;
-    weathermap.settings.colorScaleMode = mode;
-    onChange(weathermap);
+    // Clone instead of mutating props.value so the editor re-renders and the
+    // selected indicator follows (#162).
+    onChange({ ...value, settings: { ...value.settings, colorScaleMode: mode } });
   };
 
   const thresholdLabel = currentMode === 'value' ? 'Value' : '%';
@@ -91,7 +91,15 @@ export const ColorForm = (props: Props) => {
       </h6>
       <div className={styles.modeRow}>
         <span className={styles.modeLabel}>Scale Mode</span>
-        <RadioButtonGroup options={scaleModeOptions} value={currentMode} onChange={handleModeChange} size="sm" />
+        {/* Stable id: without it @grafana/ui regenerates the radio input ids on
+            every render, breaking label/input pairing and duplicating ids (#162). */}
+        <RadioButtonGroup
+          id="nwm-color-scale-mode"
+          options={scaleModeOptions}
+          value={currentMode}
+          onChange={handleModeChange}
+          size="sm"
+        />
       </div>
       {editedPercents.map((threshold, i) => (
         <Input

--- a/src/forms/NodeForm.test.tsx
+++ b/src/forms/NodeForm.test.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { StandardEditorProps } from '@grafana/data';
+import { NodeForm } from './NodeForm';
+import { Weathermap } from 'types';
+import { getData, theme } from '../testData';
+
+// Stateful harness: the editor only re-renders when onChange delivers a new
+// options object, which is exactly the behavior under test (#162).
+const Harness = ({ initial, onChangeSpy }: { initial: Weathermap; onChangeSpy: jest.Mock }) => {
+  const [wm, setWm] = useState(initial);
+  const props = {
+    value: wm,
+    onChange: (v: Weathermap) => {
+      onChangeSpy(v);
+      setWm(v);
+    },
+    context: { data: [] },
+    item: { settings: { placeholder: '' } },
+  } as unknown as StandardEditorProps<Weathermap, { placeholder: string }>;
+  return <NodeForm {...props} />;
+};
+
+const openStatusSection = async () => {
+  // Pick "Node A" in the react-select node picker, then expand Status.
+  const picker = screen.getAllByRole('combobox')[0];
+  fireEvent.keyDown(picker, { key: 'ArrowDown' });
+  fireEvent.click(await screen.findByText('Node A'));
+  fireEvent.click(screen.getByText('Status'));
+};
+
+test('status color target keeps its selected indicator after changing (#162)', async () => {
+  const spy = jest.fn();
+  const initial = getData(theme);
+  render(<Harness initial={initial} onChangeSpy={spy} />);
+  await openStatusSection();
+
+  expect(screen.getByRole('radio', { name: 'Border' })).toBeChecked();
+
+  const background = screen.getByRole('radio', { name: 'Background' });
+  fireEvent.click(background);
+
+  expect(background).toBeChecked();
+  expect(screen.getByRole('radio', { name: 'Border' })).not.toBeChecked();
+  // The editor must receive a new object, not a mutation of the rendered one,
+  // or the options pane can skip re-rendering on reference equality.
+  const updated = spy.mock.calls[0][0];
+  expect(updated).not.toBe(initial);
+  const nodeA = updated.nodes.find((n: { label: string }) => n.label === 'Node A');
+  expect(nodeA.nodeStatusColorTarget).toBe('background');
+});
+
+test('status color target radios have stable per-node ids (#162)', async () => {
+  const initial = getData(theme);
+  render(<Harness initial={initial} onChangeSpy={jest.fn()} />);
+  await openStatusSection();
+
+  const nodeA = initial.nodes.find((n) => n.label === 'Node A')!;
+  for (const target of ['border', 'background', 'both']) {
+    const id = `option-${target}-nwm-status-color-target-${nodeA.id}`;
+    expect(document.getElementById(id)).toBeInTheDocument();
+  }
+});

--- a/src/forms/NodeForm.tsx
+++ b/src/forms/NodeForm.tsx
@@ -535,6 +535,10 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                   <p style={{ margin: '8px 0 4px', fontSize: '12px', fontWeight: 600 }}>Color Target</p>
                   <div style={{ marginBottom: '8px' }}>
                     <RadioButtonGroup
+                      // Stable id: without it @grafana/ui regenerates the radio
+                      // input ids on every render, breaking label/input pairing
+                      // and duplicating ids across groups (#162).
+                      id={`nwm-status-color-target-${node.id}`}
                       options={[
                         { label: 'Border', value: 'border' },
                         { label: 'Background', value: 'background' },
@@ -542,9 +546,12 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                       ] as Array<{ label: string; value: 'border' | 'background' | 'both' }>}
                       value={node.nodeStatusColorTarget ?? 'border'}
                       onChange={(v) => {
-                        let weathermap: Weathermap = value;
-                        weathermap.nodes[i].nodeStatusColorTarget = v;
-                        onChange(weathermap);
+                        // Clone instead of mutating props.value so the editor
+                        // re-renders and the selected indicator follows (#162).
+                        onChange({
+                          ...value,
+                          nodes: value.nodes.map((n, idx) => (idx === i ? { ...n, nodeStatusColorTarget: v } : n)),
+                        });
                       }}
                     />
                   </div>


### PR DESCRIPTION
Part 2 of 3 for #162 (Grafana plugin review, v1.5.6 required changes) — fixes the Status Color Target control losing its selected indicator when switching between Border / Background / Both, and the duplicate form field ids reported by the browser during the same editor session.

## Root cause (two compounding problems)

1. **No `id` prop on `RadioButtonGroup`.** Grafana's `RadioButtonGroup` computes `internalId = id ?? uniqueId('radiogroup-')` on **every render**, while the radio `name` is frozen from the first render via a ref. Without an explicit `id`, the input ids churn across renders and label→input (`htmlFor`) pairings go stale — producing the duplicate-id warnings and broken selected-state rendering.
2. **In-place mutation of the options prop.** The `onChange` handlers mutated `props.value` and passed the **same object reference** back (`weathermap.nodes[i].nodeStatusColorTarget = v; onChange(weathermap)`). The panel applies the change (it reads the mutated object), but the options pane can skip re-rendering on reference equality — so the controlled radios never display the new selection. This matches the review's observation exactly ("the selected behavior appears to affect the panel, but the editor no longer shows which value is selected").

## Changes

- `NodeForm` Status Color Target: stable per-node id (`nwm-status-color-target-<node.id>`), immutable update via clone.
- `ColorForm` Scale Mode: stable id (`nwm-color-scale-mode`), immutable update via clone. (These are the only two `RadioButtonGroup` usages in the plugin.)
- Regression tests for both groups using a stateful harness that only re-renders on a *new* options object — asserting the indicator follows the selection, the previous option unchecks, onChange delivers a new reference, and ids are deterministic/per-node.
- jsdom `IntersectionObserver` stub in `jest-polyfills.js` (needed by the Select menu's ScrollContainer in the new NodeForm test).

## Verification

- `tsc --noEmit` clean, `eslint` clean, full jest suite 57/57 passing.
- Manual retest path (as in the review): in the node editor, switch Status Color Target between Border/Background/Both — the selected indicator persists; no duplicate form field id warnings in the browser console.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Status Color Target and Color Scale Mode radio groups so the selected state persists and duplicate form field id warnings are gone. Addresses #162 from the Grafana plugin review.

- **Bug Fixes**
  - Set stable ids on `@grafana/ui` `RadioButtonGroup` (per-node for Status Color Target, fixed id for Color Scale Mode) to stop regenerated input ids.
  - Use immutable updates in `onChange` handlers so the editor re-renders and shows the correct selection.
  - Add regression tests for both groups with a stateful harness to verify new object references and deterministic ids.
  - Stub `IntersectionObserver` in `jest-polyfills.js` for Select menu rendering in tests.

<sup>Written for commit 9a2e89073a708eec6e49189202ca14a8c87a09b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

