### PR TITLE
fix(#178): empty data frame crashes the panel via node status resolution

### DIFF
--- a/src/components/MapNode.test.tsx
+++ b/src/components/MapNode.test.tsx
@@ -1,0 +1,38 @@
+// Regression tests for #178: pathological data frames must not crash the
+// panel — MapNode status resolution filters frames by display name, which
+// throws for frames without a value field.
+import React from 'react';
+import { getDefaultRelativeTimeRange, getTimeZone, LoadingState, PanelProps, toDataFrame } from '@grafana/data';
+import { render, screen } from '@testing-library/react';
+import { WeathermapPanel } from 'WeathermapPanel';
+import { SimpleOptions } from 'types';
+import { getData, theme } from 'testData';
+
+const baseProps = (series: unknown[]) =>
+  ({
+    id: 1,
+    data: { state: LoadingState.Done, series, timeRange: getDefaultRelativeTimeRange() },
+    timeRange: getDefaultRelativeTimeRange(),
+    timeZone: getTimeZone(),
+    options: { weathermap: (() => { const wm = getData(theme); wm.nodes.forEach((n) => (n.statusQuery = 'STATUS X')); return wm; })() },
+    transparent: false,
+    width: 600,
+    height: 400,
+    fieldConfig: {},
+    renderCounter: 1,
+    title: 'T',
+    eventBus: {},
+    onOptionsChange: () => {},
+  } as unknown as PanelProps<SimpleOptions>);
+
+test('empty frame (no fields, no name) does not crash the panel', () => {
+  const empty = toDataFrame({ fields: [] });
+  render(<WeathermapPanel {...baseProps([empty])} />);
+  expect(screen.getAllByTestId('link').length).toBeGreaterThan(0);
+});
+
+test('frame with a single non-numeric field does not crash the panel', () => {
+  const weird = toDataFrame({ name: undefined, fields: [{ name: 'label', values: ['a', 'b'] }] });
+  render(<WeathermapPanel {...baseProps([weird])} />);
+  expect(screen.getAllByTestId('link').length).toBeGreaterThan(0);
+});

--- a/src/components/MapNode.tsx
+++ b/src/components/MapNode.tsx
@@ -7,6 +7,7 @@ import {
   calculateRectangleAutoWidth,
   calculateRectangleAutoHeight,
   getDataFrameName,
+  getValueField,
   sanitizeUrl,
 } from '../utils';
 import { css } from '@emotion/css';
@@ -68,8 +69,20 @@ const MapNode: React.FC<NodeProps> = (props: NodeProps) => {
   let nodeStatusColor: string | null = null;
   if (node.statusQuery) {
     const recentFrame = data.series
-      .filter((series) => getDataFrameName(series, data.series) === node.statusQuery)
-      .map((frame) => frame.fields[1].values[frame.fields[1].values.length - 1]);
+      .filter((series) => {
+        // A transient empty or valueless frame (fresh exporter, scrape gap,
+        // regex matching nothing) must not take down the whole panel (#178) —
+        // name resolution throws for frames without a value field.
+        try {
+          return getDataFrameName(series, data.series) === node.statusQuery;
+        } catch (e) {
+          return false;
+        }
+      })
+      .map((frame) => {
+        const valueField = getValueField(frame);
+        return valueField.values[valueField.values.length - 1];
+      });
 
     const rawValue = recentFrame.length > 0 ? recentFrame[0] : undefined;
 


### PR DESCRIPTION
Closes #178.

## Root cause — not where the issue guessed

The issue pointed at `WeathermapPanel`'s frame map (:502) and hover filter (:740) — those turn out to have been guarded (`fields.length` skip + try/catch) since the initial import. The actual crash site is **`MapNode.tsx:70-72`**: the node status-color lookup filters `data.series` with an **unguarded** `getDataFrameName`, which throws for any frame lacking a numeric value field. It only executes for nodes with a **Status Query** — which is why the demo dashboards with per-node/per-port statuses crashed while simple maps never did.

Deterministic repro (now a committed regression test): render the panel with all nodes carrying a status query and inject one empty frame → `Error: No value field found in frame "undefined"` → error boundary latches until reload.

## Fix

- Wrap the name resolution in try/catch like every other call site — a transient empty frame is simply not a status match.
- Read the status value via `getValueField` instead of assuming `fields[1]` (bonus: correct values on non-standard frame layouts, same convention as the rest of the codebase).

## Verification

- New regression tests (empty frame; single string-field frame) fail on the previous code with the exact #178 error, pass now. Full suite **69/69**.
- Live: rebuilt dist on the docker stack, Interactive Rack View (every node/port has a status query) renders with zero page errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the panel from crashing when a node with a Status Query encounters an empty or non-numeric data frame. `MapNode` now safely resolves frame names and reads status values correctly.

- **Bug Fixes**
  - Guard `getDataFrameName` during status-color lookup to skip empty/valueless frames.
  - Use `getValueField` instead of `fields[1]` to pick the last value, fixing non-standard frame layouts.
  - Add regression tests for empty frames and single string-field frames.

<sup>Written for commit aa59bef1369333e2dd0fdd882619b7c9db273a8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

