### PR TITLE
chore: credit author in plugin description (visualization picker text)

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -3,7 +3,7 @@
   "name": "Network Weathermap NG",
   "id": "tamirsuliman-weathermap-panel",
   "info": {
-    "description": "Next-generation, actively maintained network weathermap panel. A continuation and fork of the deprecated Network Weathermap plugin, updated for modern Grafana.",
+    "description": "Next-generation, actively maintained network weathermap by Tamir Suliman. A continuation and fork of the deprecated Network Weathermap plugin, updated for modern Grafana.",
     "author": {
       "name": "Tamir Suliman",
       "url": "https://github.com/allamiro"


### PR DESCRIPTION
The visualization picker card shows `info.description` from `src/plugin.json` — the `info.author` field is not displayed there. Add the author credit to the description so the picker reads:

> Next-generation, actively maintained network weathermap **by Tamir Suliman**. A continuation and fork of the deprecated Network Weathermap plugin, updated for modern Grafana.

Note: this only reaches the Grafana catalog/marketplace with the next released zip — worth folding into the next version bump (or a quick v1.5.11 before resubmitting, if you want it visible to the reviewer).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add "by Tamir Suliman" to the plugin description so the visualization picker shows author credit. Metadata-only change in `src/plugin.json`; visible in the Grafana catalog after the next release.

<sup>Written for commit c3ae2c9e6a8b9979813f19a003d198da2feed38b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

