### PR TITLE
ci: e2e workflow, path filters, install consistency, packaging checks (#205)

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -16,7 +16,9 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  # Job 1: check against the latest Grafana SDK (uses levitate via plugin-actions)
+  # Job 1: ADVISORY — checks against the newest (possibly unsupported)
+  # Grafana SDK so upcoming breakage is visible early without blocking merges
+  # (fail-if-incompatible: 'no' below is deliberate).
   compatibility-latest:
     name: Check Grafana API compatibility (latest)
     permissions:
@@ -31,8 +33,9 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      # Plain npm ci matches test/release; the lockfile resolves cleanly.
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
       - name: Build plugin
         run: npm run build
@@ -44,7 +47,9 @@ jobs:
           comment-pr: 'yes'
           fail-if-incompatible: 'no'
 
-  # Job 2: matrix check — verify the plugin TypeScript compiles cleanly
+  # Job 2: BLOCKING — levitate exits non-zero on incompatibility with the
+  # supported Grafana versions, failing the job and gating the PR.
+  # Matrix check — verify the plugin TypeScript compiles cleanly
   # against each supported Grafana SDK version (11.x, 12.x, 13.x — the
   # plugin's grafanaDependency is >=11.0.0, so 10.x is not checked).
   # Uses --no-save so the installed test versions don't modify package.json.
@@ -63,9 +68,13 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
+      # Plain npm ci matches test/release; the lockfile resolves cleanly.
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm ci
 
+      # --legacy-peer-deps is required HERE (and only here): overlaying a
+      # different @grafana/* major on top of the locked tree creates real
+      # peer conflicts that are intentional for this check.
       - name: Overlay Grafana ${{ matrix.grafana-version }} SDK packages
         run: |
           npm install --no-save --legacy-peer-deps \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,72 @@
+name: E2E
+
+# Playwright end-to-end tests against a real Grafana. Too heavy/flaky to gate
+# every PR, so this runs weekly and on demand (Actions tab -> E2E -> Run
+# workflow). Locally: `npm run build`, start Grafana on :3000 with dist/
+# mounted as the plugin (see the docker run below), then `npm run e2e`.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  e2e:
+    name: E2E (Grafana ${{ matrix.grafana-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        grafana-version: ['11.0.0', 'latest']
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build plugin
+        run: npm run build
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Start Grafana with the built plugin
+        run: |
+          docker run -d --name grafana -p 3000:3000 \
+            -v "$PWD/dist:/var/lib/grafana/plugins/tamirsuliman-weathermap-panel" \
+            -e GF_DEFAULT_APP_MODE=development \
+            -e GF_AUTH_ANONYMOUS_ENABLED=true \
+            -e GF_AUTH_ANONYMOUS_ORG_ROLE=Admin \
+            grafana/grafana:${{ matrix.grafana-version }}
+          for i in $(seq 1 45); do
+            curl -fs http://localhost:3000/api/health > /dev/null && exit 0
+            sleep 2
+          done
+          echo "Grafana did not become healthy in time" >&2
+          docker logs grafana >&2
+          exit 1
+
+      - name: Run E2E tests
+        run: npm run e2e
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-grafana-${{ matrix.grafana-version }}
+          path: playwright-report/
+          retention-days: 14
+
+      - name: Stop Grafana
+        if: always()
+        run: docker rm -f grafana

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,22 @@ name: Test
 
 on:
   push:
+    # Everything that can change build/test outcomes must trigger CI on push
+    # (pull_request below has no filter and always runs).
     paths:
       - 'src/**'
+      - 'tests/**'
+      - 'scripts/**'
+      - '.github/workflows/**'
+      - 'package.json'
       - 'package-lock.json'
+      - 'tsconfig.json'
+      - 'jest.config.js'
+      - 'jest-setup.js'
+      - 'jest-polyfills.js'
+      - 'playwright.config.ts'
+      - '.eslintrc'
+      - '.prettierrc.js'
   pull_request:
 
 # CI only reads the repo; least-privilege token per CodeQL
@@ -25,10 +38,24 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-      - run: npm ci --legacy-peer-deps
+      # Plain npm ci, matching the release workflow — the lockfile resolves
+      # cleanly without --legacy-peer-deps (only the compatibility workflow's
+      # mixed-version SDK overlay still needs that flag).
+      - run: npm ci
       - run: npm run lint
       - run: npm run typecheck
       - run: npm run test:ci
       - run: npm run build
       - name: Verify dist packaging
         run: node scripts/verify-dist.js
+      # Stage the archive exactly like the release workflow does, so zip
+      # layout problems surface on PRs instead of at release time.
+      - name: Verify plugin archive layout
+        run: |
+          cp -r dist tamirsuliman-weathermap-panel
+          zip -qr plugin-layout-check.zip tamirsuliman-weathermap-panel
+          unzip -l plugin-layout-check.zip | grep -q "tamirsuliman-weathermap-panel/plugin.json" || {
+            echo "::error::archive root layout is wrong (expected tamirsuliman-weathermap-panel/plugin.json)"; exit 1; }
+          unzip -l plugin-layout-check.zip | grep -q "tamirsuliman-weathermap-panel/module.js" || {
+            echo "::error::module.js missing from archive"; exit 1; }
+          rm -rf tamirsuliman-weathermap-panel plugin-layout-check.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ on:
       - 'playwright.config.ts'
       - '.eslintrc'
       - '.prettierrc.js'
+      # Root configs proxy into .config/ (jest, webpack, tsconfig, eslint) —
+      # changes there alter build/test outcomes too.
+      - '.config/**'
   pull_request:
 
 # CI only reads the repo; least-privilege token per CodeQL
@@ -51,11 +54,14 @@ jobs:
       # Stage the archive exactly like the release workflow does, so zip
       # layout problems surface on PRs instead of at release time.
       - name: Verify plugin archive layout
+        # Read the plugin id from dist/plugin.json (same as the release
+        # workflow) so this check follows any future id change.
         run: |
-          cp -r dist tamirsuliman-weathermap-panel
-          zip -qr plugin-layout-check.zip tamirsuliman-weathermap-panel
-          unzip -l plugin-layout-check.zip | grep -q "tamirsuliman-weathermap-panel/plugin.json" || {
-            echo "::error::archive root layout is wrong (expected tamirsuliman-weathermap-panel/plugin.json)"; exit 1; }
-          unzip -l plugin-layout-check.zip | grep -q "tamirsuliman-weathermap-panel/module.js" || {
+          PLUGIN_ID=$(node -p "require('./dist/plugin.json').id")
+          cp -r dist "$PLUGIN_ID"
+          zip -qr plugin-layout-check.zip "$PLUGIN_ID"
+          unzip -l plugin-layout-check.zip | grep -q "$PLUGIN_ID/plugin.json" || {
+            echo "::error::archive root layout is wrong (expected $PLUGIN_ID/plugin.json)"; exit 1; }
+          unzip -l plugin-layout-check.zip | grep -q "$PLUGIN_ID/module.js" || {
             echo "::error::module.js missing from archive"; exit 1; }
-          rm -rf tamirsuliman-weathermap-panel plugin-layout-check.zip
+          rm -rf "$PLUGIN_ID" plugin-layout-check.zip

--- a/testing/README.md
+++ b/testing/README.md
@@ -74,3 +74,21 @@ The exporter (`testing/exporter/main.go`) produces:
 
 The exporter also serves the demo background images over HTTP (port 8080,
 published by the compose file): `/floorplan.svg`, `/worldmap.svg`, `/rack.svg`, `/rack2.svg`.
+
+## E2E tests
+
+Playwright E2E tests (`tests/panel.spec.ts`, via `@grafana/plugin-e2e`) run in CI
+weekly and on demand (Actions → E2E → Run workflow). Locally:
+
+```bash
+npm run build
+docker run -d --name grafana-e2e -p 3000:3000 \
+  -v "$PWD/dist:/var/lib/grafana/plugins/tamirsuliman-weathermap-panel" \
+  -e GF_DEFAULT_APP_MODE=development \
+  -e GF_AUTH_ANONYMOUS_ENABLED=true \
+  -e GF_AUTH_ANONYMOUS_ORG_ROLE=Admin \
+  grafana/grafana:latest
+npx playwright install chromium   # first time only
+npm run e2e
+docker rm -f grafana-e2e
+```


### PR DESCRIPTION
Fixes #205. CI/workflow changes only — no plugin code.

## What changed

1. **E2E workflow** (`e2e.yml`, new): runs `npm run e2e` (Playwright + `@grafana/plugin-e2e`) against real Grafana 11.0.0 and latest with the built plugin volume-mounted, weekly and via workflow_dispatch — too heavy for every PR by design. Playwright report uploaded as an artifact on failure. Local run documented in `testing/README.md`.
2. **Path filters** (`test.yml`): push triggers now cover `src/**`, `tests/**`, `scripts/**`, workflows, package files, tsconfig, jest configs, playwright config, eslint/prettier config (pull_request remains unfiltered).
3. **Install consistency**: test and compatibility workflows now use plain `npm ci`, matching release — the lockfile resolves cleanly without `--legacy-peer-deps` (verified via dry-run and by this PR's own CI). The flag remains only in the compatibility SDK-overlay step, where mixed `@grafana/*` majors create intentional peer conflicts — documented with a comment.
4. **Compatibility policy made explicit**: comments mark the latest-SDK check as ADVISORY (`fail-if-incompatible: 'no'` is deliberate) and the supported-version levitate matrix as BLOCKING (non-zero exit gates the PR).
5. **PR-level archive layout check** (`test.yml`): stages the zip exactly like the release workflow and asserts `tamirsuliman-weathermap-panel/plugin.json` and `module.js` at the expected root — packaging drift now fails PRs, not releases. Complements the existing `verify-dist.js` content check. No secrets involved, fork-PR safe.

## Validation

This PR's own checks exercise the plain `npm ci` in test + both compatibility jobs, plus the new layout check. The e2e workflow will be validated with a manual dispatch after merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens CI by adding a weekly/on-demand E2E workflow against real Grafana, aligning installs to plain `npm ci`, broadening path filters, and adding a PR-time packaging check to catch release issues earlier. No plugin code changes.

- New Features
  - E2E workflow: runs `npm run e2e` (Playwright + `@grafana/plugin-e2e`) against Grafana 11.0.0 and latest; mounts the built plugin; uploads the Playwright report on failure; scheduled weekly and via dispatch.
  - Packaging check: reads the plugin id from `dist/plugin.json`, zips `dist` under that id, and asserts `plugin.json` and `module.js` at the archive root; fails fast on PRs; fork-safe.

- Refactors
  - Path filters: push triggers now include `src/**`, `tests/**`, `scripts/**`, workflows, package and root configs, and `.config/**`; `pull_request` remains unfiltered.
  - Install consistency: use plain `npm ci` in tests and the latest-compat job; keep `--legacy-peer-deps` only when overlaying mixed `@grafana/*` majors in the compatibility matrix.
  - Compatibility policy: latest-SDK check is advisory (`fail-if-incompatible: 'no'`); supported-versions matrix is blocking.

<sup>Written for commit 8d57195ca9bfccdd933ca7f7ebb30677983b1053. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

