### PR TITLE
fix: query dropdown entries indistinguishable with many series from one query (#191)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,7 @@
     "playwright.config.ts",
     "tests/",
     "testing/scripts/",
-    "website/scripts/"
+    "website/scripts/",
+    "website/site/"
   ]
 }

--- a/src/forms/LinkForm.tsx
+++ b/src/forms/LinkForm.tsx
@@ -18,7 +18,7 @@ import { SelectableValue, StandardEditorProps } from '@grafana/data';
 import { v4 as uuidv4 } from 'uuid';
 import { Weathermap, Node, Link, Anchor, LinkSide, LinkTooltipMetric } from 'types';
 import { FormDivider } from './FormDivider';
-import { getDataFrameName, getValueField, sanitizeUrl } from 'utils';
+import { buildQueryOptions, sanitizeUrl } from 'utils';
 
 interface Settings {
   placeholder: string;
@@ -188,26 +188,7 @@ export const LinkForm = (props: Props) => {
   let usedConnectionNodes = usedConnectionSourceNodes.filter((n) => usedConnectionTargetNodes.includes(n));
   let availableNodes = value.nodes.filter((n) => !usedConnectionNodes.includes(n.id));
 
-  const seenNames = new Set<string>();
-  let dataWithIds: Array<{ value: string; label: string }> = [];
-  context.data.forEach((d) => {
-    if (d.fields.length < 2) {
-      return;
-    }
-    try {
-      const name = getDataFrameName(d, context.data);
-      if (!seenNames.has(name)) {
-        seenNames.add(name);
-        // Build a concise label: "refId: fieldName" so the dropdown stays
-        // readable even when Grafana appends full label sets to the display name.
-        const fieldName = getValueField(d).name || name;
-        const label = d.refId ? `${d.refId}: ${fieldName}` : fieldName;
-        dataWithIds.push({ value: name, label });
-      }
-    } catch (e) {
-      console.warn('Network Weathermap: Error while attempting to access query data.', e);
-    }
-  });
+  const dataWithIds = buildQueryOptions(context.data);
 
   return (
     <React.Fragment>

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -4,6 +4,7 @@ import { DrawnNode, Weathermap } from 'types';
 import {
   addViaToLink,
   buildQueryOptions,
+  getDataFrameName,
   resolveLinkChain,
   spreadLabels,
   aggregateFieldValues,
@@ -384,7 +385,7 @@ describe('buildQueryOptions (#49, #191)', () => {
     expect(new Set(labels).size).toBe(3);
     expect(labels[0]).toContain('ge-0/0/1');
     // stored values stay the full display names so existing configs match
-    expect(opts.map((o) => o.value)).toEqual(frames.map((f, i) => opts[i].value));
+    expect(opts.map((o) => o.value)).toEqual(frames.map((f) => getDataFrameName(f, frames)));
     opts.forEach((o) => expect(o.value).toContain('wm_link_bps'));
   });
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,7 +1,9 @@
+import { toDataFrame } from '@grafana/data';
 import { defaultNodes, getData, legacyWeathermap, theme } from 'testData';
 import { DrawnNode, Weathermap } from 'types';
 import {
   addViaToLink,
+  buildQueryOptions,
   resolveLinkChain,
   spreadLabels,
   aggregateFieldValues,
@@ -354,5 +356,57 @@ describe('spreadLabels (#179)', () => {
       expect(pct).toBeGreaterThanOrEqual(10);
       expect(pct).toBeLessThanOrEqual(90);
     }
+  });
+});
+
+describe('buildQueryOptions (#49, #191)', () => {
+  const frame = (refId: string, displayName: string, valueFieldName = 'Value') =>
+    toDataFrame({
+      refId,
+      fields: [
+        { name: 'Time', values: [1, 2] },
+        { name: valueFieldName, values: [10, 20], config: { displayNameFromDS: displayName } },
+      ],
+    });
+
+  test('one query returning many series keeps every label distinguishable (#191)', () => {
+    // Simulates a single Prometheus rate() query: same refId, same "Value"
+    // field, distinct label sets in the display name.
+    const frames = [
+      frame('A', 'wm_link_bps{device="rtr-1",interface="ge-0/0/1",direction="tx",job="wm",site="dfw"}'),
+      frame('A', 'wm_link_bps{device="rtr-1",interface="ge-0/0/2",direction="tx",job="wm",site="dfw"}'),
+      frame('A', 'wm_link_bps{device="rtr-2",interface="ge-0/0/1",direction="tx",job="wm",site="atl"}'),
+    ];
+    const opts = buildQueryOptions(frames);
+    expect(opts).toHaveLength(3);
+    // pre-#191-fix behavior collapsed all labels to "A: Value"
+    const labels = opts.map((o) => o.label);
+    expect(new Set(labels).size).toBe(3);
+    expect(labels[0]).toContain('ge-0/0/1');
+    // stored values stay the full display names so existing configs match
+    expect(opts.map((o) => o.value)).toEqual(frames.map((f, i) => opts[i].value));
+    opts.forEach((o) => expect(o.value).toContain('wm_link_bps'));
+  });
+
+  test('long unique disambiguation strings stay concise (#49)', () => {
+    const frames = [
+      frame('A', 'node_cpu_seconds_total{mode="idle",instance="host-1:9100",job="node"}', 'node_cpu_seconds_total'),
+      frame('B', 'node_network_transmit_bytes_total{device="eth0",instance="host-1:9100"}', 'node_network_transmit_bytes_total'),
+    ];
+    const opts = buildQueryOptions(frames);
+    expect(opts.map((o) => o.label)).toEqual(['A: node_cpu_seconds_total', 'B: node_network_transmit_bytes_total']);
+  });
+
+  test('short display names (custom legends) are shown verbatim', () => {
+    const frames = [frame('A', 'SW-CORE to BKB-CARPINA'), frame('B', 'BKB-CARPINA to SW-CORE')];
+    const opts = buildQueryOptions(frames);
+    expect(opts.map((o) => o.label)).toEqual(['SW-CORE to BKB-CARPINA', 'BKB-CARPINA to SW-CORE']);
+  });
+
+  test('frames without a value field or with duplicate names are skipped', () => {
+    const empty = toDataFrame({ fields: [] });
+    const dupe = frame('A', 'SAME NAME');
+    const opts = buildQueryOptions([empty, dupe, frame('A', 'SAME NAME')]);
+    expect(opts).toHaveLength(1);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -439,6 +439,66 @@ export const getDataFrameName = (frame: DataFrame, allFrames: DataFrame[]): stri
   return getFieldDisplayName(getValueField(frame), frame, allFrames);
 };
 
+/** A select option for picking one of the panel's query result frames. */
+export interface QueryOption {
+  value: string;
+  label: string;
+}
+
+/**
+ * Display names at or below this length are shown in dropdowns verbatim —
+ * longer Grafana disambiguation strings fall back to a concise form (#49).
+ */
+const QUERY_LABEL_MAX_VERBATIM = 60;
+
+/**
+ * Build the options for the query-picker dropdowns.
+ *
+ * The stored value is always the frame's full display name (what the panel
+ * matches series by), so existing configs keep working. The visible label
+ * balances two failure modes:
+ *  - Long disambiguation strings made dropdowns unreadable (#49), so long
+ *    names are shortened to "refId: fieldName" — but only while that stays
+ *    unique.
+ *  - One query returning many series gave every frame the same "A: Value"
+ *    concise label (#191), so when concise labels collide the full display
+ *    name (with its distinguishing label set) is used instead.
+ */
+export const buildQueryOptions = (frames: DataFrame[]): QueryOption[] => {
+  const seenNames = new Set<string>();
+  const entries: Array<{ value: string; concise: string }> = [];
+  for (const d of frames) {
+    if (d.fields.length < 2) {
+      continue;
+    }
+    try {
+      const name = getDataFrameName(d, frames);
+      if (seenNames.has(name)) {
+        continue;
+      }
+      seenNames.add(name);
+      const fieldName = getValueField(d).name || name;
+      const concise = d.refId ? `${d.refId}: ${fieldName}` : fieldName;
+      entries.push({ value: name, concise });
+    } catch (e) {
+      console.warn('Network Weathermap: Error while attempting to access query data.', e);
+    }
+  }
+
+  const conciseCounts = new Map<string, number>();
+  for (const e of entries) {
+    conciseCounts.set(e.concise, (conciseCounts.get(e.concise) ?? 0) + 1);
+  }
+
+  return entries.map((e) => {
+    if (e.value.length <= QUERY_LABEL_MAX_VERBATIM) {
+      return { value: e.value, label: e.value };
+    }
+    const conciseIsUnique = conciseCounts.get(e.concise) === 1;
+    return { value: e.value, label: conciseIsUnique ? e.concise : e.value };
+  });
+};
+
 /**
  * Schemes that are explicitly unsafe for navigation or resource loading.
  * Any absolute URL must use http:// or https:// — everything else is rejected.


### PR DESCRIPTION
## Summary

Fixes #191 — with a single Prometheus query returning many series, every entry in the link query dropdowns rendered as `A: Value`, making selection impossible.

**Root cause:** the #49/#90 readability fix (8992c88) shortened dropdown labels to `refId: fieldName`. For a multi-series Prometheus response every frame shares refId `A` and value-field name `Value`, so all labels collapsed to the same string. Present in 1.5.11 and 1.5.12. Only labels were affected — the stored value remained the unique frame display name.

**Fix:** the label logic moves to a tested helper (`buildQueryOptions` in `utils.ts`, shared by all five link dropdowns) with an explicit precedence:

1. Display names ≤ 60 chars are shown **verbatim** — custom legends and short labelsets appear exactly as configured.
2. Longer names use the concise `refId: fieldName` form **only while it is unique** (preserves the #49 fix).
3. When concise labels would collide (the #191 case), the full display name with its labelset is shown, so every entry stays distinguishable — the labelset view the reporter asked for.

Stored values are unchanged (full display name), so existing link configs keep matching.

## Testing

- New unit tests covering: the #191 many-series scenario (labels distinct, values preserved), the #49 long-unique-names scenario (stays concise), custom legends shown verbatim, and skipping valueless/duplicate frames. Full suite: 73/73 pass.
- Live repro in Grafana 12.4 against the demo Prometheus: `rate(wm_link_bps[2m])` (56 series, no legend) previously produced 56× `A: Value`; the A Side Query dropdown now lists 56 distinct labelsets (verified programmatically and by screenshot).
- `npm run lint`, `typecheck`, and `build` clean. (`.eslintrc` also gains `website/site/` in ignorePatterns so local mkdocs output can't pollute lint runs.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix query dropdown labels so entries stay distinguishable when one query returns many series. Labels now fall back to the full display name when needed and keep the short form only if it stays unique; saved values remain the full display name.

- **Bug Fixes**
  - Address #191 where multi-series Prometheus results all showed as "A: Value".
  - Label rules: show display names ≤ 60 chars verbatim; use "refId: field" only if unique; otherwise use the full display name.
  - Applies to all link-side query dropdowns; existing configs continue to match.

- **Refactors**
  - Centralized label logic in `buildQueryOptions` (`utils.ts`) and used by `LinkForm`.
  - Added unit tests for multi-series, concise-unique, custom legends, and duplicate/empty frames; tests also assert stored values via `getDataFrameName`.
  - Updated `.eslintrc` to ignore `website/site/`.

<sup>Written for commit dd3096a72112836269c4c5bda8d3d30fb5565dd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

