### PR TITLE
fix: numeric inputs never store NaN in saved options (#200)

### DIFF
--- a/src/forms/ColorForm.test.tsx
+++ b/src/forms/ColorForm.test.tsx
@@ -65,3 +65,39 @@ test('threshold inputs have explicit unique ids (#167)', () => {
   expect(document.getElementById('nwm-scale-threshold-0')).toBeInTheDocument();
   expect(document.getElementById('nwm-scale-threshold-1')).toBeInTheDocument();
 });
+
+// #200: clearing a threshold input and blurring must not save NaN into the
+// scale; the previous threshold value is kept instead.
+describe('number inputs do not store NaN (#200)', () => {
+  test('clearing a threshold keeps the previous percent on blur', () => {
+    const initial = getData(theme);
+    initial.scale = [
+      { percent: 10, color: '#111111' },
+      { percent: 50, color: '#222222' },
+    ];
+    const spy = jest.fn();
+    render(<Harness initial={initial} onChangeSpy={spy} />);
+
+    const threshold = screen.getByLabelText('Weathermap Threshold 10');
+    fireEvent.change(threshold, { target: { value: '' } });
+    fireEvent.blur(threshold);
+
+    const updated: Weathermap = spy.mock.calls[spy.mock.calls.length - 1][0];
+    expect(updated.scale.map((s) => s.percent)).toEqual([10, 50]);
+    expect(updated.scale.some((s) => Number.isNaN(s.percent))).toBe(false);
+  });
+
+  test('0 is a valid threshold value', () => {
+    const initial = getData(theme);
+    initial.scale = [{ percent: 10, color: '#111111' }];
+    const spy = jest.fn();
+    render(<Harness initial={initial} onChangeSpy={spy} />);
+
+    const threshold = screen.getByLabelText('Weathermap Threshold 10');
+    fireEvent.change(threshold, { target: { value: '0' } });
+    fireEvent.blur(threshold);
+
+    const updated: Weathermap = spy.mock.calls[spy.mock.calls.length - 1][0];
+    expect(updated.scale[0].percent).toBe(0);
+  });
+});

--- a/src/forms/ColorForm.tsx
+++ b/src/forms/ColorForm.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { css } from '@emotion/css';
 import { Button, Input, ColorPicker, Icon, useStyles2, RadioButtonGroup } from '@grafana/ui';
 import { GrafanaTheme2, SelectableValue, StandardEditorProps } from '@grafana/data';
+import { finiteOrFallback } from 'utils';
 import { Weathermap } from 'types';
 
 interface Settings {
@@ -17,7 +18,11 @@ export const ColorForm = (props: Props) => {
 
   const handleNumberChange = (e: any, currentIndex: number) => {
     let weathermap: Weathermap = value;
-    weathermap.scale[currentIndex].percent = e.currentTarget.valueAsNumber;
+    // Blank input reports NaN; keep the previous threshold instead of saving it.
+    weathermap.scale[currentIndex].percent = finiteOrFallback(
+      e.currentTarget.valueAsNumber,
+      weathermap.scale[currentIndex].percent
+    );
     weathermap.scale.sort((a, b) => a.percent - b.percent);
     onChange(weathermap);
     setEditedPercents(weathermap.scale);
@@ -112,12 +117,13 @@ export const ColorForm = (props: Props) => {
           step="0.0001"
           key={i}
           onChange={(e) => {
-            setEditedPercents((prev) => {
-              let t = prev;
-              t[i].percent = e.currentTarget.valueAsNumber;
-              return t;
-            });
-            onChange(value);
+            // Clone the edited entry: editedPercents shares object references
+            // with value.scale, so an in-place write here would push NaN (from
+            // a blanked input) straight into the saved options and corrupt the
+            // "previous value" fallback used on blur (#200). NaN in the local
+            // copy is fine — it just renders the field empty while typing.
+            const raw = e.currentTarget.valueAsNumber;
+            setEditedPercents((prev) => prev.map((t, ti) => (ti === i ? { ...t, percent: raw } : t)));
           }}
           value={editedPercents[i].percent}
           aria-label={`Weathermap Threshold ${threshold.percent}`}

--- a/src/forms/LinkForm.test.tsx
+++ b/src/forms/LinkForm.test.tsx
@@ -162,3 +162,41 @@ describe('link anchor accounting (#202)', () => {
     expect(updated.nodes.find((n) => n.id === idZ)!.anchors[anchorZ].numLinks).toBe(beforeZ - 1);
   });
 });
+
+// #200: clearing the bandwidth input must not write NaN into link options.
+describe('number inputs do not store NaN (#200)', () => {
+  const lastValue = (spy: jest.Mock): Weathermap => spy.mock.calls[spy.mock.calls.length - 1][0];
+
+  test('clearing the A-side bandwidth keeps the previous value', async () => {
+    const initial = getData(theme);
+    initial.links[0].sides.A.bandwidth = 1000;
+    const spy = jest.fn();
+    const { container } = render(<Harness initial={initial} onChangeSpy={spy} frames={[]} />);
+    await selectFirstLink();
+
+    const bandwidth = container.querySelector('input[name="Abandwidth"]')!;
+    fireEvent.change(bandwidth, { target: { value: '' } });
+
+    expect(lastValue(spy).links[0].sides.A.bandwidth).toBe(1000);
+
+    fireEvent.change(bandwidth, { target: { value: '0' } });
+    expect(lastValue(spy).links[0].sides.A.bandwidth).toBe(0);
+  });
+
+  test('link offset treats blank and invalid input as unset', async () => {
+    const initial = getData(theme);
+    initial.links[0].linkOffset = 5;
+    const spy = jest.fn();
+    const { container } = render(<Harness initial={initial} onChangeSpy={spy} frames={[]} />);
+    await selectFirstLink();
+
+    const offset = Array.from(container.querySelectorAll('input[type="number"]')).find(
+      (el) => (el as HTMLInputElement).placeholder === '0'
+    )!;
+    fireEvent.change(offset, { target: { value: '' } });
+    expect(lastValue(spy).links[0].linkOffset).toBeUndefined();
+
+    fireEvent.change(offset, { target: { value: '12' } });
+    expect(lastValue(spy).links[0].linkOffset).toBe(12);
+  });
+});

--- a/src/forms/LinkForm.tsx
+++ b/src/forms/LinkForm.tsx
@@ -18,7 +18,7 @@ import { SelectableValue, StandardEditorProps } from '@grafana/data';
 import { v4 as uuidv4 } from 'uuid';
 import { Weathermap, Node, Link, Anchor, LinkSide, LinkTooltipMetric } from 'types';
 import { FormDivider } from './FormDivider';
-import { buildQueryOptions, sanitizeUrl } from 'utils';
+import { buildQueryOptions, finiteOrFallback, parseOptionalFiniteNumber, sanitizeUrl } from 'utils';
 
 interface Settings {
   placeholder: string;
@@ -42,7 +42,8 @@ export const LinkForm = (props: Props) => {
 
   const handleBandwidthChange = (amt: number, i: number, side: 'A' | 'Z') => {
     let weathermap: Weathermap = value;
-    weathermap.links[i].sides[side].bandwidth = amt;
+    // Blank input reports NaN; keep the previous bandwidth instead of saving it.
+    weathermap.links[i].sides[side].bandwidth = finiteOrFallback(amt, weathermap.links[i].sides[side].bandwidth ?? 0);
     weathermap.links[i].sides[side].bandwidthQuery = undefined;
     onChange(weathermap);
   };
@@ -406,7 +407,7 @@ export const LinkForm = (props: Props) => {
                   onChange={(e) => {
                     let wm = value;
                     const raw = e.currentTarget.value;
-                    wm.links[i].linkOffset = raw === '' ? undefined : Number(raw);
+                    wm.links[i].linkOffset = parseOptionalFiniteNumber(raw);
                     onChange(wm);
                   }}
                   placeholder={'0'}

--- a/src/forms/NodeForm.test.tsx
+++ b/src/forms/NodeForm.test.tsx
@@ -61,3 +61,44 @@ test('status color target radios have stable per-node ids (#162)', async () => {
     expect(document.getElementById(id)).toBeInTheDocument();
   }
 });
+
+// #200: blank numeric inputs must not write NaN into node positions.
+describe('number inputs do not store NaN (#200)', () => {
+  const lastValue = (spy: jest.Mock): Weathermap => spy.mock.calls[spy.mock.calls.length - 1][0];
+
+  const openNodeA = async () => {
+    const picker = screen.getAllByRole('combobox')[0];
+    fireEvent.keyDown(picker, { key: 'ArrowDown' });
+    fireEvent.click(await screen.findByText('Node A'));
+  };
+
+  test('clearing the X position keeps the previous coordinate', async () => {
+    const initial = getData(theme);
+    const nodeA = initial.nodes.find((n) => n.label === 'Node A')!;
+    const startX = nodeA.position[0];
+    const spy = jest.fn();
+    const { container } = render(<Harness initial={initial} onChangeSpy={spy} />);
+    await openNodeA();
+
+    const xInput = container.querySelector('input[name="X"]')!;
+    fireEvent.change(xInput, { target: { value: '' } });
+
+    const updated = lastValue(spy).nodes.find((n) => n.label === 'Node A')!;
+    expect(updated.position[0]).toBe(startX);
+    expect(Number.isNaN(updated.position[0])).toBe(false);
+  });
+
+  test('0 is a valid coordinate and typing resumes after a blank', async () => {
+    const spy = jest.fn();
+    const { container } = render(<Harness initial={getData(theme)} onChangeSpy={spy} />);
+    await openNodeA();
+
+    const xInput = container.querySelector('input[name="X"]')!;
+    fireEvent.change(xInput, { target: { value: '0' } });
+    expect(lastValue(spy).nodes.find((n) => n.label === 'Node A')!.position[0]).toBe(0);
+
+    fireEvent.change(xInput, { target: { value: '' } });
+    fireEvent.change(xInput, { target: { value: '250' } });
+    expect(lastValue(spy).nodes.find((n) => n.label === 'Node A')!.position[0]).toBe(250);
+  });
+});

--- a/src/forms/NodeForm.tsx
+++ b/src/forms/NodeForm.tsx
@@ -31,7 +31,7 @@ import {
   LanguageIcons,
   AerospaceIcons,
 } from './iconOptions';
-import { getDataFrameName, sanitizeUrl } from 'utils';
+import { finiteOrFallback, getDataFrameName, sanitizeUrl } from 'utils';
 
 interface Settings {
   placeholder: string;
@@ -52,9 +52,9 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
   const handleChange = (e: React.FormEvent<HTMLInputElement>, i: number) => {
     let weathermap: Weathermap = value;
     if (e.currentTarget.name === 'X') {
-      weathermap.nodes[i].position[0] = e.currentTarget.valueAsNumber;
+      weathermap.nodes[i].position[0] = finiteOrFallback(e.currentTarget.valueAsNumber, weathermap.nodes[i].position[0]);
     } else if (e.currentTarget.name === 'Y') {
-      weathermap.nodes[i].position[1] = e.currentTarget.valueAsNumber;
+      weathermap.nodes[i].position[1] = finiteOrFallback(e.currentTarget.valueAsNumber, weathermap.nodes[i].position[1]);
     } else if (e.currentTarget.name === 'label') {
       weathermap.nodes[i].label = e.currentTarget.value;
     }
@@ -145,6 +145,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
   const handleIconSizeChange = (amt: number, i: number, type: 'width' | 'height') => {
     let weathermap: Weathermap = value;
     const icon = weathermap.nodes[i].nodeIcon!;
+    amt = finiteOrFallback(amt, type === 'width' ? icon.size.width : icon.size.height);
     if (lockAspectRatio && icon.size.width > 0 && icon.size.height > 0) {
       const ratio = icon.size.width / icon.size.height;
       if (type === 'width') {
@@ -609,7 +610,10 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                           value={mapping.value}
                           onChange={(e) => {
                             let weathermap: Weathermap = value;
-                            weathermap.nodes[i].statusValueMappings![mi].value = e.currentTarget.valueAsNumber;
+                            weathermap.nodes[i].statusValueMappings![mi].value = finiteOrFallback(
+                              e.currentTarget.valueAsNumber,
+                              weathermap.nodes[i].statusValueMappings![mi].value
+                            );
                             onChange(weathermap);
                           }}
                           width={8}

--- a/src/forms/PanelForm.test.tsx
+++ b/src/forms/PanelForm.test.tsx
@@ -74,8 +74,9 @@ describe('number inputs do not store NaN (#200)', () => {
     const spy = jest.fn();
     const { container } = render(<Harness initial={initial} onChangeSpy={spy} />);
 
-    // The zoom/offset inputs carry no name attribute; identify them by their
-    // current values within the panel-options section.
+    // The zoom/offset inputs carry no name attribute, so clear every number
+    // input in the form — any unguarded handler then surfaces NaN in the
+    // containsNaN sweep below.
     const numberInputs = Array.from(container.querySelectorAll('input[type="number"]'));
     for (const input of numberInputs) {
       fireEvent.change(input, { target: { value: '' } });

--- a/src/forms/PanelForm.test.tsx
+++ b/src/forms/PanelForm.test.tsx
@@ -1,0 +1,90 @@
+// Regression tests for numeric input handling (#200): blank numeric inputs
+// report NaN via valueAsNumber, and NaN must never reach the saved options —
+// it propagates into the panel viewBox and SVG geometry.
+import React, { useState } from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { StandardEditorProps } from '@grafana/data';
+import { PanelForm } from './PanelForm';
+import { Weathermap } from 'types';
+import { getData, theme } from '../testData';
+
+const Harness = ({ initial, onChangeSpy }: { initial: Weathermap; onChangeSpy: jest.Mock }) => {
+  const [wm, setWm] = useState(initial);
+  const props = {
+    value: wm,
+    onChange: (v: Weathermap) => {
+      onChangeSpy(v);
+      setWm(v);
+    },
+    context: { data: [] },
+    item: { settings: { placeholder: '' } },
+  } as unknown as StandardEditorProps<Weathermap, { placeholder: string }>;
+  return <PanelForm {...props} />;
+};
+
+const lastValue = (spy: jest.Mock): Weathermap => spy.mock.calls[spy.mock.calls.length - 1][0];
+
+const containsNaN = (o: unknown): boolean => {
+  if (typeof o === 'number') {
+    return Number.isNaN(o);
+  }
+  if (Array.isArray(o)) {
+    return o.some(containsNaN);
+  }
+  if (o && typeof o === 'object') {
+    return Object.values(o).some(containsNaN);
+  }
+  return false;
+};
+
+describe('number inputs do not store NaN (#200)', () => {
+  test('clearing the viewbox width keeps the previous value', () => {
+    const initial = getData(theme);
+    const startWidth = initial.settings.panel.panelSize.width;
+    const spy = jest.fn();
+    const { container } = render(<Harness initial={initial} onChangeSpy={spy} />);
+
+    const width = container.querySelector('input[name="panelWidth"]')!;
+    fireEvent.change(width, { target: { value: '' } });
+
+    expect(lastValue(spy).settings.panel.panelSize.width).toBe(startWidth);
+    expect(Number.isNaN(lastValue(spy).settings.panel.panelSize.width)).toBe(false);
+  });
+
+  test('0 is stored as a valid value and typing resumes after a blank', () => {
+    const spy = jest.fn();
+    const { container } = render(<Harness initial={getData(theme)} onChangeSpy={spy} />);
+
+    const width = container.querySelector('input[name="panelWidth"]')!;
+    fireEvent.change(width, { target: { value: '0' } });
+    expect(lastValue(spy).settings.panel.panelSize.width).toBe(0);
+
+    fireEvent.change(width, { target: { value: '' } });
+    fireEvent.change(width, { target: { value: '800' } });
+    expect(lastValue(spy).settings.panel.panelSize.width).toBe(800);
+  });
+
+  test('zoom scale and offsets never store NaN when cleared', () => {
+    const initial = getData(theme);
+    const before = {
+      zoom: initial.settings.panel.zoomScale,
+      x: initial.settings.panel.offset.x,
+      y: initial.settings.panel.offset.y,
+    };
+    const spy = jest.fn();
+    const { container } = render(<Harness initial={initial} onChangeSpy={spy} />);
+
+    // The zoom/offset inputs carry no name attribute; identify them by their
+    // current values within the panel-options section.
+    const numberInputs = Array.from(container.querySelectorAll('input[type="number"]'));
+    for (const input of numberInputs) {
+      fireEvent.change(input, { target: { value: '' } });
+    }
+
+    const updated = lastValue(spy);
+    expect(updated.settings.panel.zoomScale).toBe(before.zoom);
+    expect(updated.settings.panel.offset.x).toBe(before.x);
+    expect(updated.settings.panel.offset.y).toBe(before.y);
+    expect(containsNaN(updated)).toBe(false);
+  });
+});

--- a/src/forms/PanelForm.tsx
+++ b/src/forms/PanelForm.tsx
@@ -17,7 +17,7 @@ import { Weathermap, ValueMappingMode } from 'types';
 import { v4 as uuidv4 } from 'uuid';
 import { FormDivider } from './FormDivider';
 import { css } from '@emotion/css';
-import { sanitizeUrl } from 'utils';
+import { finiteOrFallback, sanitizeUrl } from 'utils';
 
 interface Settings {}
 
@@ -149,7 +149,10 @@ export const PanelForm = ({ value, onChange }: Props) => {
             name={'panelWidth'}
             onChange={(e) => {
               let options = value;
-              options.settings.panel.panelSize.width = e.currentTarget.valueAsNumber;
+              options.settings.panel.panelSize.width = finiteOrFallback(
+                e.currentTarget.valueAsNumber,
+                options.settings.panel.panelSize.width
+              );
               onChange(options);
             }}
           ></Input>
@@ -162,7 +165,10 @@ export const PanelForm = ({ value, onChange }: Props) => {
             name={'panelHeight'}
             onChange={(e) => {
               let options = value;
-              options.settings.panel.panelSize.height = e.currentTarget.valueAsNumber;
+              options.settings.panel.panelSize.height = finiteOrFallback(
+                e.currentTarget.valueAsNumber,
+                options.settings.panel.panelSize.height
+              );
               onChange(options);
             }}
           ></Input>
@@ -174,7 +180,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
             type={'number'}
             onChange={(e) => {
               let options = value;
-              options.settings.panel.zoomScale = e.currentTarget.valueAsNumber;
+              options.settings.panel.zoomScale = finiteOrFallback(e.currentTarget.valueAsNumber, options.settings.panel.zoomScale);
               onChange(options);
             }}
           ></Input>
@@ -186,7 +192,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
             type={'number'}
             onChange={(e) => {
               let options = value;
-              options.settings.panel.offset.x = e.currentTarget.valueAsNumber;
+              options.settings.panel.offset.x = finiteOrFallback(e.currentTarget.valueAsNumber, options.settings.panel.offset.x);
               onChange(options);
             }}
           ></Input>
@@ -198,7 +204,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
             type={'number'}
             onChange={(e) => {
               let options = value;
-              options.settings.panel.offset.y = e.currentTarget.valueAsNumber;
+              options.settings.panel.offset.y = finiteOrFallback(e.currentTarget.valueAsNumber, options.settings.panel.offset.y);
               onChange(options);
             }}
           ></Input>

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -11,11 +11,13 @@ import {
   calculateRectangleAutoHeight,
   calculateRectangleAutoWidth,
   CURRENT_VERSION,
+  finiteOrFallback,
   getSolidFromAlphaColor,
   handleVersionedStateUpdates,
   isSafeUrl,
   measureText,
   nearestMultiple,
+  parseOptionalFiniteNumber,
   getTimeField,
   removeVia,
   sanitizeUrl,
@@ -55,6 +57,30 @@ test('node calculations', () => {
 test('versioned state updates', () => {
   let wm: Weathermap = getData(theme);
   expect(handleVersionedStateUpdates(wm, theme)).toHaveProperty('version', CURRENT_VERSION);
+});
+
+// #200: blank numeric inputs report NaN via valueAsNumber; these helpers are
+// what keeps that out of the saved options.
+describe('numeric input helpers (#200)', () => {
+  test('finiteOrFallback keeps finite values, including 0', () => {
+    expect(finiteOrFallback(5, 1)).toBe(5);
+    expect(finiteOrFallback(0, 1)).toBe(0);
+    expect(finiteOrFallback(-3.5, 1)).toBe(-3.5);
+  });
+
+  test('finiteOrFallback replaces NaN and infinities with the fallback', () => {
+    expect(finiteOrFallback(NaN, 1)).toBe(1);
+    expect(finiteOrFallback(Infinity, 2)).toBe(2);
+    expect(finiteOrFallback(-Infinity, 0)).toBe(0);
+  });
+
+  test('parseOptionalFiniteNumber maps blank/invalid to undefined, keeps 0', () => {
+    expect(parseOptionalFiniteNumber('')).toBeUndefined();
+    expect(parseOptionalFiniteNumber('   ')).toBeUndefined();
+    expect(parseOptionalFiniteNumber('abc')).toBeUndefined();
+    expect(parseOptionalFiniteNumber('0')).toBe(0);
+    expect(parseOptionalFiniteNumber('-3.5')).toBe(-3.5);
+  });
 });
 
 test('versioned state updates backfill settings missing from pre-v14 options (#162)', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -272,6 +272,25 @@ export function handleFileUploadErrors(files: FileList | null): void {
   }
 }
 
+/**
+ * Numeric <input> handlers receive NaN from valueAsNumber when the field is
+ * blank or mid-edit (e.g. "-"). NaN must never reach the saved options — it
+ * propagates into SVG geometry and the viewBox. Required numeric fields keep
+ * their previous valid value instead; 0 is a valid value.
+ */
+export function finiteOrFallback(value: number, fallback: number): number {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+/** Optional numeric fields: blank or unparsable input becomes undefined. */
+export function parseOptionalFiniteNumber(raw: string): number | undefined {
+  if (raw.trim() === '') {
+    return undefined;
+  }
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
 export function handleVersionedStateUpdates(wm: Weathermap, theme: GrafanaTheme2): Weathermap {
   const modelWeathermap: Weathermap = {
     version: CURRENT_VERSION,


### PR DESCRIPTION
Closes #200

## Problem

A blanked or mid-edit numeric input reports `NaN` via `valueAsNumber`. Eleven handlers stored it directly into the weathermap options — node positions, viewbox width/height, zoom scale, view offsets, icon sizes, node status mapping thresholds, color scale thresholds, and link bandwidth. Stored `NaN` propagates into SVG geometry and the panel viewBox.

`ColorForm` had a second layer to the bug: its keystroke handler wrote raw `valueAsNumber` into local edit state whose objects are **shared by reference with `value.scale`**, so `NaN` leaked into saved options on every keystroke and also corrupted the previous-value fallback used at blur time.

## Fix

Two shared helpers in `utils.ts`:

- `finiteOrFallback(value, fallback)` — required numeric fields keep their previous valid value on blank/invalid input. `0` stays valid.
- `parseOptionalFiniteNumber(raw)` — optional fields (`linkOffset`) map blank/unparsable input to `undefined`, matching their existing blank semantics.

Applied at every unguarded site in `PanelForm` (5), `NodeForm` (position ×2, icon size, status mapping), `ColorForm` (blur commit), `LinkForm` (bandwidth, linkOffset). The `ColorForm` keystroke handler now clones the edited entry instead of mutating the shared object — `NaN` in the transient local copy just renders the field empty while typing; the commit still happens on blur, as before.

## Adjacent behavior preserved

- Valid keystrokes store exactly what they did before.
- Already-guarded handlers (node `fontSize`, `linkDecimals`) untouched.
- Icon-size aspect-ratio locking unchanged for valid input.
- ColorForm still commits threshold edits on blur and keeps the field blank while typing.

## Tests

- Unit tests for both helpers (`utils.test.ts`).
- `PanelForm.test.tsx` (new file): clearing viewbox width keeps the previous value; `0` is stored; typing resumes after a blank; clearing every numeric input leaves no `NaN` anywhere in the options (recursive scan).
- `NodeForm.test.tsx`: clearing X keeps the coordinate; `0` is valid; typing resumes.
- `ColorForm.test.tsx`: clearing a threshold keeps the previous percent on blur; `0` is a valid threshold.
- `LinkForm.test.tsx`: clearing bandwidth keeps the previous value; `0` valid; blank/invalid `linkOffset` becomes `undefined`, re-entering works.

## Validation

- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm run test:ci` — 107 tests pass (12 suites)
- `npm run build` — pass
- `node scripts/verify-dist.js` — pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents NaN from being saved when numeric inputs are blank or mid-edit, keeping SVG geometry and the panel viewBox stable.

- **Bug Fixes**
  - Guard numeric handlers to keep the previous value on blank/invalid input (0 stays valid): panel size, zoom/offsets, node positions, icon sizes, status mappings, color scale thresholds, and link bandwidth. `linkOffset` treats blank/invalid as unset.
  - ColorForm keystroke handling clones the edited entry to avoid mutating shared objects; NaN while typing stays local, commit happens on blur.
  - Tests: new PanelForm suite, updates across Node/Color/Link forms, and unit tests for numeric helpers.

- **Refactors**
  - Introduced `finiteOrFallback` and `parseOptionalFiniteNumber` in `utils.ts` and applied them across forms.

<sup>Written for commit 1e91843d6d8a3e73f474fbd16f69205524a7c63a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

