### PR TITLE
chore(release): bump version to 1.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.5.9](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.9) (2026-07-02)
+
+Addresses all required changes from the Grafana plugin catalog review of v1.5.6 ([#162](https://github.com/allamiro/grafana-network-weathermap-ng/issues/162)).
+
+### Bug Fixes
+
+* **panel-editor**: opening the panel editor on dashboards saved before options schema v14 no longer throws `Cannot read properties of undefined (reading 'backgroundColor')` on Grafana 11.0.0 — the editor forms now render the migrated options directly instead of waiting for the migration to round-trip through `onChange` ([#162](https://github.com/allamiro/grafana-network-weathermap-ng/issues/162), PR [#163](https://github.com/allamiro/grafana-network-weathermap-ng/pull/163))
+* **node-editor**: the Status Color Target control keeps its selected indicator when switching between Border, Background, and Both, and the browser no longer reports duplicate form field ids — radio groups now use stable deterministic ids and immutable option updates ([#162](https://github.com/allamiro/grafana-network-weathermap-ng/issues/162), PR [#164](https://github.com/allamiro/grafana-network-weathermap-ng/pull/164))
+
+### Documentation
+
+* **catalog-readme**: new user-focused README at `src/README.md` shown in the Grafana plugin catalog — what the plugin does, use cases, setup walkthrough, and screenshots; the root README remains the GitHub-facing document ([#162](https://github.com/allamiro/grafana-network-weathermap-ng/issues/162), PR [#165](https://github.com/allamiro/grafana-network-weathermap-ng/pull/165))
+
 ## [1.5.8](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.8) (2026-07-02)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamirsuliman-weathermap-panel",
-      "version": "1.5.8",
+      "version": "1.5.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Release 1.5.9 — addresses all required changes from the Grafana catalog review of v1.5.6 (#162):

- fix(#162): panel editor crash on pre-v14 dashboards (#163)
- fix(#162): Status Color Target selection state + duplicate form field ids (#164)
- docs(#162): catalog-focused README at src/README.md (#165)

Retested on Grafana 11.0.0 with the bundled test dashboard: editor opens without errors, Status Color Target keeps its selection across Border/Background/Both, no duplicate form field ids. Plugin validator clean on the packaged archive (only the expected unsigned-plugin warning).

After merge: `scripts/release.sh tag 1.5.9` pushes the tag and the release workflow publishes the GitHub release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release 1.5.9 to ship Grafana catalog review fixes from #162 and add a catalog-focused README. Bumps `package.json`/`package-lock.json` to 1.5.9 and updates the changelog.

- **Bug Fixes**
  - Panel editor no longer crashes on dashboards saved before options schema v14 (Grafana 11).
  - Status Color Target keeps its selection across Border/Background/Both and removes duplicate form field ids.

<sup>Written for commit 0d2af5a09879fb92e08f6266248e196f8cc57285. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

