### PR TITLE
ci: least-privilege GITHUB_TOKEN permissions (CodeQL alerts #2, #3)

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -7,6 +7,11 @@ on:
       - 'package.json'
   pull_request:
 
+# Least-privilege default for the GITHUB_TOKEN; jobs that need more (the
+# PR-comment step in the latest check) declare their own block.
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,11 @@ on:
       - 'package-lock.json'
   pull_request:
 
+# CI only reads the repo; least-privilege token per CodeQL
+# actions/missing-workflow-permissions.
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 


### PR DESCRIPTION
## Summary

Resolves the two open CodeQL `actions/missing-workflow-permissions` alerts by declaring an explicit least-privilege `permissions: contents: read` block in:

- `test.yml` (alert #3) — lint/typecheck/test/build only reads the repo
- `compatibility.yml` (alert #2) — workflow-level read-only default; the "latest" levitate job keeps its existing `pull-requests: write` block for PR comments, which overrides the workflow default

This only scopes the ephemeral `GITHUB_TOKEN` injected into CI runs — it does not restrict developers' ability to commit, push, or merge in any way. `release.yml` and `docs.yml` already declare their permissions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets least-privilege `permissions: contents: read` in `test.yml` and `compatibility.yml` to scope the CI `GITHUB_TOKEN` and resolve CodeQL `actions/missing-workflow-permissions` alerts (#3, #2). The compatibility workflow keeps `pull-requests: write` for its PR comment step; this only affects the ephemeral CI token, not developer permissions.

<sup>Written for commit c8552744cba6b9d4225fb0287b4759ae4508e5bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

