### PR TITLE
feat(#179): rendering/UX for dense maps — six opt-in features

### DIFF
--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -45,6 +45,9 @@ import {
   calculateRectangleAutoHeight,
   CURRENT_VERSION,
   handleVersionedStateUpdates,
+  resolveLinkChain,
+  spreadLabels,
+  LabelPlacement,
   getDataFrameName,
   getValueField,
   sanitizeUrl,
@@ -76,7 +79,10 @@ function generateDrawnNode(d: Node, i: number, wm: Weathermap): DrawnNode {
     toReturn.dashboardLink = tmplSrv?.replace(toReturn.dashboardLink) ?? toReturn.dashboardLink;
   }
 
-  toReturn.labelWidth = measureText(toReturn.label ? toReturn.label : '', wm.settings.fontSizing.node).width;
+  toReturn.labelWidth = measureText(
+    toReturn.label ? toReturn.label : '',
+    toReturn.fontSize ?? wm.settings.fontSizing.node
+  ).width;
   toReturn.anchors = {
     0: { numLinks: toReturn.anchors[0].numLinks, numFilledLinks: 0 },
     1: { numLinks: toReturn.anchors[1].numLinks, numFilledLinks: 0 },
@@ -470,6 +476,25 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
       toReturn.arrows.width
     );
 
+    // Single-direction links (#179): one full-length A line ending in one
+    // arrow at the Z node edge. VIA middle segments (connection targets) are
+    // already full-length with no arrows, so only final segments change.
+    if (d.singleDirection && !tempNodes[toReturn.target.index].isConnection) {
+      toReturn.lineEndA = shiftAlong(
+        toReturn.lineStartZ,
+        toReturn.lineStartZ,
+        toReturn.lineStartA,
+        -toReturn.arrows.height
+      );
+      toReturn.arrowCenterA = toReturn.lineStartZ;
+      toReturn.arrowPolygonA = getArrowPolygon(
+        toReturn.lineStartA,
+        toReturn.arrowCenterA,
+        toReturn.arrows.height,
+        toReturn.arrows.width
+      );
+    }
+
     if (d.statusQuery) {
       const sv = frameMap.get(d.statusQuery);
       toReturn.isDown = sv === undefined || sv < 1;
@@ -662,6 +687,47 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
     }
     setHoveredLink(null as unknown as HoveredLink);
   };
+
+  // Hover highlight (#179): when enabled, hovering a link keeps its whole VIA
+  // chain at full opacity and fades every other link and value label.
+  const hoverChain =
+    wm.settings.link.hoverHighlight && hoveredLink ? resolveLinkChain(wm.links, hoveredLink.link.id) : null;
+  const linkOpacity = (id: string) => (hoverChain && !hoverChain.has(id) ? 0.12 : 1);
+
+  // Zoom-dependent labels (#179): hide value labels once zoomed out past the
+  // configured number of wheel steps.
+  const labelHideZoom = wm.settings.link.labelHideZoom ?? 0;
+  const hideValueLabels = labelHideZoom > 0 && wm.settings.panel.zoomScale >= labelHideZoom;
+
+  // Label collision avoidance (#179): opt-in greedy pass that nudges value
+  // labels along their own link until they stop overlapping each other.
+  let collisionOffsets: Map<string, number> | null = null;
+  if (wm.settings.link.labelCollision && !hideValueLabels) {
+    const placements: LabelPlacement[] = [];
+    const fs = wm.settings.fontSizing.link;
+    for (const d of links) {
+      if (d.nodes[0].id === d.nodes[1].id) {
+        continue;
+      }
+      placements.push({
+        key: `${d.id}:A`,
+        segment: { x1: d.lineStartZ.x, y1: d.lineStartZ.y, x2: d.lineStartA.x, y2: d.lineStartA.y },
+        offsetPercent: (tempNodes[d.target.index].isConnection ? 1 : 0.5) * d.sides.A.labelOffset,
+        width: measureText(`${d.sides.A.currentText}`, fs).width + fs * 1.5,
+        height: fs * 2,
+      });
+      if (!tempNodes[d.target.index].isConnection && !d.singleDirection) {
+        placements.push({
+          key: `${d.id}:Z`,
+          segment: { x1: d.lineStartA.x, y1: d.lineStartA.y, x2: d.lineStartZ.x, y2: d.lineStartZ.y },
+          offsetPercent: 0.5 * d.sides.Z.labelOffset,
+          width: measureText(`${d.sides.Z.currentText}`, fs).width + fs * 1.5,
+          height: fs * 2,
+        });
+      }
+    }
+    collisionOffsets = spreadLabels(placements);
+  }
 
   // VIA editing on the canvas (#67): double-click a link to insert a waypoint
   // (a connection node at the link midpoint, which can then be dragged), and
@@ -1076,6 +1142,39 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
           ''
         )}
         <ColorScale thresholds={wm.scale} settings={wm.settings} />
+        {wm.settings.statusLegend?.enabled && wm.settings.statusLegend.items.length > 0 ? (
+          <div
+            className={css`
+              position: absolute;
+              top: ${wm.settings.statusLegend.position.y}%;
+              left: ${wm.settings.statusLegend.position.x}%;
+              padding: 6px 10px;
+              border-radius: 4px;
+              background-color: ${theme.colors.background.secondary};
+              border: 1px solid ${theme.colors.border.weak};
+              font-size: 12px;
+              pointer-events: none;
+            `}
+            data-testid="status-legend"
+          >
+            {wm.settings.statusLegend.items.map((item, i) => (
+              <div key={i} style={{ display: 'flex', alignItems: 'center', gap: '6px', lineHeight: '18px' }}>
+                <span
+                  style={{
+                    width: '10px',
+                    height: '10px',
+                    borderRadius: '2px',
+                    backgroundColor: item.color,
+                    display: 'inline-block',
+                  }}
+                ></span>
+                {item.label}
+              </div>
+            ))}
+          </div>
+        ) : (
+          ''
+        )}
         <svg
           style={{
             position: 'absolute',
@@ -1286,6 +1385,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                     key={i}
                     className="line"
                     data-testid="link"
+                    opacity={linkOpacity(d.id)}
                     strokeOpacity={1}
                     width={Math.abs(d.target.x - d.source.x)}
                     height={Math.abs(d.target.y - d.source.y)}
@@ -1363,6 +1463,8 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                           }}
                           style={d.sides.A.dashboardLink.length > 0 ? { cursor: 'pointer' } : {}}
                         ></polygon>
+                        {!d.singleDirection && (
+                        <React.Fragment>
                         <line
                           strokeWidth={getLinkStroke(d.sides.Z.currentValue, d.sides.Z.bandwidth, d.stroke)}
                           stroke={
@@ -1419,6 +1521,8 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                           }}
                           style={d.sides.Z.dashboardLink.length > 0 ? { cursor: 'pointer' } : {}}
                         ></polygon>
+                        </React.Fragment>
+                        )}
                       </React.Fragment>
                     )}
                   </g>
@@ -1427,17 +1531,17 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
             </g>
             <g>
               {links.map((d, i) => {
-                if (d.nodes[0].id === d.nodes[1].id) {
+                if (d.nodes[0].id === d.nodes[1].id || hideValueLabels) {
                   return;
                 }
-                const transform = getPercentPoint(
-                  d.lineStartZ,
-                  d.lineStartA,
-                  (tempNodes[d.target.index].isConnection ? 1 : 0.5) * (d.sides.A.labelOffset / 100)
-                );
+                const aPct =
+                  collisionOffsets?.get(`${d.id}:A`) ??
+                  (tempNodes[d.target.index].isConnection ? 1 : 0.5) * d.sides.A.labelOffset;
+                const transform = getPercentPoint(d.lineStartZ, d.lineStartA, aPct / 100);
                 return (
                   <g
                     fontStyle={'italic'}
+                    opacity={linkOpacity(d.id)}
                     transform={`translate(${transform.x},${transform.y})`}
                     onMouseMove={(e) => {
                       handleLinkHover(d, 'A', e);
@@ -1481,13 +1585,20 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
             </g>
             <g>
               {links.map((d, i) => {
-                if (d.nodes[0].id === d.nodes[1].id || tempNodes[d.target.index].isConnection) {
+                if (
+                  d.nodes[0].id === d.nodes[1].id ||
+                  tempNodes[d.target.index].isConnection ||
+                  d.singleDirection ||
+                  hideValueLabels
+                ) {
                   return;
                 }
-                const transform = getPercentPoint(d.lineStartA, d.lineStartZ, 0.5 * (d.sides.Z.labelOffset / 100));
+                const zPct = collisionOffsets?.get(`${d.id}:Z`) ?? 0.5 * d.sides.Z.labelOffset;
+                const transform = getPercentPoint(d.lineStartA, d.lineStartZ, zPct / 100);
                 return (
                   <g
                     fontStyle={'italic'}
+                    opacity={linkOpacity(d.id)}
                     transform={`translate(${transform.x},${transform.y})`}
                     onMouseMove={(e) => {
                       handleLinkHover(d, 'Z', e);

--- a/src/components/MapNode.tsx
+++ b/src/components/MapNode.tsx
@@ -38,7 +38,9 @@ function calculateTextY(d: DrawnNode) {
 function calculateRectX(d: DrawnNode, wm: Weathermap) {
   const offset = Math.min(
     -calculateRectangleAutoWidth(d, wm) / 2,
-    d.label !== undefined ? -(measureText(d.label, wm.settings.fontSizing.node).width / 2 + d.padding.horizontal) : 0
+    d.label !== undefined
+      ? -(measureText(d.label, d.fontSize ?? wm.settings.fontSizing.node).width / 2 + d.padding.horizontal)
+      : 0
   );
   return offset;
 }
@@ -167,7 +169,8 @@ const MapNode: React.FC<NodeProps> = (props: NodeProps) => {
                 dominantBaseline={'central'}
                 fill={node.colors.font}
                 className={styles.nodeText}
-                fontSize={node.isConnection ? '6px' : `${wm.settings.fontSizing.node}px`}
+                fontSize={node.isConnection ? '6px' : `${node.fontSize ?? wm.settings.fontSizing.node}px`}
+                fontWeight={node.fontBold ? 'bold' : undefined}
               >
                 {node.label !== undefined && !(node.isConnection && disabled) ? node.label : ''}
               </text>
@@ -185,7 +188,7 @@ const MapNode: React.FC<NodeProps> = (props: NodeProps) => {
                   ? -(
                       node.nodeIcon.size.height +
                       node.nodeIcon.padding.vertical +
-                      measureText(node.label!, wm.settings.fontSizing.node).actualBoundingBoxAscent
+                      measureText(node.label!, node.fontSize ?? wm.settings.fontSizing.node).actualBoundingBoxAscent
                     ) / 2
                   : -node.nodeIcon.size.height / 2
                 : node.label!.length > 0

--- a/src/forms/LinkForm.tsx
+++ b/src/forms/LinkForm.tsx
@@ -428,6 +428,23 @@ export const LinkForm = (props: Props) => {
               </InlineField>
               <InlineField
                 grow
+                label={'Single Direction (A → Z)'}
+                className={styles.inlineField}
+                tooltip={
+                  'Render this link as a one-way flow: one full-length line with a single arrow into the Z side, and only the A-side value label. For flows that physically go one way (power feeds, unidirectional replication).'
+                }
+              >
+                <InlineSwitch
+                  value={link.singleDirection ?? false}
+                  onChange={(e) => {
+                    let options = value;
+                    options.links[i].singleDirection = e.currentTarget.checked;
+                    onChange(options);
+                  }}
+                />
+              </InlineField>
+              <InlineField
+                grow
                 label={'Arrow Meeting Point (%)'}
                 className={styles.inlineField}
                 tooltip={'Where along the A→Z line the two directional arrows meet. 50% is the midpoint (default); lower values move the junction toward the A side, higher toward the Z side.'}

--- a/src/forms/NodeForm.tsx
+++ b/src/forms/NodeForm.tsx
@@ -743,6 +743,33 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                     <InlineField grow label={'Constant Spacing'}>
                       <InlineSwitch value={node.useConstantSpacing} onChange={(e) => handleSpacingChange(e, i)} />
                     </InlineField>
+                    <InlineField
+                      grow
+                      label={'Label Font Size (override)'}
+                      tooltip={'Overrides the global Node Font Size for this node only. 0 resets to the global size.'}
+                    >
+                      <Input
+                        value={node.fontSize ?? 0}
+                        type={'number'}
+                        min={0}
+                        onChange={(e) => {
+                          let weathermap: Weathermap = value;
+                          const v = e.currentTarget.valueAsNumber;
+                          weathermap.nodes[i].fontSize = v > 0 ? v : undefined;
+                          onChange(weathermap);
+                        }}
+                      />
+                    </InlineField>
+                    <InlineField grow label={'Bold Label'}>
+                      <InlineSwitch
+                        value={node.fontBold ?? false}
+                        onChange={(e) => {
+                          let weathermap: Weathermap = value;
+                          weathermap.nodes[i].fontBold = e.currentTarget.checked;
+                          onChange(weathermap);
+                        }}
+                      />
+                    </InlineField>
                     <InlineField grow label={'Compact Vertical Links'}>
                       <InlineSwitch value={node.compactVerticalLinks} onChange={(e) => handleCompactChange(e, i)} />
                     </InlineField>

--- a/src/forms/PanelForm.tsx
+++ b/src/forms/PanelForm.tsx
@@ -14,6 +14,7 @@ import {
 } from '@grafana/ui';
 import { GrafanaTheme2, StandardEditorProps } from '@grafana/data';
 import { Weathermap, ValueMappingMode } from 'types';
+import { v4 as uuidv4 } from 'uuid';
 import { FormDivider } from './FormDivider';
 import { css } from '@emotion/css';
 import { sanitizeUrl } from 'utils';
@@ -601,8 +602,8 @@ export const PanelForm = ({ value, onChange }: Props) => {
                   enabled: e.currentTarget.checked,
                   position: { x: 1, y: 1 },
                   items: [
-                    { color: '#73BF69', label: 'up' },
-                    { color: '#F2495C', label: 'down' },
+                    { color: '#73BF69', label: 'up', id: uuidv4() },
+                    { color: '#F2495C', label: 'down', id: uuidv4() },
                   ],
                 };
               } else {
@@ -641,7 +642,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
               />
             </InlineField>
             {value.settings.statusLegend.items.map((item, li) => (
-              <InlineFieldRow key={li} className={styles.inlineRow}>
+              <InlineFieldRow key={item.id ?? li} className={styles.inlineRow}>
                 <InlineLabel width={'auto'} style={{ marginBottom: '4px' }}>
                   Color:
                   <ColorPicker
@@ -683,7 +684,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
               size="sm"
               onClick={() => {
                 let options = value;
-                options.settings.statusLegend!.items.push({ color: '#FF9830', label: 'label' });
+                options.settings.statusLegend!.items.push({ color: '#FF9830', label: 'label', id: uuidv4() });
                 onChange(options);
               }}
             >

--- a/src/forms/PanelForm.tsx
+++ b/src/forms/PanelForm.tsx
@@ -534,6 +534,165 @@ export const PanelForm = ({ value, onChange }: Props) => {
             }}
           />
         </InlineField>
+        <FormDivider title="Interaction & Labels" />
+        <InlineField
+          grow
+          label="Hover Highlight"
+          className={styles.inlineField}
+          tooltip={'Hovering a link highlights its whole path (including VIA segments) and fades unrelated links.'}
+        >
+          <InlineSwitch
+            value={value.settings.link.hoverHighlight ?? false}
+            onChange={(e) => {
+              let options = value;
+              options.settings.link.hoverHighlight = e.currentTarget.checked;
+              onChange(options);
+            }}
+          />
+        </InlineField>
+        <InlineField
+          grow
+          label="Label Collision Avoidance"
+          className={styles.inlineField}
+          tooltip={'Nudge overlapping link value labels along their links so they stop covering each other.'}
+        >
+          <InlineSwitch
+            value={value.settings.link.labelCollision ?? false}
+            onChange={(e) => {
+              let options = value;
+              options.settings.link.labelCollision = e.currentTarget.checked;
+              onChange(options);
+            }}
+          />
+        </InlineField>
+        <InlineField
+          grow
+          label="Hide Labels When Zoomed Out"
+          className={styles.inlineField}
+          tooltip={
+            'Hide link value labels once the map is zoomed out this many scroll steps or more. 0 always shows labels.'
+          }
+        >
+          <Slider
+            min={0}
+            max={10}
+            step={1}
+            value={value.settings.link.labelHideZoom ?? 0}
+            onChange={(num) => {
+              let options = value;
+              options.settings.link.labelHideZoom = num;
+              onChange(options);
+            }}
+          />
+        </InlineField>
+        <FormDivider title="Status Legend" />
+        <InlineField
+          grow
+          label="Show Status Legend"
+          className={styles.inlineField}
+          tooltip={'A small legend explaining your status colors, positioned in panel percent coordinates.'}
+        >
+          <InlineSwitch
+            value={value.settings.statusLegend?.enabled ?? false}
+            onChange={(e) => {
+              let options = value;
+              if (!options.settings.statusLegend) {
+                options.settings.statusLegend = {
+                  enabled: e.currentTarget.checked,
+                  position: { x: 1, y: 1 },
+                  items: [
+                    { color: '#73BF69', label: 'up' },
+                    { color: '#F2495C', label: 'down' },
+                  ],
+                };
+              } else {
+                options.settings.statusLegend.enabled = e.currentTarget.checked;
+              }
+              onChange(options);
+            }}
+          />
+        </InlineField>
+        {value.settings.statusLegend?.enabled ? (
+          <React.Fragment>
+            <InlineField grow label="Legend Position X (%)" className={styles.inlineField}>
+              <Slider
+                min={0}
+                max={100}
+                step={1}
+                value={value.settings.statusLegend.position.x}
+                onChange={(num) => {
+                  let options = value;
+                  options.settings.statusLegend!.position.x = num;
+                  onChange(options);
+                }}
+              />
+            </InlineField>
+            <InlineField grow label="Legend Position Y (%)" className={styles.inlineField}>
+              <Slider
+                min={0}
+                max={100}
+                step={1}
+                value={value.settings.statusLegend.position.y}
+                onChange={(num) => {
+                  let options = value;
+                  options.settings.statusLegend!.position.y = num;
+                  onChange(options);
+                }}
+              />
+            </InlineField>
+            {value.settings.statusLegend.items.map((item, li) => (
+              <InlineFieldRow key={li} className={styles.inlineRow}>
+                <InlineLabel width={'auto'} style={{ marginBottom: '4px' }}>
+                  Color:
+                  <ColorPicker
+                    color={item.color}
+                    onChange={(color) => {
+                      let options = value;
+                      options.settings.statusLegend!.items[li].color = color;
+                      onChange(options);
+                    }}
+                  />
+                </InlineLabel>
+                <InlineField grow label="Label">
+                  <Input
+                    value={item.label}
+                    type={'text'}
+                    onChange={(e) => {
+                      let options = value;
+                      options.settings.statusLegend!.items[li].label = e.currentTarget.value;
+                      onChange(options);
+                    }}
+                  />
+                </InlineField>
+                <Button
+                  variant="destructive"
+                  icon="trash-alt"
+                  size="sm"
+                  aria-label="Remove legend item"
+                  onClick={() => {
+                    let options = value;
+                    options.settings.statusLegend!.items.splice(li, 1);
+                    onChange(options);
+                  }}
+                />
+              </InlineFieldRow>
+            ))}
+            <Button
+              variant="secondary"
+              icon="plus"
+              size="sm"
+              onClick={() => {
+                let options = value;
+                options.settings.statusLegend!.items.push({ color: '#FF9830', label: 'label' });
+                onChange(options);
+              }}
+            >
+              Add Legend Item
+            </Button>
+          </React.Fragment>
+        ) : (
+          ''
+        )}
         <FormDivider title="Tootlip Options" />
         <InlineLabel width={'auto'} style={{ marginBottom: '4px' }}>
           Background Color:

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,6 +108,11 @@ export interface Node {
   statusQuery?: string;
   statusValueMappings?: NodeStatusValueMapping[];
   nodeStatusColorTarget?: 'border' | 'background' | 'both';
+  // Per-node font overrides (#179): structural labels can stay small/muted
+  // while important device names stand out. Fall back to the global
+  // settings.fontSizing.node when unset.
+  fontSize?: number;
+  fontBold?: boolean;
 }
 
 export interface LinkSide {
@@ -152,6 +157,10 @@ export interface Link {
   statusQuery?: string;
   statusDownColor?: string;
   statusBlink?: boolean;
+  // Render only the A->Z direction (#179): one full-length line, one arrow at
+  // the Z end, and only the A-side value label. For flows that physically go
+  // one way (power feeds, unidirectional replication).
+  singleDirection?: boolean;
 }
 
 export interface DrawnNode extends Node {
@@ -247,6 +256,15 @@ export interface WeathermapSettings {
       speed: number;
     };
     gradientColor?: boolean;
+    // Hovering a link highlights its whole VIA chain and fades unrelated
+    // links (#179). Off by default.
+    hoverHighlight?: boolean;
+    // Hide link value labels once zoomed out this many wheel steps or more
+    // (zoomScale >= threshold). 0/unset = always show (#179).
+    labelHideZoom?: number;
+    // Opt-in greedy de-overlap pass that nudges colliding value labels along
+    // their link (#179). Off by default so existing maps render unchanged.
+    labelCollision?: boolean;
   };
   fontSizing: {
     node: number;
@@ -256,6 +274,13 @@ export interface WeathermapSettings {
   panel: PanelOptions;
   tooltip: TooltipOptions;
   scale: TrafficPanelSettings;
+  // Optional built-in legend explaining status colors (#179), positioned in
+  // panel percent coordinates like the utilization scale.
+  statusLegend?: {
+    enabled: boolean;
+    position: Position;
+    items: Array<{ color: string; label: string }>;
+  };
 }
 
 export interface Threshold {

--- a/src/types.ts
+++ b/src/types.ts
@@ -279,7 +279,7 @@ export interface WeathermapSettings {
   statusLegend?: {
     enabled: boolean;
     position: Position;
-    items: Array<{ color: string; label: string }>;
+    items: Array<{ color: string; label: string; id?: string }>;
   };
 }
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -2,6 +2,8 @@ import { defaultNodes, getData, legacyWeathermap, theme } from 'testData';
 import { DrawnNode, Weathermap } from 'types';
 import {
   addViaToLink,
+  resolveLinkChain,
+  spreadLabels,
   aggregateFieldValues,
   calculateRectangleAutoHeight,
   calculateRectangleAutoWidth,
@@ -291,5 +293,66 @@ describe('timeline helpers (valueAtTime / getTimeField)', () => {
       ],
     };
     expect(getTimeField(frame)).toBeUndefined();
+  });
+});
+
+describe('resolveLinkChain (#179)', () => {
+  const node = (id: string, isConnection = false) => ({ id, isConnection } as never);
+  const link = (id: string, a: unknown, z: unknown) => ({ id, nodes: [a, z] } as never);
+
+  it('walks a VIA chain in both directions from a middle segment', () => {
+    const a = node('a');
+    const c1 = node('c1', true);
+    const c2 = node('c2', true);
+    const z = node('z');
+    const links = [link('l1', a, c1), link('l2', c1, c2), link('l3', c2, z), link('other', node('x'), node('y'))];
+    expect([...resolveLinkChain(links as never, 'l2')].sort()).toEqual(['l1', 'l2', 'l3']);
+    expect([...resolveLinkChain(links as never, 'l1')].sort()).toEqual(['l1', 'l2', 'l3']);
+    expect([...resolveLinkChain(links as never, 'l3')].sort()).toEqual(['l1', 'l2', 'l3']);
+  });
+
+  it('returns just the link itself when it has no connection endpoints', () => {
+    const links = [link('solo', node('a'), node('z'))];
+    expect([...resolveLinkChain(links as never, 'solo')]).toEqual(['solo']);
+    expect([...resolveLinkChain(links as never, 'missing')]).toEqual(['missing']);
+  });
+});
+
+describe('spreadLabels (#179)', () => {
+  const seg = { x1: 0, y1: 0, x2: 100, y2: 0 };
+
+  it('keeps non-overlapping labels at their preferred offsets', () => {
+    const result = spreadLabels([
+      { key: 'a', segment: seg, offsetPercent: 20, width: 10, height: 10 },
+      { key: 'b', segment: seg, offsetPercent: 80, width: 10, height: 10 },
+    ]);
+    expect(result.get('a')).toBe(20);
+    expect(result.get('b')).toBe(80);
+  });
+
+  it('nudges the second of two colliding labels apart', () => {
+    const result = spreadLabels([
+      { key: 'a', segment: seg, offsetPercent: 50, width: 20, height: 10 },
+      { key: 'b', segment: seg, offsetPercent: 50, width: 20, height: 10 },
+    ]);
+    expect(result.get('a')).toBe(50);
+    expect(result.get('b')).not.toBe(50);
+    // The two resolved boxes must no longer overlap horizontally.
+    expect(Math.abs(result.get('b')! - result.get('a')!)).toBeGreaterThanOrEqual(20);
+  });
+
+  it('stays within the allowed offset range', () => {
+    const labels = Array.from({ length: 8 }, (_, i) => ({
+      key: `k${i}`,
+      segment: seg,
+      offsetPercent: 50,
+      width: 18,
+      height: 10,
+    }));
+    const result = spreadLabels(labels);
+    for (const pct of result.values()) {
+      expect(pct).toBeGreaterThanOrEqual(10);
+      expect(pct).toBeLessThanOrEqual(90);
+    }
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -700,11 +700,29 @@ export function resolveLinkChain(links: Link[], linkId: string): Set<string> {
     return chain;
   }
 
+  // Index segments by their endpoint node ids once, so each hop of the chain
+  // walk is a map lookup instead of a scan (keeps hover-time resolution
+  // linear on dense maps).
+  const bySourceNode = new Map<string, Link[]>();
+  const byTargetNode = new Map<string, Link[]>();
+  for (const l of links) {
+    if (l.nodes[0]?.id) {
+      const list = bySourceNode.get(l.nodes[0].id) ?? [];
+      list.push(l);
+      bySourceNode.set(l.nodes[0].id, list);
+    }
+    if (l.nodes[1]?.id) {
+      const list = byTargetNode.get(l.nodes[1].id) ?? [];
+      list.push(l);
+      byTargetNode.set(l.nodes[1].id, list);
+    }
+  }
+
   // Walk backward: while the current segment starts at a connection node,
   // include the segment feeding that connection.
   let current: Link | undefined = start;
   for (let guard = 0; guard < links.length && current && current.nodes[0]?.isConnection; guard++) {
-    const prev = links.find((l) => l.id !== current!.id && l.nodes[1]?.id === current!.nodes[0].id);
+    const prev: Link | undefined = (byTargetNode.get(current.nodes[0].id) ?? []).find((l) => l.id !== current!.id);
     if (!prev || chain.has(prev.id)) {
       break;
     }
@@ -716,7 +734,7 @@ export function resolveLinkChain(links: Link[], linkId: string): Set<string> {
   // include the segment leaving that connection.
   current = start;
   for (let guard = 0; guard < links.length && current && current.nodes[1]?.isConnection; guard++) {
-    const next = links.find((l) => l.id !== current!.id && l.nodes[0]?.id === current!.nodes[1].id);
+    const next: Link | undefined = (bySourceNode.get(current.nodes[1].id) ?? []).find((l) => l.id !== current!.id);
     if (!next || chain.has(next.id)) {
       break;
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -167,14 +167,15 @@ export function calculateRectangleAutoHeight(d: DrawnNode, wm: Weathermap): numb
       )
       .map((l) => l.stroke)
   );
-  let minHeight = wm.settings.fontSizing.node + 2 * d.padding.vertical; // fontSize + padding
+  const nodeFontSize = d.fontSize ?? wm.settings.fontSizing.node;
+  let minHeight = nodeFontSize + 2 * d.padding.vertical; // fontSize + padding
 
   if (d.nodeIcon?.drawInside) {
     minHeight += d.nodeIcon.size.height + 2 * d.nodeIcon.padding.vertical;
   }
 
   if (d.nodeIcon && d.label === '') {
-    minHeight -= wm.settings.fontSizing.node;
+    minHeight -= nodeFontSize;
   }
 
   const linkHeight = maxLinkHeight + wm.settings.link.spacing.vertical + 2 * d.padding.vertical;
@@ -683,4 +684,101 @@ export function aggregateFieldValues(
     default:
       return lastValid;
   }
+}
+
+/**
+ * Resolve the full VIA chain a link belongs to (#179): starting from one link,
+ * walk backward through connection-node sources and forward through
+ * connection-node targets, collecting every segment of the logical link.
+ * Returns the set of link ids in the chain (always includes the given link).
+ */
+export function resolveLinkChain(links: Link[], linkId: string): Set<string> {
+  const chain = new Set<string>([linkId]);
+  const byId = new Map(links.map((l) => [l.id, l]));
+  const start = byId.get(linkId);
+  if (!start) {
+    return chain;
+  }
+
+  // Walk backward: while the current segment starts at a connection node,
+  // include the segment feeding that connection.
+  let current: Link | undefined = start;
+  for (let guard = 0; guard < links.length && current && current.nodes[0]?.isConnection; guard++) {
+    const prev = links.find((l) => l.id !== current!.id && l.nodes[1]?.id === current!.nodes[0].id);
+    if (!prev || chain.has(prev.id)) {
+      break;
+    }
+    chain.add(prev.id);
+    current = prev;
+  }
+
+  // Walk forward: while the current segment ends at a connection node,
+  // include the segment leaving that connection.
+  current = start;
+  for (let guard = 0; guard < links.length && current && current.nodes[1]?.isConnection; guard++) {
+    const next = links.find((l) => l.id !== current!.id && l.nodes[0]?.id === current!.nodes[1].id);
+    if (!next || chain.has(next.id)) {
+      break;
+    }
+    chain.add(next.id);
+    current = next;
+  }
+
+  return chain;
+}
+
+export interface LabelPlacement {
+  key: string;
+  // The segment the label slides along, and its preferred position (percent).
+  segment: { x1: number; y1: number; x2: number; y2: number };
+  offsetPercent: number;
+  width: number;
+  height: number;
+}
+
+const labelBoxAt = (l: LabelPlacement, pct: number) => {
+  const x = l.segment.x1 + ((l.segment.x2 - l.segment.x1) * pct) / 100;
+  const y = l.segment.y1 + ((l.segment.y2 - l.segment.y1) * pct) / 100;
+  return { x0: x - l.width / 2, y0: y - l.height / 2, x1: x + l.width / 2, y1: y + l.height / 2 };
+};
+
+const boxesOverlap = (a: ReturnType<typeof labelBoxAt>, b: ReturnType<typeof labelBoxAt>) =>
+  a.x0 < b.x1 && a.x1 > b.x0 && a.y0 < b.y1 && a.y1 > b.y0;
+
+/**
+ * Greedy label de-overlap pass (#179): keeps each label on its own link
+ * segment, nudging its offset percentage away from already-placed labels.
+ * Returns the resolved offset percent per label key; labels that cannot be
+ * de-overlapped within the segment keep their preferred position.
+ */
+export function spreadLabels(labels: LabelPlacement[], step = 8, min = 10, max = 90): Map<string, number> {
+  const placed: Array<ReturnType<typeof labelBoxAt>> = [];
+  const result = new Map<string, number>();
+
+  for (const label of labels) {
+    let chosen = label.offsetPercent;
+    let found = false;
+    // Try the preferred spot, then alternate outward: +step, -step, +2step, ...
+    for (let k = 0; k <= Math.ceil((max - min) / step); k++) {
+      for (const dir of k === 0 ? [0] : [1, -1]) {
+        const pct = label.offsetPercent + dir * k * step;
+        if (pct < min || pct > max) {
+          continue;
+        }
+        const box = labelBoxAt(label, pct);
+        if (!placed.some((p) => boxesOverlap(box, p))) {
+          chosen = pct;
+          found = true;
+          break;
+        }
+      }
+      if (found) {
+        break;
+      }
+    }
+    placed.push(labelBoxAt(label, chosen));
+    result.set(label.key, chosen);
+  }
+
+  return result;
 }


### PR DESCRIPTION
Closes #179. Implements all six items, ordered easiest→hardest as planned. **Everything is additive and default-off — existing maps render pixel-identical** (regression-verified below).

## Features

1. **Single-direction links** — per-link *Single Direction (A → Z)* switch: one full-length line, one arrow into the Z node edge, only the A-side value label. VIA chains inherit the flag; middle segments were already arrow-less. For one-way flows (power feeds, unidirectional replication).
2. **Hover highlight** — *Panel Options → Hover Highlight*: hovering a link keeps its entire VIA chain at full opacity and fades unrelated links/labels to 12%. Chain resolution is the new `resolveLinkChain()` utility, unit-tested walking both directions from any segment.
3. **Label collision avoidance** — *Label Collision Avoidance* switch: greedy pass (`spreadLabels()`, unit-tested) nudges overlapping value labels along their own link within a 10–90% offset window; labels that can't be resolved keep their preferred spot.
4. **Zoom-dependent labels** — *Hide Labels When Zoomed Out* (0–10 wheel steps, 0 = never): value labels disappear once zoomed out past the threshold and return on zoom-in.
5. **Status legend** — *Status Legend* section: built-in overlay with user-defined color+label rows, positioned in panel percent coordinates like the utilization scale.
6. **Per-node font overrides** — *Label Font Size (override)* + *Bold Label* under the node's Advanced section, threaded through label measurement so node boxes size correctly.

## Safety / verification

- **Regression**: live capture of an existing demo dashboard with defaults — identical output (17 value labels, no legend, zero page errors).
- **Feature exercise** (temp dashboard on the docker stack, not committed): one-way power arrows render as a single flow with one wattage label; hovering faded 26/27 link groups leaving the hovered chain; one shift+scroll zoom-out hid all value labels; legend overlay + bold node label confirmed on screen.
- Schema changes are optional fields only — no migration needed, `CURRENT_VERSION` unchanged.
- `tsc`, eslint, jest **67/67** (5 new unit tests), production build all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds six opt-in rendering and UX improvements for dense maps; all default-off so existing maps are unchanged. Closes #179.

- **New Features**
  - Single-direction links: one full-length A→Z line with a single arrow at Z and only the A-side label; VIA chains inherit.
  - Hover highlight: hovered VIA chain stays full opacity; unrelated links and labels dim to 12%.
  - Label collision avoidance: nudge overlapping value labels along their link (10–90% range).
  - Zoom-dependent labels: hide link labels past a wheel-step threshold (0 = never).
  - Status legend: optional overlay with color+label rows, positioned in panel percent coordinates.
  - Per-node font overrides: font size and bold per node, with correct box sizing.

- **Bug Fixes**
  - Hover highlight performance: chain resolution now indexes link endpoints for linear-time lookups on dense maps.
  - Status legend editor: uses stable keys for items so color/label inputs stay bound after add/remove.

<sup>Written for commit ab0cdab761dd51e9e6132738d6241e31151ae024. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

