### PR TITLE
chore(release): bump version to 1.5.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.5.13](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.13) (2026-07-04)
+
+### Bug Fixes
+
+* **query dropdown entries were indistinguishable** when a single query returned many series — the concise `refId: fieldName` labels introduced for [#49](https://github.com/allamiro/grafana-network-weathermap-ng/issues/49) collapsed to identical `A: Value` entries for multi-series Prometheus responses. Labels now show short display names (custom legends, label sets) verbatim, keep long unique names concise, and expand to the full label set whenever concise labels would collide; stored selections are unchanged ([#191](https://github.com/allamiro/grafana-network-weathermap-ng/issues/191), PR [#195](https://github.com/allamiro/grafana-network-weathermap-ng/pull/195))
+
+### Chores (not part of the plugin archive)
+
+* regression-hardening test suite — editor dropdown component tests, a duplicate-DOM-id guard, options-migration round-trip guarantees, a hostile-data render matrix, and a dist packaging verification step in CI and the signed release pipeline (PR [#196](https://github.com/allamiro/grafana-network-weathermap-ng/pull/196))
+* least-privilege `GITHUB_TOKEN` permissions across CI workflows, resolving the open CodeQL alerts (PR [#194](https://github.com/allamiro/grafana-network-weathermap-ng/pull/194))
+* docs site: step-by-step Getting Started/Links screenshots and the Dracula color scheme (PRs [#192](https://github.com/allamiro/grafana-network-weathermap-ng/pull/192), [#193](https://github.com/allamiro/grafana-network-weathermap-ng/pull/193))
+
 ## [1.5.12](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.12) (2026-07-03)
 
 ### Features

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,5 +8,5 @@ authors:
 repository-code: "https://github.com/allamiro/grafana-network-weathermap-ng"
 url: "https://allamiro.github.io/grafana-network-weathermap-ng/"
 license: Apache-2.0
-version: 1.5.12
+version: 1.5.13
 date-released: "2026-07-03"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamirsuliman-weathermap-panel",
-      "version": "1.5.12",
+      "version": "1.5.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.12",
+  "version": "1.5.13",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Release PR for v1.5.13.

**In the plugin archive:** the #191 fix — query dropdown labels stay distinguishable with multi-series queries (PR #195).

**Repo-only since 1.5.12:** regression-hardening tests + dist packaging verification (#196), least-privilege workflow tokens (#194), docs screenshots + Dracula theme (#192, #193).

After merge: `scripts/release.sh tag 1.5.13` — the release workflow builds, verifies packaging, signs (Community signature, hard-fail if unsigned), attests provenance, and publishes the GitHub release. This release is **not** submitted to the Grafana catalog until the 1.5.12 review completes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare v1.5.13 release. Fixes indistinguishable query dropdown entries for multi‑series results; also adds CI hardening and docs updates (repo-only).

- **Bug Fixes**
  - Query dropdown labels stay unique for multi‑series queries by using short display names and expanding only on collisions; existing selections are preserved.

<sup>Written for commit 6a307050dacd14502334e3df802db2825db5d24e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

