### PR TITLE
fix(#167): explicit ids on bare form controls to prevent Grafana 13 id collisions

### DIFF
--- a/src/forms/ColorForm.test.tsx
+++ b/src/forms/ColorForm.test.tsx
@@ -51,3 +51,17 @@ test('scale mode radios have stable, deterministic ids', () => {
     'option-value-nwm-color-scale-mode'
   );
 });
+
+test('threshold inputs have explicit unique ids (#167)', () => {
+  const initial = getData(theme);
+  initial.scale = [
+    { percent: 0, color: '#73BF69' },
+    { percent: 50, color: '#C4162A' },
+  ];
+  render(<Harness initial={initial} onChangeSpy={jest.fn()} />);
+
+  // Without explicit ids, Grafana 13's options-pane Field context assigns
+  // every bare control the options-item id, producing duplicate ids.
+  expect(document.getElementById('nwm-scale-threshold-0')).toBeInTheDocument();
+  expect(document.getElementById('nwm-scale-threshold-1')).toBeInTheDocument();
+});

--- a/src/forms/ColorForm.tsx
+++ b/src/forms/ColorForm.tsx
@@ -103,6 +103,10 @@ export const ColorForm = (props: Props) => {
       </div>
       {editedPercents.map((threshold, i) => (
         <Input
+          // Explicit id: without one, Grafana 13's options-pane Field context
+          // assigns every bare control the options-item id, producing
+          // duplicate form field ids (#167).
+          id={`nwm-scale-threshold-${i}`}
           className={styles.item}
           type="number"
           step="0.0001"

--- a/src/forms/LinkForm.tsx
+++ b/src/forms/LinkForm.tsx
@@ -221,6 +221,10 @@ export const LinkForm = (props: Props) => {
         Links
       </h6>
       <Select
+        // Explicit inputId: without one, Grafana 13's options-pane Field
+        // context assigns every bare control the options-item id, producing
+        // duplicate form field ids (#167).
+        inputId="nwm-link-picker"
         onChange={(v) => {
           setCurrentLink(v as Link);
         }}

--- a/src/forms/NodeForm.tsx
+++ b/src/forms/NodeForm.tsx
@@ -289,6 +289,10 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
         Nodes
       </h6>
       <Select
+        // Explicit inputId: without one, Grafana 13's options-pane Field
+        // context assigns every bare control the options-item id, producing
+        // duplicate form field ids (#167).
+        inputId="nwm-node-picker"
         onChange={(v) => {
           setCurrentNode(v as unknown as Node);
         }}
@@ -375,6 +379,9 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
               <InlineFieldRow className={styles.inlineRow}>
                 <ControlledCollapse label="Icon">
                   <Select
+                    // Explicit inputId: avoids Grafana 13 options-pane id
+                    // collisions on bare controls (#167).
+                    inputId={`nwm-node-icon-${node.id}`}
                     onChange={(v) => {
                       handleIconChange(v ? v.value : undefined, i);
                     }}

--- a/src/forms/WeathermapBuilder.test.tsx
+++ b/src/forms/WeathermapBuilder.test.tsx
@@ -36,6 +36,15 @@ test('renders the editor for pre-v14 weathermaps without crashing (#162)', () =>
   expect(migrated.settings.scale).toBeDefined();
 });
 
+test('node and link pickers have explicit unique input ids (#167)', () => {
+  renderBuilder(JSON.parse(JSON.stringify(legacyWeathermap)));
+
+  // Without explicit ids, Grafana 13's options-pane Field context assigns
+  // every bare control the options-item id, producing duplicate ids.
+  expect(document.getElementById('nwm-node-picker')).toBeInTheDocument();
+  expect(document.getElementById('nwm-link-picker')).toBeInTheDocument();
+});
+
 test('initializes and renders the default weathermap when no value is saved', () => {
   const onChange = renderBuilder(undefined);
 


### PR DESCRIPTION
Fixes #167.

Grafana 13's new options-pane Field context assigns the options-item id (`weathermapEditor`) to every form control inside a custom editor that lacks an explicit id — producing 8 duplicate ids. Exactly four controls in the plugin are bare (not wrapped in `InlineField`, which auto-assigns ids):

- Nodes picker `Select` → `inputId="nwm-node-picker"`
- Links picker `Select` → `inputId="nwm-link-picker"`
- per-node Icon `Select` → `inputId={`nwm-node-icon-${node.id}`}` (node ids are always present: required by the `Node` type, assigned by `generateBasicNode` via uuid, and backfilled by migration for legacy dashboards)
- Color Scale threshold `Input`s → `id={`nwm-scale-threshold-${i}`}`

All other `Select`/`Input` usages are `InlineField`-wrapped and already receive unique ids. No behavior change on Grafana 11/12 (these controls previously had no id at all), so no version conditionals are needed.

## Verification

In-editor Playwright retest against the bundled test dashboard, per version:

| Check | 11.0.0 | 12.0.0 | 12.3.8 | 13.1.0 |
|---|---|---|---|---|
| Editor opens on pre-v14 dashboard without TypeError | ✅ | ✅ | ✅ | ✅ |
| Tooltip/Scale editor sections render | ✅ | ✅ | ✅ | ✅ |
| Status Color Target indicator tracks selection | ✅ | ✅ | ✅ | ✅ |
| No duplicate form field ids (incl. Icon collapse open) | ✅ | ✅ | ✅ | ✅ |

Unit tests assert the ids render (`WeathermapBuilder.test.tsx`, `ColorForm.test.tsx`). `tsc`, eslint, and the full jest suite (62/62) pass; production build succeeds.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit, unique ids to bare editor form controls to prevent duplicate id collisions in Grafana 13’s options pane. Fixes #167 with no behavior change on Grafana 11/12.

- Bug Fixes
  - Node picker Select → inputId: `nwm-node-picker`
  - Link picker Select → inputId: `nwm-link-picker`
  - Per-node Icon Select → inputId: `nwm-node-icon-${node.id}`
  - Color Scale threshold Inputs → id: `nwm-scale-threshold-${i}`

<sup>Written for commit 109c430428387fcaa5d6153390cb1b298d3fde06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

