### PR TITLE
chore: author attribution — NOTICE (shipped in zip), CITATION.cff, LICENSE copyright

### DIFF
--- a/.config/webpack/webpack.config.ts
+++ b/.config/webpack/webpack.config.ts
@@ -145,6 +145,9 @@ const config = async (env): Promise<Configuration> => ({
         { from: hasReadme() ? 'README.md' : '../README.md', to: '.', force: true },
         { from: 'plugin.json', to: '.' },
         { from: '../LICENSE', to: '.' },
+        // Apache-2.0 §4(d): the NOTICE file's attribution must travel with
+        // redistributions, so ship it inside the plugin archive.
+        { from: '../NOTICE', to: '.' },
         { from: '../CHANGELOG.md', to: '.', force: true },
         { from: '**/*.json', to: '.' }, // TODO<Add an error for checking the basic structure of the repo>
         { from: '**/*.svg', to: '.', noErrorOnMissing: true }, // Optional

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,12 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+type: software
+title: "Grafana Network Weathermap NG"
+authors:
+  - family-names: "Suliman"
+    given-names: "Tamir"
+repository-code: "https://github.com/allamiro/grafana-network-weathermap-ng"
+url: "https://allamiro.github.io/grafana-network-weathermap-ng/"
+license: Apache-2.0
+version: 1.5.11
+date-released: "2026-07-03"

--- a/LICENSE
+++ b/LICENSE
@@ -187,6 +187,7 @@
       identification within third-party archives.
 
    Copyright 2022 Seth Knights
+   Copyright 2026 Tamir Suliman
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,9 @@
+Grafana Network Weathermap NG
+Copyright 2026 Tamir Suliman (https://github.com/allamiro)
+
+This product is a continuation and modernization of the Network Weathermap
+panel plugin (https://github.com/knightss27/grafana-network-weathermap),
+Copyright 2022 Seth Knights, licensed under the Apache License, Version 2.0.
+
+Bundled world-map background for the demo dashboards is derived from
+"BlankMap-World-Equirectangular.svg" (Wikimedia Commons, public domain).

--- a/README.md
+++ b/README.md
@@ -117,6 +117,21 @@ Contributions are welcome. Please open an issue first to discuss significant cha
 
 **Tamir Suliman** — [allamiro@gmail.com](mailto:allamiro@gmail.com) — [GitHub](https://github.com/allamiro)
 
+## Citing
+
+If you use this project in research or publications, please cite it — GitHub's
+**"Cite this repository"** button (powered by [CITATION.cff](CITATION.cff)) provides
+APA and BibTeX entries, e.g.:
+
+```bibtex
+@software{Suliman_Grafana_Network_Weathermap_NG,
+  author  = {Suliman, Tamir},
+  title   = {Grafana Network Weathermap NG},
+  url     = {https://github.com/allamiro/grafana-network-weathermap-ng},
+  license = {Apache-2.0}
+}
+```
+
 ## License
 
-Apache-2.0 — see [LICENSE](https://github.com/allamiro/grafana-network-weathermap-ng/blob/main/LICENSE) for details.
+Apache-2.0 — see [LICENSE](https://github.com/allamiro/grafana-network-weathermap-ng/blob/main/LICENSE) and [NOTICE](https://github.com/allamiro/grafana-network-weathermap-ng/blob/main/NOTICE) for details. Redistributions must retain the attribution in the NOTICE file per Apache-2.0 §4(d).


### PR DESCRIPTION
Keeps **Apache-2.0** and uses the license's own attribution mechanisms instead of switching license:

- **NOTICE** — fork copyright (Tamir Suliman 2026), preserved upstream credit (Seth Knights 2022, Apache-2.0), and world-map asset provenance. Now copied into the plugin archive next to LICENSE, because Apache-2.0 §4(d) obligates anyone redistributing the plugin to retain the NOTICE contents — this is the legally enforceable attribution channel.
- **LICENSE** — adds the fork's copyright line in the appendix; the original upstream copyright is preserved (required, since the fork inherits it).
- **CITATION.cff** — GitHub renders a *Cite this repository* button with APA/BibTeX. Root README gets a matching *Citing* section with the BibTeX entry.

Verified: NOTICE lands in `dist/` (ships in the release zip), tsc/lint/jest all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Apache-2.0 attribution by introducing a NOTICE file with upstream credits and asset provenance, and ensuring it ships in the plugin zip. Also updates LICENSE with the fork copyright and adds `CITATION.cff` plus a README “Citing” section.

- **New Features**
  - Ship NOTICE in the plugin archive via webpack (complies with Apache-2.0 §4(d)).
  - Add the fork’s copyright line to LICENSE; preserve upstream notice.
  - Add `CITATION.cff` so GitHub shows “Cite this repository”; README includes a matching BibTeX example.

<sup>Written for commit 23fdc823ae4dd3662ddfe221713e6ff8cdc1abb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

