### PR TITLE
fix: address cubic review findings on #171 (unused port-status target, lon<->fra labels)

### DIFF
--- a/testing/grafana/dashboards/wm-capacity-planning.json
+++ b/testing/grafana/dashboards/wm-capacity-planning.json
@@ -95,16 +95,6 @@
           "range": true,
           "interval": "",
           "format": "time_series"
-        },
-        {
-          "refId": "G",
-          "expr": "wm_port_status",
-          "legendFormat": "PORT {{port}}",
-          "exemplar": false,
-          "instant": false,
-          "range": true,
-          "interval": "",
-          "format": "time_series"
         }
       ],
       "options": {

--- a/testing/grafana/dashboards/wm-device-health.json
+++ b/testing/grafana/dashboards/wm-device-health.json
@@ -95,16 +95,6 @@
           "range": true,
           "interval": "",
           "format": "time_series"
-        },
-        {
-          "refId": "G",
-          "expr": "wm_port_status",
-          "legendFormat": "PORT {{port}}",
-          "exemplar": false,
-          "instant": false,
-          "range": true,
-          "interval": "",
-          "format": "time_series"
         }
       ],
       "options": {

--- a/testing/grafana/dashboards/wm-floorplan.json
+++ b/testing/grafana/dashboards/wm-floorplan.json
@@ -95,16 +95,6 @@
           "range": true,
           "interval": "",
           "format": "time_series"
-        },
-        {
-          "refId": "G",
-          "expr": "wm_port_status",
-          "legendFormat": "PORT {{port}}",
-          "exemplar": false,
-          "instant": false,
-          "range": true,
-          "interval": "",
-          "format": "time_series"
         }
       ],
       "options": {

--- a/testing/grafana/dashboards/wm-global-backbone.json
+++ b/testing/grafana/dashboards/wm-global-backbone.json
@@ -95,16 +95,6 @@
           "range": true,
           "interval": "",
           "format": "time_series"
-        },
-        {
-          "refId": "G",
-          "expr": "wm_port_status",
-          "legendFormat": "PORT {{port}}",
-          "exemplar": false,
-          "instant": false,
-          "range": true,
-          "interval": "",
-          "format": "time_series"
         }
       ],
       "options": {
@@ -784,14 +774,17 @@
                   "query": "lon<->fra tx",
                   "labelOffset": 55,
                   "anchor": 0,
-                  "dashboardLink": ""
+                  "dashboardLink": "",
+                  "portLabel": "PEB-1",
+                  "directionLabel": "Out"
                 },
                 "Z": {
                   "bandwidth": 100000000000,
                   "query": "lon<->fra rx",
                   "labelOffset": 55,
                   "anchor": 0,
-                  "dashboardLink": ""
+                  "dashboardLink": "",
+                  "directionLabel": "In"
                 }
               },
               "units": "bps",

--- a/testing/grafana/dashboards/wm-incident-replay.json
+++ b/testing/grafana/dashboards/wm-incident-replay.json
@@ -95,16 +95,6 @@
           "range": true,
           "interval": "",
           "format": "time_series"
-        },
-        {
-          "refId": "G",
-          "expr": "wm_port_status",
-          "legendFormat": "PORT {{port}}",
-          "exemplar": false,
-          "instant": false,
-          "range": true,
-          "interval": "",
-          "format": "time_series"
         }
       ],
       "options": {

--- a/testing/grafana/dashboards/wm-multihop.json
+++ b/testing/grafana/dashboards/wm-multihop.json
@@ -95,16 +95,6 @@
           "range": true,
           "interval": "",
           "format": "time_series"
-        },
-        {
-          "refId": "G",
-          "expr": "wm_port_status",
-          "legendFormat": "PORT {{port}}",
-          "exemplar": false,
-          "instant": false,
-          "range": true,
-          "interval": "",
-          "format": "time_series"
         }
       ],
       "options": {

--- a/testing/grafana/dashboards/wm-parallel-lag.json
+++ b/testing/grafana/dashboards/wm-parallel-lag.json
@@ -95,16 +95,6 @@
           "range": true,
           "interval": "",
           "format": "time_series"
-        },
-        {
-          "refId": "G",
-          "expr": "wm_port_status",
-          "legendFormat": "PORT {{port}}",
-          "exemplar": false,
-          "instant": false,
-          "range": true,
-          "interval": "",
-          "format": "time_series"
         }
       ],
       "options": {

--- a/testing/grafana/dashboards/wm-wan-utilization.json
+++ b/testing/grafana/dashboards/wm-wan-utilization.json
@@ -95,16 +95,6 @@
           "range": true,
           "interval": "",
           "format": "time_series"
-        },
-        {
-          "refId": "G",
-          "expr": "wm_port_status",
-          "legendFormat": "PORT {{port}}",
-          "exemplar": false,
-          "instant": false,
-          "range": true,
-          "interval": "",
-          "format": "time_series"
         }
       ],
       "options": {

--- a/testing/scripts/generate-scenario-dashboards.js
+++ b/testing/scripts/generate-scenario-dashboards.js
@@ -423,6 +423,8 @@ function buildCustomTopology(nodesSpec, linksSpec) {
 // Dashboard envelope
 // ---------------------------------------------------------------------------
 
+const targetDefaults = (t) => ({ ...t, exemplar: false, instant: false, range: true, interval: '', format: 'time_series' });
+
 const TARGETS = [
   { refId: 'A', expr: 'wm_link_bps', legendFormat: '{{link}} {{direction}}' },
   { refId: 'B', expr: 'wm_device_status', legendFormat: 'STATUS {{device}}' },
@@ -430,10 +432,13 @@ const TARGETS = [
   { refId: 'D', expr: 'wm_packet_loss_pct', legendFormat: 'LOSS {{device}}' },
   { refId: 'E', expr: 'wm_link_errors', legendFormat: 'ERR {{link}}' },
   { refId: 'F', expr: 'wm_link_discards', legendFormat: 'DISC {{link}}' },
-  { refId: 'G', expr: 'wm_port_status', legendFormat: 'PORT {{port}}' },
-].map((t) => ({ ...t, exemplar: false, instant: false, range: true, interval: '', format: 'time_series' }));
+].map(targetDefaults);
 
-function makeDashboard({ uid, title, description, weathermap, refresh = '10s', timeFrom = 'now-1h' }) {
+// Only the rack board consumes wm_port_status frames; keep the extra query
+// off every other dashboard.
+const PORT_STATUS_TARGET = targetDefaults({ refId: 'G', expr: 'wm_port_status', legendFormat: 'PORT {{port}}' });
+
+function makeDashboard({ uid, title, description, weathermap, refresh = '10s', timeFrom = 'now-1h', withPortStatus = false }) {
   return {
     annotations: { list: [] },
     editable: true,
@@ -457,7 +462,7 @@ function makeDashboard({ uid, title, description, weathermap, refresh = '10s', t
         id: 1,
         title,
         type: 'tamirsuliman-weathermap-panel',
-        targets: TARGETS,
+        targets: withPortStatus ? [...TARGETS, PORT_STATUS_TARGET] : TARGETS,
         options: { weathermap },
       },
     ],
@@ -587,7 +592,7 @@ const dashboards = [
         [
           { frame: 'nyc<->lon', a: 'NYC', z: 'LON', cap: 100e9, portLabel: 'TAT-14', directionLabels: true },
           { frame: 'nyc<->fra', a: 'NYC', z: 'FRA', cap: 100e9, portLabel: 'AC-2', directionLabels: true },
-          { frame: 'lon<->fra', a: 'LON', z: 'FRA', cap: 100e9 },
+          { frame: 'lon<->fra', a: 'LON', z: 'FRA', cap: 100e9, portLabel: 'PEB-1', directionLabels: true },
           { frame: 'lon<->dxb', a: 'LON', z: 'DXB', cap: 100e9, portLabel: 'EIG-1', directionLabels: true },
           { frame: 'fra<->dxb', a: 'FRA', z: 'DXB', cap: 100e9, portLabel: 'SMW-5', directionLabels: true },
         ]
@@ -632,6 +637,7 @@ const dashboards = [
   }),
   makeDashboard({
     uid: 'wm-rack-ports',
+    withPortStatus: true,
     title: 'WAN Demo — Rack Port Status',
     description:
       'A switch faceplate drawn as the background with each port as a status-colored node: green = up, red = down (ports 7 and 19 are unpatched; port 13 flaps every ~5 minutes), gray = admin-disabled (23/24). T1/T2 are the 10G uplinks.',


### PR DESCRIPTION
Follow-up for the two cubic findings on the merged #171:

- **P2**: the `wm_port_status` target (refId G) was included in all nine dashboards but only the Rack Port Status board consumes `PORT …` frames. The generator now adds it only there — verified: `wm-rack-ports` has targets A–G, all others A–F.
- **P3**: `lon<->fra` was the only global-backbone link without a `portLabel`/direction labels; it now carries `PEB-1` (matching the exporter's interface label) and Out/In labels.

Dashboards regenerated from the script; no plugin code touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops issuing unused `wm_port_status` queries on eight dashboards and adds missing labels to the `lon<->fra` backbone link. Addresses P2 and P3 from the cubic review on #171.

- **Bug Fixes**
  - Only `wm-rack-ports` keeps target G (`wm_port_status`); all other dashboards now use targets A–F.
  - `lon<->fra` now has `portLabel` `PEB-1` and direction labels Out/In on `wm-global-backbone`.
  - Generator updated to conditionally add the port-status target; dashboards regenerated. No plugin code changes.

<sup>Written for commit a2d2a02c5f01c0befa552ac05bd71908011896cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

