### PR TITLE
chore(release): bump version to 1.5.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.5.11](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.11) (2026-07-03)
+
+### Chores
+
+* **plugin-metadata**: the description shown in Grafana's visualization picker now credits the author — "Next-generation, actively maintained network weathermap by Tamir Suliman…" (PR [#172](https://github.com/allamiro/grafana-network-weathermap-ng/pull/172))
+* **attribution**: added a NOTICE file (fork copyright, preserved upstream credit to Seth Knights, demo world-map asset provenance) that now ships inside the plugin archive per Apache-2.0 §4(d), the fork's copyright line in the LICENSE appendix, and a CITATION.cff enabling GitHub's "Cite this repository" button (PR [#173](https://github.com/allamiro/grafana-network-weathermap-ng/pull/173))
+* **testing/docs** (not part of the plugin archive): simulated-WAN exporter and nine scenario demo dashboards with a step-by-step use-cases guide ([#170](https://github.com/allamiro/grafana-network-weathermap-ng/issues/170), PR [#171](https://github.com/allamiro/grafana-network-weathermap-ng/pull/171))
+
 ## [1.5.10](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.10) (2026-07-02)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamirsuliman-weathermap-panel",
-      "version": "1.5.10",
+      "version": "1.5.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Release 1.5.11 — plugin-archive changes since 1.5.10:

- visualization-picker description now credits the author (#172)
- NOTICE file shipped in the archive + LICENSE copyright line + CITATION.cff (#173)

Also rolls up the testing/docs-only scenario-dashboard work (#171), which does not affect the archive.

After merge: `scripts/release.sh tag 1.5.11`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release 1.5.11 focusing on metadata and attribution. The Grafana visualization picker description now credits the author, and the plugin archive now ships a NOTICE, an updated LICENSE attribution line, and a CITATION.cff; docs/testing dashboards are included in the repo but not the archive.

<sup>Written for commit 5585d424a4e49e1bc33680999634c54fde8ebefc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

