### PR TITLE
chore(release): bump version to 1.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.5.10](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.10) (2026-07-02)
+
+### Bug Fixes
+
+* **editor-form-ids**: explicit unique ids on the node/link picker Selects, the per-node icon Select, and the color-scale threshold inputs. Grafana 13's options pane assigns the options-item id to bare controls, which produced duplicate form field ids on Grafana 13; no behavior change on Grafana 11/12. Verified in-editor on Grafana 11.0.0, 12.0.0, 12.3.8, and 13.1.0 ([#167](https://github.com/allamiro/grafana-network-weathermap-ng/issues/167), PR [#168](https://github.com/allamiro/grafana-network-weathermap-ng/pull/168))
+
 ## [1.5.9](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.9) (2026-07-02)
 
 Addresses all required changes from the Grafana plugin catalog review of v1.5.6 ([#162](https://github.com/allamiro/grafana-network-weathermap-ng/issues/162)).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamirsuliman-weathermap-panel",
-      "version": "1.5.9",
+      "version": "1.5.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Release 1.5.10 — adds the Grafana 13 duplicate-form-field-id fix (#167, PR #168) on top of 1.5.9's catalog-review fixes, so the submission artifact is verified green across Grafana 11.0.0, 12.0.0, 12.3.8, and 13.1.0.

After merge: `scripts/release.sh tag 1.5.10`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release 1.5.10 fixes duplicate form field IDs in the panel editor on Grafana 13 by adding unique IDs to node/link pickers, the per-node icon select, and color-scale threshold inputs. Verified on Grafana 11.0.0, 12.0.0, 12.3.8, and 13.1.0; no behavior change on Grafana 11/12.

<sup>Written for commit ac13fa0d01272d55bd897cefb50222c237143f21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

