### PR TITLE
ci: pin Node 22 LTS across workflows

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -40,8 +40,8 @@ jobs:
           fail-if-incompatible: 'no'
 
   # Job 2: matrix check — verify the plugin TypeScript compiles cleanly
-  # against each supported Grafana SDK version (11.x, 12.x — the plugin's
-  # grafanaDependency is >=11.0.0, so 10.x is not checked).
+  # against each supported Grafana SDK version (11.x, 12.x, 13.x — the
+  # plugin's grafanaDependency is >=11.0.0, so 10.x is not checked).
   # Uses --no-save so the installed test versions don't modify package.json.
   compatibility-matrix:
     name: Grafana ${{ matrix.grafana-version }} API check
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        grafana-version: ['11.0.0', '12.0.0']
+        grafana-version: ['11.0.0', '12.0.0', '13.1.0']
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -19,9 +19,9 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -40,7 +40,8 @@ jobs:
           fail-if-incompatible: 'no'
 
   # Job 2: matrix check — verify the plugin TypeScript compiles cleanly
-  # against each supported Grafana SDK version (10.x, 11.x, 12.x).
+  # against each supported Grafana SDK version (11.x, 12.x — the plugin's
+  # grafanaDependency is >=11.0.0, so 10.x is not checked).
   # Uses --no-save so the installed test versions don't modify package.json.
   compatibility-matrix:
     name: Grafana ${{ matrix.grafana-version }} API check
@@ -48,11 +49,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        grafana-version: ['10.4.0', '11.0.0', '12.0.0']
+        grafana-version: ['11.0.0', '12.0.0']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -54,7 +54,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
     name: Build docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
       attestations: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,8 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
           cache: 'npm'
       - run: npm ci --legacy-peer-deps
       - run: npm run lint


### PR DESCRIPTION
Node 24 is outside `@grafana/plugin-e2e`'s supported engine range (`>=18 <=22` — every CI run logs an EBADENGINE warning) and coincided with a transient `@swc/core` postinstall **bus error** that failed the compatibility job on the v1.5.12 release PR (siblings on the same commit passed; rerun succeeded). Pin Node 22 LTS so CI runs in-spec.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned Node.js 22 LTS across CI and bumped `actions/checkout`/`actions/setup-node` to v5 to match `@grafana/plugin-e2e` (engines >=18 <=22) and stabilize runs. Updated the compatibility matrix to remove Grafana 10.4.0 and add 13.1.0 (plugin requires >=11), eliminating EBADENGINE warnings and reducing transient `@swc/core` postinstall failures.

<sup>Written for commit 5c6d5660901fc6eaae804234ca4ecf2987c59326. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

