### PR TITLE
ci: sign plugin releases with Grafana Community signature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,19 @@ jobs:
       - name: Build plugin
         run: npm run build
 
+      - name: Sign plugin
+        env:
+          GRAFANA_ACCESS_POLICY_TOKEN: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
+        run: npx --yes @grafana/sign-plugin@latest
+
+      - name: Verify signature manifest
+        run: |
+          if [ ! -f dist/MANIFEST.txt ]; then
+            echo "::error::dist/MANIFEST.txt missing — plugin was not signed"
+            exit 1
+          fi
+          grep -q '"signatureType": "community"' dist/MANIFEST.txt
+
       - name: Get plugin metadata
         id: metadata
         run: |


### PR DESCRIPTION
## Summary

The Grafana catalog review of v1.5.12 was approved, and the plugin has been granted a **Community** signature level. The final requirement is to submit a **signed** archive built through CI (per the reviewer's recommendation to sign in GitHub Actions for reproducibility).

- Add a **Sign plugin** step to the release workflow: runs `@grafana/sign-plugin` after the build, using the `GRAFANA_ACCESS_POLICY_TOKEN` repository secret (already configured). This writes `dist/MANIFEST.txt`, which is then packaged into the release zip.
- Add a **Verify signature manifest** guard: fails the release if `MANIFEST.txt` is missing or not a Community signature, so an unsigned archive can never be published again.

Provenance attestation was already in place (`actions/attest-build-provenance@v2`) and continues to attest the (now signed) zip.

## Testing

- Signed the current 1.5.12 build locally with the same token: `sign-plugin@3.3.1` succeeded, MANIFEST.txt shows `signatureType: community`, `signedByOrg: tamirsuliman`, all dist files checksummed.
- `gh attestation verify` passes against the existing release zip, confirming the attestation pipeline works.

## Follow-up

After merge, the v1.5.12 release will be re-cut from this workflow so the published archive is signed, then the catalog submission gets updated with the new URLs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sign plugin releases in CI with the Grafana Community signature and block unsigned archives from being published. Ensures reproducible, catalog-compliant builds.

- **New Features**
  - Sign in the release workflow using `@grafana/sign-plugin@latest` with `GRAFANA_ACCESS_POLICY_TOKEN`; writes `dist/MANIFEST.txt` and includes it in the zip.
  - Add a guard that fails if `dist/MANIFEST.txt` is missing or not `"signatureType": "community"`.
  - Keep provenance attestation via `actions/attest-build-provenance@v2`.

<sup>Written for commit 2a703d7d6a78a4dc6d8e670d2683fae82bd0a574. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

