### PR TITLE
test: regression hardening for editor, migration, hostile data, and packaging

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
     "tests/",
     "testing/scripts/",
     "website/scripts/",
-    "website/site/"
+    "website/site/",
+    "scripts/"
   ]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Build plugin
         run: npm run build
 
+      - name: Verify dist packaging
+        run: node scripts/verify-dist.js
+
       - name: Sign plugin
         env:
           GRAFANA_ACCESS_POLICY_TOKEN: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,5 @@ jobs:
       - run: npm run typecheck
       - run: npm run test:ci
       - run: npm run build
+      - name: Verify dist packaging
+        run: node scripts/verify-dist.js

--- a/scripts/verify-dist.js
+++ b/scripts/verify-dist.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/*
+ * Packaging sanity check, run in CI after `npm run build`.
+ *
+ * Catches "the build config drifted" regressions before they reach a signed
+ * release: version mismatches between package.json and the built plugin.json,
+ * icon sets missing from dist (webpack copy config), and required metadata
+ * files not making it into the archive.
+ */
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const DIST = path.join(ROOT, 'dist');
+const failures = [];
+
+const check = (ok, message) => {
+  if (!ok) {
+    failures.push(message);
+  }
+};
+
+// 1. dist exists and carries the module + metadata files.
+check(fs.existsSync(DIST), 'dist/ does not exist — run npm run build first');
+for (const f of ['module.js', 'plugin.json', 'README.md', 'CHANGELOG.md', 'LICENSE', 'NOTICE']) {
+  check(fs.existsSync(path.join(DIST, f)), `dist/${f} is missing`);
+}
+
+// 2. plugin.json version must match package.json (a release built from a
+// stale dist would otherwise ship the wrong version silently).
+try {
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+  const plugin = JSON.parse(fs.readFileSync(path.join(DIST, 'plugin.json'), 'utf8'));
+  check(
+    plugin.info.version === pkg.version,
+    `version mismatch: dist/plugin.json has ${plugin.info.version}, package.json has ${pkg.version}`
+  );
+  check(plugin.id === 'tamirsuliman-weathermap-panel', `unexpected plugin id: ${plugin.id}`);
+
+  // Screenshots and logos declared in plugin.json must exist in dist.
+  const assets = [
+    ...(plugin.info.logos ? Object.values(plugin.info.logos) : []),
+    ...(plugin.info.screenshots ?? []).map((s) => s.path),
+  ];
+  for (const rel of assets) {
+    check(fs.existsSync(path.join(DIST, rel)), `plugin.json references missing asset: ${rel}`);
+  }
+} catch (e) {
+  failures.push(`could not compare versions: ${e.message}`);
+}
+
+// 3. Every icon set in src/icons must reach dist/icons with the same file
+// count (guards the webpack CopyPlugin config).
+const srcIcons = path.join(ROOT, 'src', 'icons');
+const distIcons = path.join(DIST, 'icons');
+check(fs.existsSync(distIcons), 'dist/icons is missing entirely');
+if (fs.existsSync(srcIcons) && fs.existsSync(distIcons)) {
+  for (const set of fs.readdirSync(srcIcons).filter((d) => fs.statSync(path.join(srcIcons, d)).isDirectory())) {
+    const srcCount = fs.readdirSync(path.join(srcIcons, set)).filter((f) => f.endsWith('.svg')).length;
+    const distSet = path.join(distIcons, set);
+    const distCount = fs.existsSync(distSet) ? fs.readdirSync(distSet).filter((f) => f.endsWith('.svg')).length : 0;
+    check(distCount === srcCount, `icon set "${set}": src has ${srcCount} svg(s), dist has ${distCount}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('dist verification FAILED:');
+  for (const f of failures) {
+    console.error(`  - ${f}`);
+  }
+  process.exit(1);
+}
+console.log('dist verification passed');

--- a/scripts/verify-dist.js
+++ b/scripts/verify-dist.js
@@ -49,17 +49,26 @@ try {
   failures.push(`could not compare versions: ${e.message}`);
 }
 
-// 3. Every icon set in src/icons must reach dist/icons with the same file
-// count (guards the webpack CopyPlugin config).
+// 3. Every icon set in src/icons must reach dist/icons with exactly the same
+// files — filename comparison, not just counts, so a swapped or missing icon
+// is caught too (guards the webpack CopyPlugin config).
+const svgsIn = (dir) => (fs.existsSync(dir) ? fs.readdirSync(dir).filter((f) => f.endsWith('.svg')).sort() : []);
 const srcIcons = path.join(ROOT, 'src', 'icons');
 const distIcons = path.join(DIST, 'icons');
 check(fs.existsSync(distIcons), 'dist/icons is missing entirely');
 if (fs.existsSync(srcIcons) && fs.existsSync(distIcons)) {
   for (const set of fs.readdirSync(srcIcons).filter((d) => fs.statSync(path.join(srcIcons, d)).isDirectory())) {
-    const srcCount = fs.readdirSync(path.join(srcIcons, set)).filter((f) => f.endsWith('.svg')).length;
-    const distSet = path.join(distIcons, set);
-    const distCount = fs.existsSync(distSet) ? fs.readdirSync(distSet).filter((f) => f.endsWith('.svg')).length : 0;
-    check(distCount === srcCount, `icon set "${set}": src has ${srcCount} svg(s), dist has ${distCount}`);
+    const srcFiles = svgsIn(path.join(srcIcons, set));
+    const distFiles = new Set(svgsIn(path.join(distIcons, set)));
+    const missing = srcFiles.filter((f) => !distFiles.has(f));
+    check(
+      missing.length === 0,
+      `icon set "${set}": ${missing.length} svg(s) missing from dist (${missing.slice(0, 3).join(', ')}${missing.length > 3 ? ', …' : ''})`
+    );
+    check(
+      distFiles.size === srcFiles.length,
+      `icon set "${set}": dist has ${distFiles.size} svg(s), src has ${srcFiles.length}`
+    );
   }
 }
 

--- a/src/WeathermapPanel.hostile.test.tsx
+++ b/src/WeathermapPanel.hostile.test.tsx
@@ -1,0 +1,114 @@
+// Hostile-data render matrix: shapes that have crashed the panel in the wild
+// (#178 was one instance) or can appear via hand-edited/provisioned
+// dashboards. The panel must render — degraded, never thrown.
+import React from 'react';
+import { getDefaultRelativeTimeRange, getTimeZone, LoadingState, PanelProps, toDataFrame } from '@grafana/data';
+import { render, screen } from '@testing-library/react';
+import { WeathermapPanel } from 'WeathermapPanel';
+import { SimpleOptions, Weathermap } from 'types';
+import { getData, theme } from 'testData';
+
+const renderPanel = (series: unknown[], mutate?: (wm: Weathermap) => void) => {
+  const wm = getData(theme);
+  wm.links[0].sides.A.query = 'A QUERY';
+  wm.links[0].sides.Z.query = 'Z QUERY';
+  wm.nodes.forEach((n) => (n.statusQuery = 'STATUS X'));
+  if (mutate) {
+    mutate(wm);
+  }
+  const props = {
+    id: 1,
+    data: { state: LoadingState.Done, series, timeRange: getDefaultRelativeTimeRange() },
+    timeRange: getDefaultRelativeTimeRange(),
+    timeZone: getTimeZone(),
+    options: { weathermap: wm },
+    transparent: false,
+    width: 600,
+    height: 400,
+    fieldConfig: {},
+    renderCounter: 1,
+    title: 'T',
+    eventBus: {},
+    onOptionsChange: () => {},
+  } as unknown as PanelProps<SimpleOptions>;
+  render(<WeathermapPanel {...props} />);
+};
+
+const expectRendered = () => expect(screen.getAllByTestId('link').length).toBeGreaterThan(0);
+
+const goodFrame = (name: string, values: number[] = [1, 2, 3]) =>
+  toDataFrame({
+    refId: 'A',
+    fields: [
+      { name: 'Time', values: values.map((_, i) => i * 1000) },
+      { name: 'Value', values, config: { displayNameFromDS: name } },
+    ],
+  });
+
+test('frame with a time field but no value field', () => {
+  renderPanel([toDataFrame({ fields: [{ name: 'Time', values: [1, 2, 3] }] })]);
+  expectRendered();
+});
+
+test('frame with all-NaN values', () => {
+  renderPanel([goodFrame('A QUERY', [NaN, NaN, NaN] as unknown as number[])]);
+  expectRendered();
+});
+
+test('frames with duplicate display names', () => {
+  renderPanel([goodFrame('A QUERY'), goodFrame('A QUERY'), goodFrame('Z QUERY')]);
+  expectRendered();
+});
+
+test('value field without a time field', () => {
+  renderPanel([
+    toDataFrame({
+      refId: 'A',
+      fields: [{ name: 'Value', values: [5, 6], config: { displayNameFromDS: 'A QUERY' } }],
+    }),
+  ]);
+  expectRendered();
+});
+
+test('link whose queries match no frame', () => {
+  renderPanel([goodFrame('SOMETHING ELSE ENTIRELY')]);
+  expectRendered();
+});
+
+test('zero and negative panel-ish values', () => {
+  renderPanel([goodFrame('A QUERY', [0, -100, 0])]);
+  expectRendered();
+});
+
+test('node icon pointing at a nonexistent bundled icon still renders', () => {
+  renderPanel([goodFrame('A QUERY')], (wm) => {
+    wm.nodes[0].nodeIcon = {
+      src: 'public/plugins/tamirsuliman-weathermap-panel/icons/networking/does-not-exist.svg',
+      name: 'networking/does-not-exist',
+      size: { width: 40, height: 40 },
+      padding: { vertical: 0, horizontal: 0 },
+      drawInside: false,
+    };
+  });
+  expectRendered();
+});
+
+test('scale with a single threshold and out-of-range utilization', () => {
+  renderPanel([goodFrame('A QUERY', [10_000_000_000])], (wm) => {
+    wm.scale = [{ percent: 0, color: '#00ff00' }];
+    wm.links[0].sides.A.bandwidth = 1; // utilization far above 100%
+  });
+  expectRendered();
+});
+
+test('connection node with fewer than two links (corrupt VIA) does not crash', () => {
+  renderPanel([goodFrame('A QUERY')], (wm) => {
+    wm.nodes.push({
+      ...JSON.parse(JSON.stringify(wm.nodes[0])),
+      id: 'dangling-via',
+      label: 'C0',
+      isConnection: true,
+    });
+  });
+  expectRendered();
+});

--- a/src/forms/LinkForm.test.tsx
+++ b/src/forms/LinkForm.test.tsx
@@ -1,0 +1,99 @@
+// Component-level regression tests for the link query dropdowns (#49, #191):
+// the options must stay visually distinguishable with real multi-series data,
+// and selecting an option must store the frame's full display name (the
+// stored value is what the panel matches series by).
+import React, { useState } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { StandardEditorProps, toDataFrame } from '@grafana/data';
+import { LinkForm } from './LinkForm';
+import { Weathermap } from 'types';
+import { getData, theme } from '../testData';
+
+const promFrame = (refId: string, displayName: string) =>
+  toDataFrame({
+    refId,
+    fields: [
+      { name: 'Time', values: [1, 2] },
+      { name: 'Value', values: [10, 20], config: { displayNameFromDS: displayName } },
+    ],
+  });
+
+// Simulates one Prometheus rate() query returning several series: same refId,
+// same "Value" field, distinct label sets — the #191 scenario.
+const MULTI_SERIES = [
+  promFrame('A', 'wm_link_bps{device="rtr-1", direction="tx", interface="ge-0/0/1", job="wm", site="dfw"}'),
+  promFrame('A', 'wm_link_bps{device="rtr-1", direction="tx", interface="ge-0/0/2", job="wm", site="dfw"}'),
+  promFrame('A', 'wm_link_bps{device="rtr-2", direction="tx", interface="ge-0/0/1", job="wm", site="atl"}'),
+];
+
+const Harness = ({ initial, onChangeSpy, frames }: { initial: Weathermap; onChangeSpy: jest.Mock; frames: unknown[] }) => {
+  const [wm, setWm] = useState(initial);
+  const props = {
+    value: wm,
+    onChange: (v: Weathermap) => {
+      onChangeSpy(v);
+      setWm(v);
+    },
+    context: { data: frames },
+    item: { settings: { placeholder: '' } },
+  } as unknown as StandardEditorProps<Weathermap, { placeholder: string }>;
+  return <LinkForm {...props} />;
+};
+
+// Open the react-select whose control currently shows the given text (its
+// placeholder or selected value): walk up from that text node to the nearest
+// ancestor containing a combobox input, then key ArrowDown on it.
+const openSelectShowing = (text: string) => {
+  const shown = screen.getByText(text);
+  let control: HTMLElement | null = shown.parentElement;
+  while (control && !control.querySelector('[role="combobox"]')) {
+    control = control.parentElement;
+  }
+  const combobox = control?.querySelector('[role="combobox"]');
+  expect(combobox).toBeTruthy();
+  fireEvent.keyDown(combobox!, { key: 'ArrowDown' });
+};
+
+const selectFirstLink = async () => {
+  openSelectShowing('Select a link');
+  fireEvent.click(await screen.findByText(/Node A/));
+};
+
+test('one query with many series renders distinct A Side Query options (#191)', async () => {
+  render(<Harness initial={getData(theme)} onChangeSpy={jest.fn()} frames={MULTI_SERIES} />);
+  await selectFirstLink();
+
+  openSelectShowing('Select A Side Query');
+  const options = await screen.findAllByRole('option');
+
+  expect(options.length).toBe(MULTI_SERIES.length);
+  const labels = options.map((o) => o.textContent);
+  expect(new Set(labels).size).toBe(labels.length);
+  // Every label carries something that tells the series apart.
+  expect(labels.filter((l) => l?.includes('ge-0/0/1'))).toHaveLength(2);
+});
+
+test('selecting an option stores the full display name, not the label (#191)', async () => {
+  const spy = jest.fn();
+  render(<Harness initial={getData(theme)} onChangeSpy={spy} frames={MULTI_SERIES} />);
+  await selectFirstLink();
+
+  openSelectShowing('Select A Side Query');
+  const options = await screen.findAllByRole('option');
+  fireEvent.click(options[1]);
+
+  const updated: Weathermap = spy.mock.calls[spy.mock.calls.length - 1][0];
+  expect(updated.links[0].sides.A.query).toBe(
+    'wm_link_bps{device="rtr-1", direction="tx", interface="ge-0/0/2", job="wm", site="dfw"}'
+  );
+});
+
+test('short custom legends appear verbatim in the dropdown', async () => {
+  const frames = [promFrame('A', 'SW-CORE to BKB-CARPINA'), promFrame('B', 'BKB-CARPINA to SW-CORE')];
+  render(<Harness initial={getData(theme)} onChangeSpy={jest.fn()} frames={frames} />);
+  await selectFirstLink();
+
+  openSelectShowing('Select A Side Query');
+  expect(await screen.findByText('SW-CORE to BKB-CARPINA')).toBeInTheDocument();
+  expect(screen.getByText('BKB-CARPINA to SW-CORE')).toBeInTheDocument();
+});

--- a/src/forms/WeathermapBuilder.test.tsx
+++ b/src/forms/WeathermapBuilder.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { StandardEditorProps } from '@grafana/data';
 import { WeathermapBuilder } from './WeathermapBuilder';
 import { Weathermap } from 'types';
 import { CURRENT_VERSION } from 'utils';
-import { legacyWeathermap } from 'testData';
+import { getData, legacyWeathermap, theme } from 'testData';
 
 const renderBuilder = (value: Weathermap | undefined) => {
   const onChange = jest.fn();
@@ -55,4 +55,29 @@ test('initializes and renders the default weathermap when no value is saved', ()
   // Previously the builder rendered nothing on the first pass; now the forms
   // render immediately with the initialized value.
   expect(screen.getByText('Tooltip Font Size')).toBeInTheDocument();
+});
+
+// The Grafana 13 "Status Color Target radio loses selection" bug was caused
+// by duplicate element ids across the options pane (#167). Guard the whole
+// editor: no two rendered elements may share an id, and radio inputs must
+// all carry one.
+test('editor renders no duplicate element ids (#167)', async () => {
+  renderBuilder(getData(theme));
+
+  // Expand the sections that mount id-carrying controls lazily.
+  const picker = screen.getAllByRole('combobox')[0];
+  fireEvent.keyDown(picker, { key: 'ArrowDown' });
+  fireEvent.click(await screen.findByText('Node A'));
+  fireEvent.click(screen.getByText('Status'));
+  fireEvent.click(screen.getByText('Advanced'));
+
+  const ids = Array.from(document.querySelectorAll('[id]'))
+    .map((el) => el.id)
+    .filter((id) => id.length > 0);
+  const duplicates = ids.filter((id, i) => ids.indexOf(id) !== i);
+  expect(duplicates).toEqual([]);
+
+  for (const radio of screen.getAllByRole('radio')) {
+    expect(radio.id).not.toBe('');
+  }
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -411,3 +411,50 @@ describe('buildQueryOptions (#49, #191)', () => {
     expect(opts).toHaveLength(1);
   });
 });
+
+describe('handleVersionedStateUpdates round-trip guarantees', () => {
+  test('migration is idempotent: migrating a migrated map changes nothing', () => {
+    const once = handleVersionedStateUpdates(JSON.parse(JSON.stringify(legacyWeathermap)), theme);
+    const twice = handleVersionedStateUpdates(JSON.parse(JSON.stringify(once)), theme);
+    expect(twice).toEqual(once);
+  });
+
+  test('migration preserves node and link identity and query bindings', () => {
+    const legacy = JSON.parse(JSON.stringify(legacyWeathermap));
+    const migrated = handleVersionedStateUpdates(legacy, theme);
+
+    // Every node keeps its id, label, and position.
+    expect(migrated.nodes.map((n: { id: string }) => n.id)).toEqual(
+      legacyWeathermap.nodes.map((n: { id: string }) => n.id)
+    );
+    for (let i = 0; i < legacyWeathermap.nodes.length; i++) {
+      expect(migrated.nodes[i].label).toBe(legacyWeathermap.nodes[i].label);
+      expect(migrated.nodes[i].position).toEqual(legacyWeathermap.nodes[i].position);
+    }
+    // Every link keeps its endpoints and per-side query/bandwidth bindings.
+    expect(migrated.links).toHaveLength(legacyWeathermap.links.length);
+    for (let i = 0; i < legacyWeathermap.links.length; i++) {
+      const before = legacyWeathermap.links[i] as any;
+      const after = migrated.links[i] as any;
+      expect(after.id).toBe(before.id);
+      for (const side of ['A', 'Z']) {
+        expect(after.sides[side].query).toEqual(before.sides[side].query);
+        expect(after.sides[side].bandwidth).toEqual(before.sides[side].bandwidth);
+      }
+    }
+  });
+
+  test('a current-version map missing newer optional settings gains defaults without losing config', () => {
+    // Simulates a dashboard saved by an older 1.5.x release: schema already
+    // v14, but fields added later (status legend, hover options) absent.
+    const saved = JSON.parse(JSON.stringify(getData(theme)));
+    delete saved.settings.statusLegend;
+    delete saved.settings.link.hoverHighlight;
+    delete saved.settings.link.labelCollision;
+    saved.links[0].sides.A.query = 'MY QUERY';
+
+    const migrated = handleVersionedStateUpdates(JSON.parse(JSON.stringify(saved)), theme);
+    expect(migrated.links[0].sides.A.query).toBe('MY QUERY');
+    expect(migrated.nodes.map((n: { id: string }) => n.id)).toEqual(saved.nodes.map((n: { id: string }) => n.id));
+  });
+});

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -444,17 +444,18 @@ describe('handleVersionedStateUpdates round-trip guarantees', () => {
     }
   });
 
-  test('a current-version map missing newer optional settings gains defaults without losing config', () => {
-    // Simulates a dashboard saved by an older 1.5.x release: schema already
-    // v14, but fields added later (status legend, hover options) absent.
+  test('a current-version map passes through migration with all config intact', () => {
+    // Simulates a dashboard saved by an older 1.5.x release at the current
+    // schema version: newer optional fields (statusLegend, hoverHighlight,
+    // labelCollision) are absent — they are handled by runtime defaults, so
+    // migration must neither invent them nor disturb anything else.
     const saved = JSON.parse(JSON.stringify(getData(theme)));
-    delete saved.settings.statusLegend;
-    delete saved.settings.link.hoverHighlight;
-    delete saved.settings.link.labelCollision;
     saved.links[0].sides.A.query = 'MY QUERY';
 
     const migrated = handleVersionedStateUpdates(JSON.parse(JSON.stringify(saved)), theme);
     expect(migrated.links[0].sides.A.query).toBe('MY QUERY');
+    expect(migrated.version).toBe(CURRENT_VERSION);
     expect(migrated.nodes.map((n: { id: string }) => n.id)).toEqual(saved.nodes.map((n: { id: string }) => n.id));
+    expect(migrated.settings.statusLegend).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Adds the test families discussed after #191 — each maps to a bug class this repo has actually shipped, so the same class can't land again without a red X. Test-only plus one CI step; no plugin behavior changes, no release needed.

1. **Editor dropdown component tests** (`LinkForm.test.tsx`, new): renders the real LinkForm with Prometheus-shaped multi-series `PanelData` and asserts the A Side Query options are present and visually distinct (#191 at the component level, not just the helper), that selecting stores the frame's full display name (label/value divergence is what broke), and that short custom legends appear verbatim.
2. **Duplicate-DOM-id guard** (`WeathermapBuilder.test.tsx`): renders the whole editor, expands lazily-mounted sections, and asserts no two elements share an id and every radio has one — the Grafana 13 "Status Color Target loses selection" class (#167), retired permanently.
3. **Migration round-trip guarantees** (`utils.test.ts`): `handleVersionedStateUpdates` must be idempotent; must preserve node ids/labels/positions and per-side query+bandwidth bindings from the pre-v14 fixture; and a current-version map missing newer optional settings (as saved by older 1.5.x) must gain defaults without losing config — the "upgrade ate my dashboard" class.
4. **Hostile-data render matrix** (`WeathermapPanel.hostile.test.tsx`, new): 9 pathological shapes seen in the wild or reachable via hand-edited dashboards — time-only frames, all-NaN values, duplicate display names, value-without-time, unmatched queries, negative values, missing icon path, out-of-range utilization with a single-threshold scale, and a corrupt single-link VIA node. The panel must render, never throw (#178's family). All pass against current code — pure insurance.
5. **Packaging sanity in CI** (`scripts/verify-dist.js`, wired into both the Test workflow and the release workflow before signing): dist/plugin.json version must match package.json, plugin id must be correct, every logo/screenshot referenced by plugin.json must exist in dist, metadata files (NOTICE, LICENSE, CHANGELOG, README) must ship, and every icon set in src/icons must reach dist/icons with the same file count — catches webpack copy-config drift before a release is signed.

Full suite: 89/89 pass (was 73). Lint/typecheck clean (`scripts/` and `website/site/` added to eslint ignorePatterns — plain-JS tooling and mkdocs output, not TS project files).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds regression tests for editor dropdowns, migration round-trip, and hostile data rendering, plus a CI dist packaging check to catch broken builds before release. No runtime or plugin behavior changes.

- **New Features**
  - Add CI packaging verification: runs `node scripts/verify-dist.js` in test and release workflows.
  - Validates version sync between `package.json` and `dist/plugin.json`, plugin id, and existence of assets from `plugin.json`.
  - Verifies metadata files ship and every icon in `src/icons/*` exists in `dist/icons/*` with an exact filename match.

<sup>Written for commit 4e6e87e6dd5b5149c3868c36f90a3357bccafb90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

