### PR TITLE
fix: SVG export hardening for URL schemes and failed fetches (#203)

### DIFF
--- a/src/forms/ExportForm.test.tsx
+++ b/src/forms/ExportForm.test.tsx
@@ -84,10 +84,11 @@ describe('SVG export URL handling (#203)', () => {
     expect(fetchMock).toHaveBeenCalledWith('https://icons.example.com/broken.svg');
   });
 
-  test('data: hrefs are not fetched or rewritten', async () => {
+  test('data: hrefs are not fetched or rewritten (any scheme casing)', async () => {
     const value = getData(theme);
-    const dataHref = 'data:image/svg+xml;base64,AAAA';
-    setupSvg(value, [dataHref]);
+    // Mixed case on one of them: URL schemes are case-insensitive, so DATA:
+    // must be recognized the same as data:.
+    setupSvg(value, ['data:image/svg+xml;base64,AAAA', 'DATA:image/svg+xml;base64,BBBB']);
 
     const fetchMock = jest.fn();
     (global as unknown as { fetch: unknown }).fetch = fetchMock;

--- a/src/forms/ExportForm.test.tsx
+++ b/src/forms/ExportForm.test.tsx
@@ -26,3 +26,79 @@ test('SVG export does not crash when the SVG element is missing', async () => {
 
   expect(createObjectURL).not.toHaveBeenCalled();
 });
+
+describe('SVG export URL handling (#203)', () => {
+  const setupSvg = (value: Weathermap, hrefs: string[]) => {
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('id', `nw-${value.id}_`);
+    for (const href of hrefs) {
+      const image = document.createElementNS('http://www.w3.org/2000/svg', 'image');
+      image.setAttribute('href', href);
+      svg.appendChild(image);
+    }
+    document.body.appendChild(svg);
+    return svg;
+  };
+
+  const clickExport = async () => {
+    fireEvent.click(screen.getByText('Export SVG'));
+    // let the async handler settle
+    await new Promise((r) => setTimeout(r, 0));
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    document.querySelectorAll('svg').forEach((el) => el.remove());
+  });
+
+  test('svg export handles absolute icon url fetch failure', async () => {
+    const value = getData(theme);
+    setupSvg(value, ['https://icons.example.com/broken.svg', 'public/plugins/x/icons/ok.svg']);
+
+    const fetchMock = jest.fn((url: string) =>
+      url.includes('broken')
+        ? Promise.reject(new Error('network down'))
+        : Promise.resolve({ ok: true, text: () => Promise.resolve('<svg/>') })
+    );
+    (global as unknown as { fetch: unknown }).fetch = fetchMock;
+    const blobSpy = jest.fn(() => 'blob:mock');
+    (URL as unknown as { createObjectURL: unknown }).createObjectURL = blobSpy;
+    let blobContent = '';
+    const RealBlob = global.Blob;
+    jest.spyOn(global, 'Blob').mockImplementation((parts: unknown[], opts?: BlobPropertyBag) => {
+      blobContent = (parts as string[]).join('');
+      return new RealBlob(parts as BlobPart[], opts);
+    });
+
+    const props = { value, onChange: jest.fn() } as unknown as StandardEditorProps<Weathermap>;
+    render(<ExportForm {...props} />);
+    await clickExport();
+
+    // Export completed despite the failed absolute fetch...
+    expect(blobSpy).toHaveBeenCalled();
+    // ...the broken icon keeps its original href...
+    expect(blobContent).toContain('https://icons.example.com/broken.svg');
+    // ...and the healthy relative icon was inlined.
+    expect(blobContent).toContain('data:image/svg+xml;base64,');
+    // The absolute URL was fetched as-is, not origin-prefixed.
+    expect(fetchMock).toHaveBeenCalledWith('https://icons.example.com/broken.svg');
+  });
+
+  test('data: hrefs are not fetched or rewritten', async () => {
+    const value = getData(theme);
+    const dataHref = 'data:image/svg+xml;base64,AAAA';
+    setupSvg(value, [dataHref]);
+
+    const fetchMock = jest.fn();
+    (global as unknown as { fetch: unknown }).fetch = fetchMock;
+    const blobSpy = jest.fn(() => 'blob:mock');
+    (URL as unknown as { createObjectURL: unknown }).createObjectURL = blobSpy;
+
+    const props = { value, onChange: jest.fn() } as unknown as StandardEditorProps<Weathermap>;
+    render(<ExportForm {...props} />);
+    await clickExport();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(blobSpy).toHaveBeenCalled();
+  });
+});

--- a/src/forms/ExportForm.test.tsx
+++ b/src/forms/ExportForm.test.tsx
@@ -65,9 +65,9 @@ describe('SVG export URL handling (#203)', () => {
     (URL as unknown as { createObjectURL: unknown }).createObjectURL = blobSpy;
     let blobContent = '';
     const RealBlob = global.Blob;
-    jest.spyOn(global, 'Blob').mockImplementation((parts: unknown[], opts?: BlobPropertyBag) => {
-      blobContent = (parts as string[]).join('');
-      return new RealBlob(parts as BlobPart[], opts);
+    jest.spyOn(global, 'Blob').mockImplementation((parts?: BlobPart[], opts?: BlobPropertyBag) => {
+      blobContent = ((parts ?? []) as string[]).join('');
+      return new RealBlob(parts, opts);
     });
 
     const props = { value, onChange: jest.fn() } as unknown as StandardEditorProps<Weathermap>;

--- a/src/forms/ExportForm.tsx
+++ b/src/forms/ExportForm.tsx
@@ -34,15 +34,35 @@ export const ExportForm = ({ value, onChange }: Props) => {
     let data = svg.outerHTML || '';
     const preface = '<?xml version="1.0" standalone="no"?>\r\n';
 
+    // Inline each icon as a data URL so the exported SVG is self-contained.
+    // A failed fetch (offline icon host, CORS) keeps the original href and
+    // must not abort the whole export.
     const icons = svg.getElementsByTagName('image');
-    //TODO: fix exporting
     for (let i = 0; i < icons.length; i++) {
-      const iconURL = document.location.origin + '/' + icons[i].href.baseVal;
-      const iconData = await fetch(iconURL);
-      const iconString = await iconData.text();
-      const base64String = 'data:image/svg+xml;base64,' + window.btoa(iconString);
-
-      data = data.replace(icons[i].href.baseVal, base64String);
+      // href may live on the SVG animated property or a plain (xlink:)href
+      // attribute depending on how the image was authored.
+      const href =
+        icons[i].href?.baseVal || icons[i].getAttribute('href') || icons[i].getAttribute('xlink:href') || '';
+      // data: is already self-contained; blob: is session-scoped and cannot
+      // be resolved outside this page — leave both untouched.
+      if (!href || href.startsWith('data:') || href.startsWith('blob:')) {
+        continue;
+      }
+      try {
+        // Resolves relative, root-relative, and absolute URLs correctly
+        // (the old origin + '/' + href concatenation broke absolute URLs).
+        const iconURL = new URL(href, document.location.origin);
+        const iconData = await fetch(iconURL.toString());
+        if (!iconData.ok) {
+          continue;
+        }
+        const iconString = await iconData.text();
+        const base64String = 'data:image/svg+xml;base64,' + window.btoa(iconString);
+        data = data.replace(href, base64String);
+      } catch (e) {
+        // Keep the original href for this icon and continue with the rest.
+        continue;
+      }
     }
 
     const svgBlob = new Blob([preface, data], { type: 'image/svg+xml;charset=utf-8' });

--- a/src/forms/ExportForm.tsx
+++ b/src/forms/ExportForm.tsx
@@ -44,8 +44,10 @@ export const ExportForm = ({ value, onChange }: Props) => {
       const href =
         icons[i].href?.baseVal || icons[i].getAttribute('href') || icons[i].getAttribute('xlink:href') || '';
       // data: is already self-contained; blob: is session-scoped and cannot
-      // be resolved outside this page — leave both untouched.
-      if (!href || href.startsWith('data:') || href.startsWith('blob:')) {
+      // be resolved outside this page — leave both untouched. URL schemes
+      // are case-insensitive, so normalize before checking.
+      const scheme = href.trim().toLowerCase();
+      if (!href || scheme.startsWith('data:') || scheme.startsWith('blob:')) {
         continue;
       }
       try {


### PR DESCRIPTION
Fixes #203. One risk area only: SVG export URL handling. No unrelated refactoring.

## What changed

- Icon hrefs resolve through `new URL(href, document.location.origin)` — correct for relative, root-relative, and absolute URLs (previously `origin + '/' + href` mangled absolute URLs into `https://origin/https://…`).
- `data:` and `blob:` hrefs are skipped: data URLs are already self-contained; blob URLs are session-scoped and cannot be refetched meaningfully.
- Each icon fetch/inline is wrapped in try/catch and checks `response.ok`: a failed or non-OK fetch keeps that icon's original href and the export continues — one broken icon no longer aborts the whole export.
- The href read falls back from the SVG animated property to plain `href`/`xlink:href` attributes (also fixes the read under jsdom).

## Adjacent behavior preserved

JSON export, download-link mechanics, the missing-SVG guard, and the successful-fetch inlining format (`data:image/svg+xml;base64,`) are unchanged.

## Tests added (2)

- `svg export handles absolute icon url fetch failure`: absolute URL rejects → export still produces a blob, the broken icon keeps its original href, a sibling relative icon is still inlined, and the absolute URL is fetched as-is (not origin-prefixed) — fails on the previous code.
- `data: hrefs are not fetched or rewritten`.

## Validation

- `npm run typecheck` — pass
- `npm run lint` — 0 errors
- `npm run test:ci` — 91/91 pass on this branch (89 baseline + 2 new)
- `npm run build` + `node scripts/verify-dist.js` — pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens SVG export to resolve icon URLs, skip inlining for `data:`/`blob:` (case-insensitive), and keep exporting when icon fetches fail. Fixes #203.

- **Bug Fixes**
  - Resolve `image` hrefs with `new URL(href, document.location.origin)` for relative, root-relative, and absolute URLs.
  - On fetch errors or non-OK responses, keep the original href and continue export.
  - Read href from the animated property or `href`/`xlink:href` for broader SVG support (incl. jsdom).
  - Do not fetch or rewrite `data:` and `blob:` URLs; detection is case-insensitive.
  - Tests: fix `Blob` spy typing to match `lib.dom` signatures and satisfy typecheck.

<sup>Written for commit 94f44570c01a5d155e6cb092f7b743c1cf2b271e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

