### PR TITLE
docs: Dracula color scheme for the docs site

### DIFF
--- a/website/docs/stylesheets/dracula.css
+++ b/website/docs/stylesheets/dracula.css
@@ -1,0 +1,130 @@
+/* Dracula color scheme (https://draculatheme.com/contribute#color-palette)
+ * applied to Material for MkDocs' dark ("slate") scheme via its CSS
+ * variables — no extra theme package needed, all Material features keep
+ * working. Light mode is untouched.
+ *
+ * Palette: bg #282a36 · line #44475a · fg #f8f8f2 · comment #6272a4
+ *          cyan #8be9fd · green #50fa7b · orange #ffb86c · pink #ff79c6
+ *          purple #bd93f9 · red #ff5555 · yellow #f1fa8c
+ */
+
+[data-md-color-scheme='slate'],
+[data-md-color-scheme='slate'][data-md-color-primary='black'] {
+  /* surfaces */
+  --md-default-bg-color: #282a36;
+  --md-default-fg-color: rgba(248, 248, 242, 0.87);
+  --md-default-fg-color--light: rgba(248, 248, 242, 0.6);
+  --md-default-fg-color--lighter: rgba(248, 248, 242, 0.36);
+  --md-default-fg-color--lightest: rgba(248, 248, 242, 0.12);
+
+  /* header, tabs, footer */
+  --md-primary-fg-color: #1e1f29;
+  --md-primary-fg-color--light: #44475a;
+  --md-primary-fg-color--dark: #191a21;
+  --md-primary-bg-color: #f8f8f2;
+  --md-primary-bg-color--light: rgba(248, 248, 242, 0.7);
+  --md-footer-bg-color: #191a21;
+  --md-footer-bg-color--dark: #14151b;
+
+  /* accents and links */
+  --md-accent-fg-color: #ff79c6;
+  --md-accent-fg-color--transparent: rgba(255, 121, 198, 0.1);
+  --md-typeset-a-color: #8be9fd;
+
+  /* typeset details */
+  --md-typeset-mark-color: rgba(241, 250, 140, 0.3);
+  --md-typeset-kbd-color: #44475a;
+  --md-typeset-kbd-accent-color: #6272a4;
+  --md-typeset-kbd-border-color: #191a21;
+  --md-typeset-table-color: rgba(248, 248, 242, 0.12);
+  --md-typeset-table-color--light: rgba(248, 248, 242, 0.035);
+
+  /* code blocks */
+  --md-code-bg-color: #21222c;
+  --md-code-fg-color: #f8f8f2;
+  --md-code-hl-color: #bd93f9;
+  --md-code-hl-color--light: rgba(189, 147, 249, 0.15);
+
+  /* syntax highlighting (pymdownx/pygments token classes) */
+  --md-code-hl-number-color: #bd93f9;
+  --md-code-hl-special-color: #ff79c6;
+  --md-code-hl-function-color: #50fa7b;
+  --md-code-hl-constant-color: #bd93f9;
+  --md-code-hl-keyword-color: #ff79c6;
+  --md-code-hl-string-color: #f1fa8c;
+  --md-code-hl-name-color: #f8f8f2;
+  --md-code-hl-operator-color: #ff79c6;
+  --md-code-hl-punctuation-color: #f8f8f2;
+  --md-code-hl-comment-color: #6272a4;
+  --md-code-hl-generic-color: #8be9fd;
+  --md-code-hl-variable-color: #ffb86c;
+
+  /* admonitions pick up the accent automatically; map the common ones to
+   * dracula hues for a consistent look */
+  --md-admonition-fg-color: var(--md-default-fg-color);
+  --md-admonition-bg-color: rgba(68, 71, 90, 0.35);
+}
+
+/* admonition accents: tip=green, info/note=cyan, warning=orange, danger=red */
+[data-md-color-scheme='slate'] .md-typeset .admonition.tip,
+[data-md-color-scheme='slate'] .md-typeset details.tip {
+  border-color: #50fa7b;
+}
+[data-md-color-scheme='slate'] .md-typeset .tip > .admonition-title,
+[data-md-color-scheme='slate'] .md-typeset .tip > summary {
+  background-color: rgba(80, 250, 123, 0.12);
+}
+[data-md-color-scheme='slate'] .md-typeset .tip > .admonition-title::before,
+[data-md-color-scheme='slate'] .md-typeset .tip > summary::before {
+  background-color: #50fa7b;
+}
+[data-md-color-scheme='slate'] .md-typeset .admonition.info,
+[data-md-color-scheme='slate'] .md-typeset details.info,
+[data-md-color-scheme='slate'] .md-typeset .admonition.note,
+[data-md-color-scheme='slate'] .md-typeset details.note {
+  border-color: #8be9fd;
+}
+[data-md-color-scheme='slate'] .md-typeset .info > .admonition-title,
+[data-md-color-scheme='slate'] .md-typeset .info > summary,
+[data-md-color-scheme='slate'] .md-typeset .note > .admonition-title,
+[data-md-color-scheme='slate'] .md-typeset .note > summary {
+  background-color: rgba(139, 233, 253, 0.12);
+}
+[data-md-color-scheme='slate'] .md-typeset .info > .admonition-title::before,
+[data-md-color-scheme='slate'] .md-typeset .info > summary::before,
+[data-md-color-scheme='slate'] .md-typeset .note > .admonition-title::before,
+[data-md-color-scheme='slate'] .md-typeset .note > summary::before {
+  background-color: #8be9fd;
+}
+[data-md-color-scheme='slate'] .md-typeset .admonition.warning,
+[data-md-color-scheme='slate'] .md-typeset details.warning {
+  border-color: #ffb86c;
+}
+[data-md-color-scheme='slate'] .md-typeset .warning > .admonition-title,
+[data-md-color-scheme='slate'] .md-typeset .warning > summary {
+  background-color: rgba(255, 184, 108, 0.12);
+}
+[data-md-color-scheme='slate'] .md-typeset .warning > .admonition-title::before,
+[data-md-color-scheme='slate'] .md-typeset .warning > summary::before {
+  background-color: #ffb86c;
+}
+[data-md-color-scheme='slate'] .md-typeset .admonition.danger,
+[data-md-color-scheme='slate'] .md-typeset details.danger {
+  border-color: #ff5555;
+}
+[data-md-color-scheme='slate'] .md-typeset .danger > .admonition-title,
+[data-md-color-scheme='slate'] .md-typeset .danger > summary {
+  background-color: rgba(255, 85, 85, 0.12);
+}
+[data-md-color-scheme='slate'] .md-typeset .danger > .admonition-title::before,
+[data-md-color-scheme='slate'] .md-typeset .danger > summary::before {
+  background-color: #ff5555;
+}
+
+/* search input on the dracula header */
+[data-md-color-scheme='slate'] .md-search__form {
+  background-color: rgba(68, 71, 90, 0.6);
+}
+[data-md-color-scheme='slate'] .md-search__form:hover {
+  background-color: rgba(68, 71, 90, 0.9);
+}

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -11,16 +11,19 @@ theme:
     - search.highlight
   logo: assets/logo.svg
   palette:
-    - scheme: default
-      primary: black
-      toggle:
-        icon: material/brightness-7
-        name: Switch to dark mode
+    # Dracula (dark) is the default; styled via stylesheets/dracula.css
     - scheme: slate
       primary: black
       toggle:
         icon: material/brightness-4
         name: Switch to light mode
+    - scheme: default
+      primary: black
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+extra_css:
+  - stylesheets/dracula.css
 markdown_extensions:
   - admonition
   - pymdownx.details


### PR DESCRIPTION
## Summary

Documentation-site-only change — no plugin code, no release.

Applies the official [Dracula palette](https://draculatheme.com/contribute#color-palette) to the docs site and makes dark mode the default:

- **No new dependency**: instead of swapping to the standalone `mkdocs-dracula-theme` (which would drop Material's admonitions styling, collapsible blocks, tabs, and search UI), the Dracula colors are applied to Material's dark ("slate") scheme via its CSS variables in one stylesheet (`docs/stylesheets/dracula.css`). Nothing new to pip-install in CI.
- Full palette mapping: surfaces (#282a36/#44475a), header/footer, cyan links, pink accents, Dracula syntax highlighting for code blocks (pink keywords, yellow strings, purple numbers, comment #6272a4), and admonition accents (tip=green, note/info=cyan, warning=orange, danger=red).
- Dark (Dracula) is now the default scheme; the light-mode toggle still works and light mode is untouched.
- A compound `[data-md-color-scheme][data-md-color-primary]` selector is needed so the variables out-rank Material's built-in primary-color rules — verified by inspecting computed styles in headless Chromium.

`mkdocs build --strict` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies the official Dracula color scheme to the docs by overriding Material’s dark scheme and makes dark mode the default. No new dependencies; all Material features remain intact.

- **New Features**
  - Adds `website/docs/stylesheets/dracula.css` with full Dracula palette mapping for surfaces, links, code highlighting, and admonitions.
  - Avoids switching to `mkdocs-dracula-theme`, preserving Material UI (admonitions, tabs, search).
  - Updates `website/mkdocs.yml` to load the stylesheet and set the dark “slate” scheme as default; light-mode toggle still works.

<sup>Written for commit d1f3d947e251cb4c16ecd31a618e213fdfb0528e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

