### PR TITLE
chore(release): bump version to 1.5.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.5.12](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.12) (2026-07-03)
+
+### Features
+
+* **dense-map rendering/UX** ([#179](https://github.com/allamiro/grafana-network-weathermap-ng/issues/179), PR [#184](https://github.com/allamiro/grafana-network-weathermap-ng/pull/184)): six opt-in, default-off options — **single-direction links** (one full-length line and a single arrow for one-way flows like power feeds), **hover highlight** (the hovered link's whole VIA chain stays bright while unrelated links fade), **label collision avoidance**, **zoom-dependent value labels**, a built-in **status legend**, and **per-node font size/bold overrides**
+* **icon library — 997 bundled icons across 10 sets** (PRs [#181](https://github.com/allamiro/grafana-network-weathermap-ng/pull/181), [#183](https://github.com/allamiro/grafana-network-weathermap-ng/pull/183)): country flags in circle (265) and square (257) styles, rack construction parts incl. fiber LC/SC ports and panels (18), Kubernetes + Apache project logos (9), programming languages (22), aerospace symbols (5) — with a generated [Icon Reference](https://allamiro.github.io/grafana-network-weathermap-ng/icons/) docs page listing every icon
+
+### Bug Fixes
+
+* **empty data frame crashed the panel** on maps with node status queries — the status-color lookup resolved frame names unguarded; one transient empty series (fresh exporter, scrape gap, regex matching nothing) latched the error boundary until reload. Status values now also read via the value-field helper instead of assuming field order ([#178](https://github.com/allamiro/grafana-network-weathermap-ng/issues/178), PR [#186](https://github.com/allamiro/grafana-network-weathermap-ng/pull/186))
+* **status-legend overlay was painted over by the map SVG** — missing z-index (PR [#185](https://github.com/allamiro/grafana-network-weathermap-ng/pull/185))
+
+### Chores (not part of the plugin archive)
+
+* demo/testing: multi-device rack cabling with redundant power feeds ([#177](https://github.com/allamiro/grafana-network-weathermap-ng/issues/177)), the Interactive Rack View showcase for the new rendering features, docs use-cases 11–12, and the icon reference page
+
 ## [1.5.11](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.11) (2026-07-03)
 
 ### Chores

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,5 +8,5 @@ authors:
 repository-code: "https://github.com/allamiro/grafana-network-weathermap-ng"
 url: "https://allamiro.github.io/grafana-network-weathermap-ng/"
 license: Apache-2.0
-version: 1.5.11
+version: 1.5.12
 date-released: "2026-07-03"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamirsuliman-weathermap-panel",
-      "version": "1.5.11",
+      "version": "1.5.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.11",
+  "version": "1.5.12",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Release 1.5.12 — plugin-archive changes since 1.5.11:

- six opt-in dense-map rendering/UX features (#179, PR #184)
- icon library: 997 bundled icons across 10 sets (PRs #181, #183)
- fix: empty-data-frame panel crash via node status resolution (#178, PR #186)
- fix: status-legend overlay z-index (PR #185)

CITATION.cff version bumped alongside. After merge: `scripts/release.sh tag 1.5.12`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release 1.5.12 adds six opt-in dense-map UX features, bundles 997 icons across 10 sets, and fixes two panel issues. Also bumps versions in `package.json`, `package-lock.json`, and `CITATION.cff`.

- **New Features**
  - Six default-off options: single-direction links, hover highlight, label collision avoidance, zoom-based value labels, status legend, and per-node font overrides.
  - Icon library: 997 bundled icons across 10 sets.

- **Bug Fixes**
  - Prevent crash when node status queries return an empty data frame; status values now read safely.
  - Status-legend overlay now renders above the map (z-index fix).

<sup>Written for commit 9f38547395837b80cebeecb5edbf0d09c427f794. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

