### PR TITLE
fix: symmetrical self-link anchor accounting on link removal (#202)

### DIFF
--- a/src/forms/LinkForm.test.tsx
+++ b/src/forms/LinkForm.test.tsx
@@ -6,7 +6,7 @@ import React, { useState } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { StandardEditorProps, toDataFrame } from '@grafana/data';
 import { LinkForm } from './LinkForm';
-import { Weathermap } from 'types';
+import { Anchor, Weathermap } from 'types';
 import { getData, theme } from '../testData';
 
 const promFrame = (refId: string, displayName: string) =>
@@ -96,4 +96,69 @@ test('short custom legends appear verbatim in the dropdown', async () => {
   openSelectShowing('Select A Side Query');
   expect(await screen.findByText('SW-CORE to BKB-CARPINA')).toBeInTheDocument();
   expect(screen.getByText('BKB-CARPINA to SW-CORE')).toBeInTheDocument();
+});
+
+// Anchor accounting regressions (#202): addNewLink creates a self-link and
+// increments the center anchor by 2, so removeLink must decrement both
+// endpoint sides independently — an else-if between them drifts the count.
+describe('link anchor accounting (#202)', () => {
+  const lastValue = (spy: jest.Mock): Weathermap => spy.mock.calls[spy.mock.calls.length - 1][0];
+
+  test('removing_self_link_restores_anchor_counts', () => {
+    const initial = getData(theme);
+    const before = initial.nodes[0].anchors[Anchor.Center].numLinks;
+    const spy = jest.fn();
+    render(<Harness initial={initial} onChangeSpy={spy} frames={[]} />);
+
+    // Add Link creates a self-link on nodes[0] and selects it.
+    fireEvent.click(screen.getByRole('button', { name: /Add Link/ }));
+    expect(lastValue(spy).nodes[0].anchors[Anchor.Center].numLinks).toBe(before + 2);
+
+    fireEvent.click(screen.getByRole('button', { name: /Remove Link/ }));
+    expect(lastValue(spy).nodes[0].anchors[Anchor.Center].numLinks).toBe(before);
+  });
+
+  test('removing a self-link from an already-drifted map clamps at 0', async () => {
+    // A saved map hit by the old else-if bug can hold a self-link while the
+    // anchor count already reads 0; removal must not push it negative.
+    const initial = getData(theme);
+    const node = initial.nodes[0];
+    const selfLink = initial.links[0];
+    selfLink.nodes = [node, node];
+    selfLink.sides.A.anchor = Anchor.Center;
+    selfLink.sides.Z.anchor = Anchor.Center;
+    initial.links = [selfLink];
+    node.anchors[Anchor.Center].numLinks = 0;
+
+    const spy = jest.fn();
+    render(<Harness initial={initial} onChangeSpy={spy} frames={[]} />);
+    openSelectShowing('Select a link');
+    fireEvent.click(await screen.findByText('Node A <> Node A'));
+
+    fireEvent.click(screen.getByRole('button', { name: /Remove Link/ }));
+    const updated = lastValue(spy);
+    expect(updated.links).toHaveLength(0);
+    expect(updated.nodes[0].anchors[Anchor.Center].numLinks).toBe(0);
+  });
+
+  test('removing a normal two-node link decrements each endpoint once', async () => {
+    const initial = getData(theme);
+    const linkToRemove = initial.links[0];
+    const anchorA = linkToRemove.sides.A.anchor;
+    const anchorZ = linkToRemove.sides.Z.anchor;
+    const idA = linkToRemove.nodes[0].id;
+    const idZ = linkToRemove.nodes[1].id;
+    expect(idA).not.toBe(idZ);
+    const beforeA = initial.nodes.find((n) => n.id === idA)!.anchors[anchorA].numLinks;
+    const beforeZ = initial.nodes.find((n) => n.id === idZ)!.anchors[anchorZ].numLinks;
+
+    const spy = jest.fn();
+    render(<Harness initial={initial} onChangeSpy={spy} frames={[]} />);
+    await selectFirstLink();
+
+    fireEvent.click(screen.getByRole('button', { name: /Remove Link/ }));
+    const updated = lastValue(spy);
+    expect(updated.nodes.find((n) => n.id === idA)!.anchors[anchorA].numLinks).toBe(beforeA - 1);
+    expect(updated.nodes.find((n) => n.id === idZ)!.anchors[anchorZ].numLinks).toBe(beforeZ - 1);
+  });
 });

--- a/src/forms/LinkForm.tsx
+++ b/src/forms/LinkForm.tsx
@@ -145,11 +145,19 @@ export const LinkForm = (props: Props) => {
   const removeLink = (i: number) => {
     let weathermap: Weathermap = value;
     let toRemove = weathermap.links[i];
-    for (let i = 0; i < weathermap.nodes.length; i++) {
-      if (weathermap.nodes[i].id === toRemove.nodes[0].id) {
-        weathermap.nodes[i].anchors[toRemove.sides.A.anchor].numLinks--;
-      } else if (weathermap.nodes[i].id === toRemove.nodes[1].id) {
-        weathermap.nodes[i].anchors[toRemove.sides.Z.anchor].numLinks--;
+    for (let n = 0; n < weathermap.nodes.length; n++) {
+      const node = weathermap.nodes[n];
+      // Both endpoint decrements must run independently: for a self-link the
+      // A and Z endpoints are the same node (addNewLink incremented its
+      // anchor by 2), so an else-if here would leave the count drifted.
+      // Clamp at 0 so already-drifted saved maps cannot go negative.
+      if (node.id === toRemove.nodes[0].id) {
+        const anchorA = node.anchors[toRemove.sides.A.anchor];
+        anchorA.numLinks = Math.max(0, anchorA.numLinks - 1);
+      }
+      if (node.id === toRemove.nodes[1].id) {
+        const anchorZ = node.anchors[toRemove.sides.Z.anchor];
+        anchorZ.numLinks = Math.max(0, anchorZ.numLinks - 1);
       }
     }
     weathermap.links.splice(i, 1);


### PR DESCRIPTION
Closes #202

## Problem

`addNewLink` creates a self-link (both endpoints are `nodes[0]`) and increments the center anchor's `numLinks` by 2, but `removeLink` used an `else if` between the A-endpoint and Z-endpoint checks. For a self-link both checks match the same node, so removal decremented the anchor only once — every add/remove cycle drifted the count up by 1, permanently skewing link spacing on that node.

## Fix

- `removeLink` now decrements both endpoint sides independently, so a self-link removal subtracts 2 from the shared anchor — exactly mirroring the +2 on add.
- Counts clamp at 0 (`Math.max`) so saved maps already drifted by the old bug cannot go negative.

## Adjacent behavior preserved

- Normal two-node link removal still decrements each endpoint's anchor exactly once (locked by a new test).
- `clearLinks`, link selection, and link editing are untouched.

## Tests

- `removing_self_link_restores_anchor_counts` — add self-link (+2), remove, count returns to the original value.
- Pre-drifted map clamp — a self-link whose anchor already reads 0 removes cleanly without going negative.
- Normal-link removal — each endpoint decremented exactly once.

## Validation

- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm run test:ci` — 92 tests pass (11 suites)
- `npm run build` — pass
- `node scripts/verify-dist.js` — pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix self-link anchor drift by decrementing both endpoints during link removal. This keeps anchor counts symmetric with add behavior and prevents skewed link spacing.

- **Bug Fixes**
  - `removeLink` now decrements A and Z independently; self-link removal subtracts 2 from the shared anchor.
  - Anchor counts clamp at 0 to avoid negatives in already-drifted maps.
  - Normal two-node link removal remains unchanged.

- **Tests**
  - Self-link add/remove restores the original count.
  - Clamp at 0 for pre-drifted maps.
  - Normal link removal decrements each endpoint once.

<sup>Written for commit 5188fafc71e9aece1d84379d461e1ea5283ce776. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

