### PR TITLE
fix: timeline and state synchronization (#201)

### DIFF
--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -681,4 +681,74 @@ describe('timeline and state synchronization (#201)', () => {
     expect(container.textContent).toBe(renderedBefore);
     expect(JSON.stringify(testProps.options.weathermap.links)).toBe(optionsBefore);
   });
+
+  test('multi-VIA chains show the origin data on every downstream segment', () => {
+    // A -> C1 -> C2 -> B: three segments through two consecutive connection
+    // nodes. Every segment's A-side label must resolve back to the origin
+    // link's series, regardless of segment order in the links array.
+    const testProps = { ...mPanelProps };
+    const weathermap = handleVersionedStateUpdates(getConnectedLinkData(theme), theme);
+    const c2 = JSON.parse(JSON.stringify(weathermap.nodes[2]));
+    c2.id = 'conn-2';
+    c2.label = 'C1';
+    c2.position = [350, 350];
+    weathermap.nodes.push(c2);
+    const seg3 = JSON.parse(JSON.stringify(weathermap.links[1]));
+    // Rewire: seg2 now ends at C2; seg3 runs C2 -> B.
+    weathermap.links[1].nodes[1] = c2;
+    seg3.id = 'seg-3';
+    seg3.nodes[0] = c2;
+    weathermap.links.push(seg3);
+    weathermap.links[0].sides.A.query = 'origin-series';
+    testProps.options = { weathermap };
+    testProps.data = {
+      state: LoadingState.Done,
+      series: [
+        toDataFrame({
+          fields: [
+            { name: 'Time', values: [1, 2] },
+            { name: 'Value', values: [777, 777], config: { displayNameFromDS: 'origin-series' } },
+          ],
+        }),
+      ],
+      timeRange: getDefaultRelativeTimeRange(),
+    } as unknown as PanelProps<SimpleOptions>['data'];
+    testProps.onOptionsChange = jest.fn();
+
+    const { container } = render(<WeathermapPanel {...testProps} />);
+
+    // Three segments, each labeling its A side with the origin value.
+    expect(screen.getAllByTestId('link')).toHaveLength(3);
+    expect((container.textContent!.match(/777/g) || []).length).toBe(3);
+  });
+
+  test('scrubbed node status resolves raw negative values like live mode', () => {
+    const props = timelineProps();
+    const node = props.options.weathermap.nodes[0];
+    // Two thresholds: raw -3 must match the -5 mapping (RED). A clamped
+    // value of 0 would wrongly match the 0 mapping (GREEN) instead.
+    node.statusValueMappings = [
+      { value: -5, color: '#aa0000' },
+      { value: 0, color: '#00aa00' },
+    ];
+    props.data.series[1] = toDataFrame({
+      refId: 'B',
+      fields: [
+        { name: 'Time', values: [1_200_000, 2_000_000] },
+        { name: 'Value', values: [-3, 7], config: { displayNameFromDS: 'status-series' } },
+      ],
+    });
+    render(<WeathermapPanel {...props} />);
+
+    const nodeRect = () => screen.getByText(node.label!).closest('g')!.querySelector('rect')!;
+
+    // Live: last sample is 7 -> highest threshold <= 7 is 0 -> green.
+    expect(nodeRect().getAttribute('stroke')).toBe('#00aa00');
+
+    scrubBack();
+
+    // Scrubbed to the -3 sample: threshold -5 applies -> red, not the
+    // clamped-to-zero green.
+    expect(nodeRect().getAttribute('stroke')).toBe('#aa0000');
+  });
 });

--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getDefaultRelativeTimeRange, getTimeZone, LoadingState, PanelProps } from '@grafana/data';
+import { getDefaultRelativeTimeRange, getTimeZone, LoadingState, PanelProps, toDataFrame } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { WeathermapPanel } from 'WeathermapPanel';
@@ -540,5 +540,145 @@ describe('migration persistence is a commit-phase effect (#199)', () => {
     render(<WeathermapPanel {...{ ...mPanelProps, options: { weathermap: wm }, onOptionsChange }} />);
 
     expect(onOptionsChange).not.toHaveBeenCalled();
+  });
+});
+
+// #201: timeline and state synchronization.
+describe('timeline and state synchronization (#201)', () => {
+  const timelineProps = () => {
+    const testProps = { ...mPanelProps };
+    const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+    weathermap.settings.link.timeline = { enabled: true };
+    weathermap.links[0].sides.A.query = 'link-series';
+    weathermap.nodes[0].statusQuery = 'status-series';
+    testProps.options = { weathermap };
+    testProps.timeRange = {
+      from: { valueOf: () => 1_000_000 },
+      to: { valueOf: () => 2_000_000, toLocaleString: () => '2M' },
+    } as unknown as PanelProps<SimpleOptions>['timeRange'];
+    testProps.data = {
+      state: LoadingState.Done,
+      series: [
+        toDataFrame({
+          refId: 'A',
+          fields: [
+            { name: 'Time', values: [1_200_000, 2_000_000] },
+            { name: 'Value', values: [42, 87], config: { displayNameFromDS: 'link-series' } },
+          ],
+        }),
+        toDataFrame({
+          refId: 'B',
+          fields: [
+            { name: 'Time', values: [1_200_000, 2_000_000] },
+            { name: 'Value', values: [1, 0], config: { displayNameFromDS: 'status-series' } },
+          ],
+        }),
+      ],
+      timeRange: getDefaultRelativeTimeRange(),
+    } as unknown as PanelProps<SimpleOptions>['data'];
+    testProps.onOptionsChange = jest.fn();
+    return testProps;
+  };
+
+  const scrubBack = () => {
+    // One ArrowLeft moves the slider one step below the live position, which
+    // lands between the two samples: step-hold resolves to the first sample.
+    const handle = screen.getByRole('slider');
+    fireEvent.keyDown(handle, { key: 'ArrowLeft', keyCode: 37 });
+  };
+
+  test('timeline scrub updates link label value', () => {
+    const { container } = render(<WeathermapPanel {...timelineProps()} />);
+
+    // Live: the A-side label shows the most recent sample (87).
+    expect(container.textContent).toContain('87');
+    expect(container.textContent).not.toContain('42');
+
+    scrubBack();
+
+    // Scrubbed: the label replays the historical sample (42).
+    expect(container.textContent).toContain('42');
+  });
+
+  test('timeline scrub replays node status', () => {
+    const props = timelineProps();
+    const statusDown = props.options.weathermap.nodes[0].colors.statusDown;
+    render(<WeathermapPanel {...props} />);
+
+    const nodeRect = () =>
+      screen.getByText(props.options.weathermap.nodes[0].label!).closest('g')!.querySelector('rect')!;
+
+    // Live: the last status sample is 0 -> node is down.
+    expect(nodeRect().getAttribute('stroke')).toBe(statusDown);
+
+    scrubBack();
+
+    // Scrubbed into history: the status sample there is 1 -> node was up.
+    expect(nodeRect().getAttribute('stroke')).not.toBe(statusDown);
+  });
+
+  test('pan offset resyncs from changed options', () => {
+    const testProps = { ...mPanelProps };
+    const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+    testProps.options = { weathermap };
+    testProps.onOptionsChange = jest.fn();
+
+    const { container, rerender } = render(<WeathermapPanel {...testProps} />);
+    const before = container.querySelector('g')!.getAttribute('transform');
+
+    // An external change to the saved offset (dashboard reload, other session).
+    const changed = JSON.parse(JSON.stringify(weathermap));
+    changed.settings.panel.offset = { x: 120, y: 80 };
+    rerender(<WeathermapPanel {...{ ...testProps, options: { weathermap: changed } }} />);
+
+    const after = container.querySelector('g')!.getAttribute('transform');
+    expect(after).not.toEqual(before);
+    expect(after).toContain('120');
+    expect(after).toContain('80');
+  });
+
+  test('VIA chain labels and hover tooltip resolve chain data without mutation side effects', () => {
+    const testProps = { ...mPanelProps };
+    const weathermap = handleVersionedStateUpdates(getConnectedLinkData(theme), theme);
+    // Segment 1 (A -> C0) carries the chain's A-side data; segment 2
+    // (C0 -> B) carries the chain's Z-side data.
+    weathermap.links[0].sides.A.query = 'a1-series';
+    weathermap.links[1].sides.Z.query = 'z2-series';
+    testProps.options = { weathermap };
+    const mkFrame = (name: string, v: number) =>
+      toDataFrame({
+        fields: [
+          { name: 'Time', values: [1, 2] },
+          { name: 'Value', values: [v, v], config: { displayNameFromDS: name } },
+        ],
+      });
+    testProps.data = {
+      state: LoadingState.Done,
+      series: [mkFrame('a1-series', 331), mkFrame('z2-series', 222)],
+      timeRange: getDefaultRelativeTimeRange(),
+    } as unknown as PanelProps<SimpleOptions>['data'];
+    testProps.onOptionsChange = jest.fn();
+
+    const { container } = render(<WeathermapPanel {...testProps} />);
+
+    // The A-side value propagates through the connection: both the origin
+    // segment and the segment leaving the connection label with 331.
+    const count331 = (container.textContent!.match(/331/g) || []).length;
+    expect(count331).toBe(2);
+    const renderedBefore = container.textContent;
+    const optionsBefore = JSON.stringify(testProps.options.weathermap.links);
+
+    // Hover segment 1: its target is the connection, so the tooltip resolves
+    // the forward chain (segment 2's Z data) on the fly.
+    const segment1 = screen.getAllByTestId('link')[0];
+    fireEvent.mouseMove(segment1.firstChild!);
+    const tooltip = Array.from(document.querySelectorAll('div')).map((el) => el.textContent || '');
+    expect(tooltip.some((t) => t.includes('222'))).toBe(true);
+    fireEvent.mouseLeave(segment1.firstChild!);
+
+    // Hovering resolved chain data into the tooltip only: the rendered map
+    // and the saved options are byte-identical afterwards.
+    expect(container.textContent).toBe(renderedBefore);
+    expect(JSON.stringify(testProps.options.weathermap.links)).toBe(optionsBefore);
   });
 });

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -647,6 +647,20 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
 
   const [offset, setOffset] = useState(wm ? wm.settings.panel.offset : { x: 0, y: 0 });
 
+  // Resync the pan offset when the saved options change externally (dashboard
+  // reload, editor edit, another session saving). Without this the local state
+  // keeps the offset from mount forever. Skipped mid-drag so an incoming
+  // update cannot yank the map out from under the user; the drag's own
+  // mouse-up persists the final offset back into the options.
+  const savedOffsetX = wm ? wm.settings.panel.offset.x : 0;
+  const savedOffsetY = wm ? wm.settings.panel.offset.y : 0;
+  useEffect(() => {
+    if (!isDragging) {
+      setOffset((prev) => (prev.x === savedOffsetX && prev.y === savedOffsetY ? prev : { x: savedOffsetX, y: savedOffsetY }));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [savedOffsetX, savedOffsetY]);
+
   const drag = (e: React.MouseEvent<SVGSVGElement, MouseEvent>) => {
     if (e.ctrlKey || e.metaKey || e.buttons === 4 || e.shiftKey) {
       e.nativeEvent.preventDefault();
@@ -663,6 +677,22 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
 
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [hoveredLink, setHoveredLink] = useState(null as unknown as HoveredLink);
+
+  // VIA-chain data resolution: return a copy of `link` whose given side
+  // carries `src`'s data (everything except the per-segment labelOffset and
+  // anchor). The rendered DrawnLink state objects must never be mutated —
+  // hover and render both resolve chain data on the fly, and an in-place
+  // write here would permanently rewrite the segment's own side data (#201).
+  const withSideData = (link: DrawnLink, side: 'A' | 'Z', src: LinkSide): DrawnLink => {
+    const merged = { ...link.sides[side] } as unknown as Record<string, unknown>;
+    const source = src as unknown as Record<string, unknown>;
+    for (let key in source) {
+      if (key !== 'labelOffset' && key !== 'anchor') {
+        merged[key] = source[key];
+      }
+    }
+    return { ...link, sides: { ...link.sides, [side]: merged as unknown as LinkSide } };
+  };
 
   const handleLinkHover = (d: DrawnLink, side: 'A' | 'Z', e: React.MouseEvent<SVGElement>) => {
     if (e.shiftKey) {
@@ -683,11 +713,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
 
       // Check there is only one connection (otherwise this doesn't work)
       if (prevLinks.length === 1) {
-        for (let key in prevLinks[0].sides.A) {
-          if (key !== 'labelOffset' && key !== 'anchor') {
-            (d.sides.A as unknown as Record<string, unknown>)[key] = (prevLinks[0].sides.A as unknown as Record<string, unknown>)[key];
-          }
-        }
+        d = withSideData(d, 'A', prevLinks[0].sides.A);
       } else {
         console.warn(`Connection node "${d.source.label}" missing input connection.`);
       }
@@ -707,11 +733,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
 
       // Check there is only one connection (otherwise this doesn't work)
       if (forwardLinks.length === 1) {
-        for (let key in forwardLinks[0].sides.Z) {
-          if (key !== 'labelOffset' && key !== 'anchor') {
-            (d.sides.Z as unknown as Record<string, unknown>)[key] = (forwardLinks[0].sides.Z as unknown as Record<string, unknown>)[key];
-          }
-        }
+        d = withSideData(d, 'Z', forwardLinks[0].sides.Z);
       } else {
         console.warn(`Connection node "${d.target.label}" missing output connection.`);
       }
@@ -745,13 +767,27 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
   const labelHideZoom = wm?.settings?.link?.labelHideZoom ?? 0;
   const hideValueLabels = labelHideZoom > 0 && (wm?.settings?.panel?.zoomScale ?? 0) >= labelHideZoom;
 
+  // VIA-chain data collection for rendering (#201): a segment leaving a
+  // connection node displays the incoming link's A-side data. Resolved once
+  // per render into copies — the drawn-links state itself is never mutated.
+  const resolvedLinks = links.map((d) => {
+    if (tempNodes[d.source.index]?.isConnection) {
+      const prevLinks = links.filter((l) => l.target.id === d.source.id);
+      if (prevLinks.length === 1) {
+        return withSideData(d, 'A', prevLinks[0].sides.A);
+      }
+      console.warn(`Connection node "${d.source.label}" missing input connection.`);
+    }
+    return d;
+  });
+
   // Label collision avoidance (#179): opt-in greedy pass that nudges value
   // labels along their own link until they stop overlapping each other.
   let collisionOffsets: Map<string, number> | null = null;
   if (wm?.settings?.link?.labelCollision && !hideValueLabels) {
     const placements: LabelPlacement[] = [];
     const fs = wm.settings.fontSizing.link;
-    for (const d of links) {
+    for (const d of resolvedLinks) {
       if (d.nodes[0].id === d.nodes[1].id) {
         continue;
       }
@@ -1307,7 +1343,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
               `}</style>
             )}
             {wm.settings.link.gradientColor &&
-              links.map((d) => (
+              resolvedLinks.map((d) => (
                 <React.Fragment key={d.id}>
                   <linearGradient
                     id={`grad-a-${d.id}`}
@@ -1406,26 +1442,15 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
             })`}
           >
             <g>
-              {links.map((d, i) => {
+              {resolvedLinks.map((d, i) => {
                 if (d.nodes[0].id === d.nodes[1].id) {
                   return;
                 }
+                // Incoming link at a VIA junction: only needed for the
+                // junction circle radius; the side data is already resolved.
                 let prevLinks: DrawnLink[] = [];
-                // Automatic data collection through connection links
                 if (tempNodes[d.source.index].isConnection) {
-                  // If this link is coming from a connection, we want to take the link to that connection's data
-                  // Find the link with that data
                   prevLinks = links.filter((l) => l.target.id === d.source.id);
-                  // Check there is only one connection (otherwise this doesn't work)
-                  if (prevLinks.length === 1) {
-                    for (let key in d.sides.A) {
-                      if (key !== 'labelOffset' && key !== 'anchor') {
-                        (d.sides.A as unknown as Record<string, unknown>)[key] = (prevLinks[0].sides.A as unknown as Record<string, unknown>)[key];
-                      }
-                    }
-                  } else {
-                    console.warn(`Connection node "${d.source.label}" missing input connection.`);
-                  }
                 }
                 return (
                   <g
@@ -1577,7 +1602,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
               })}
             </g>
             <g>
-              {links.map((d, i) => {
+              {resolvedLinks.map((d, i) => {
                 if (d.nodes[0].id === d.nodes[1].id || hideValueLabels) {
                   return;
                 }
@@ -1631,7 +1656,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
               })}
             </g>
             <g>
-              {links.map((d, i) => {
+              {resolvedLinks.map((d, i) => {
                 if (
                   d.nodes[0].id === d.nodes[1].id ||
                   tempNodes[d.target.index].isConnection ||
@@ -1688,7 +1713,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
               })}
             </g>
             <g>
-              {links.map((d, i) => {
+              {resolvedLinks.map((d, i) => {
                 if (d.nodes[0].id === d.nodes[1].id) {
                   return;
                 }
@@ -1760,6 +1785,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                     draggedNode: draggedNode,
                     selectedNodes: selectedNodes,
                     wm: wm,
+                    scrubTimeMs: useTimeline ? effectiveScrub : null,
                     onDrag: (e, position) => {
                       // Return early if we actually want to just pan the whole weathermap.
                       if (e.ctrlKey || e.metaKey) {

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -772,7 +772,13 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
   // per render into copies — the drawn-links state itself is never mutated.
   const resolvedLinks = links.map((d) => {
     if (tempNodes[d.source.index]?.isConnection) {
-      const prevLinks = links.filter((l) => l.target.id === d.source.id);
+      // Walk back through consecutive connection nodes (same traversal as
+      // hover) so multi-VIA chains show the origin link's data on every
+      // segment regardless of segment order in the links array.
+      let prevLinks = links.filter((l) => l.target.id === d.source.id);
+      while (prevLinks.length === 1 && tempNodes[prevLinks[0].source.index]?.isConnection) {
+        prevLinks = links.filter((l) => l.target.id === prevLinks[0].source.id);
+      }
       if (prevLinks.length === 1) {
         return withSideData(d, 'A', prevLinks[0].sides.A);
       }

--- a/src/components/MapNode.tsx
+++ b/src/components/MapNode.tsx
@@ -10,7 +10,7 @@ import {
   getTimeField,
   getValueField,
   sanitizeUrl,
-  valueAtTime,
+  sampleAtTime,
 } from '../utils';
 import { css } from '@emotion/css';
 import { useStyles2 } from '@grafana/ui';
@@ -87,10 +87,12 @@ const MapNode: React.FC<NodeProps> = (props: NodeProps) => {
       .map((frame) => {
         const valueField = getValueField(frame);
         // Timeline scrubbing (#201): while scrubbing, node status replays the
-        // value at the selected time (same step-hold semantics as link
-        // values); live mode keeps reading the most recent datapoint.
+        // raw value at the selected time (step-hold like link values, but
+        // without their throughput negative-clamp — negative status values
+        // are legitimate mapping inputs and must resolve like live mode).
+        // Live mode keeps reading the most recent datapoint.
         if (scrubTimeMs !== null && scrubTimeMs !== undefined) {
-          return valueAtTime(
+          return sampleAtTime(
             getTimeField(frame)?.values as Array<number | null | undefined>,
             valueField.values as Array<number | null | undefined>,
             scrubTimeMs

--- a/src/components/MapNode.tsx
+++ b/src/components/MapNode.tsx
@@ -7,8 +7,10 @@ import {
   calculateRectangleAutoWidth,
   calculateRectangleAutoHeight,
   getDataFrameName,
+  getTimeField,
   getValueField,
   sanitizeUrl,
+  valueAtTime,
 } from '../utils';
 import { css } from '@emotion/css';
 import { useStyles2 } from '@grafana/ui';
@@ -28,6 +30,9 @@ interface NodeProps {
   onContextMenu?: React.MouseEventHandler<SVGGElement>;
   disabled: boolean;
   data: PanelData;
+  // Timeline scrub position (ms) or null/undefined for live. When set, node
+  // status replays the value at that time — matching link value behavior (#201).
+  scrubTimeMs?: number | null;
 }
 
 // Calculate the middle of the rectangle for text centering
@@ -52,7 +57,7 @@ function calculateRectY(d: DrawnNode, wm: Weathermap) {
 }
 
 const MapNode: React.FC<NodeProps> = (props: NodeProps) => {
-  const { node, draggedNode, selectedNodes, wm, onDrag, onStop, onClick, onMouseMove, onMouseLeave, onContextMenu, disabled, data } =
+  const { node, draggedNode, selectedNodes, wm, onDrag, onStop, onClick, onMouseMove, onMouseLeave, onContextMenu, disabled, data, scrubTimeMs } =
     props;
   const styles = useStyles2(getStyles);
 
@@ -81,6 +86,16 @@ const MapNode: React.FC<NodeProps> = (props: NodeProps) => {
       })
       .map((frame) => {
         const valueField = getValueField(frame);
+        // Timeline scrubbing (#201): while scrubbing, node status replays the
+        // value at the selected time (same step-hold semantics as link
+        // values); live mode keeps reading the most recent datapoint.
+        if (scrubTimeMs !== null && scrubTimeMs !== undefined) {
+          return valueAtTime(
+            getTimeField(frame)?.values as Array<number | null | undefined>,
+            valueField.values as Array<number | null | undefined>,
+            scrubTimeMs
+          );
+        }
         return valueField.values[valueField.values.length - 1];
       });
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -20,6 +20,7 @@ import {
   parseOptionalFiniteNumber,
   getTimeField,
   removeVia,
+  sampleAtTime,
   sanitizeUrl,
   valueAtTime,
 } from 'utils';
@@ -291,6 +292,28 @@ describe('VIA helpers (addViaToLink / removeVia)', () => {
     expect(wm.links).toHaveLength(1);
     expect(wm.links[0].id).toBe('self');
     expect(wm.nodes.some((n) => n.id === conn.id)).toBe(true);
+  });
+});
+
+// #201 follow-up: node status replays raw values — negatives are legitimate
+// status mapping inputs, and "no usable sample" must not collapse into 0.
+describe('sampleAtTime (raw step-hold, no clamping)', () => {
+  const times = [1000, 2000, 3000];
+
+  test('preserves negative values', () => {
+    expect(sampleAtTime(times, [-3, -7, 5], 2500)).toBe(-7);
+    expect(sampleAtTime(times, [-3, -7, 5], 900)).toBe(-3);
+  });
+
+  test('step-hold matches valueAtTime walk (skips null/NaN backwards)', () => {
+    expect(sampleAtTime(times, [4, null, NaN], 3500)).toBe(4);
+    expect(sampleAtTime(times, [4, 9, 2], 2999)).toBe(9);
+  });
+
+  test('returns undefined when nothing is usable', () => {
+    expect(sampleAtTime([], [], 1000)).toBeUndefined();
+    expect(sampleAtTime(undefined, undefined, 1000)).toBeUndefined();
+    expect(sampleAtTime(times, [null, NaN, null], 2000)).toBeUndefined();
   });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -425,8 +425,24 @@ export function valueAtTime(
   values: Array<number | null | undefined> | null | undefined,
   timeMs: number
 ): number {
+  const raw = sampleAtTime(times, values, timeMs);
+  return raw === undefined ? 0 : Math.max(0, raw);
+}
+
+/**
+ * Raw step-hold sample at a point in time: same walk as valueAtTime (most
+ * recent valid sample at or before timeMs, null/NaN skipped backwards) but
+ * without the throughput-specific negative clamp and 0 default. Used for
+ * node status (#201), where negative values are legitimate mapping inputs
+ * and "no usable sample" must stay distinguishable from a real 0.
+ */
+export function sampleAtTime(
+  times: Array<number | null | undefined> | null | undefined,
+  values: Array<number | null | undefined> | null | undefined,
+  timeMs: number
+): number | undefined {
   if (!times || !values || times.length === 0) {
-    return 0;
+    return undefined;
   }
 
   // Index of the most recent sample at or before timeMs.
@@ -450,10 +466,10 @@ export function valueAtTime(
   for (let i = idx; i >= 0; i--) {
     const v = values[i];
     if (v !== null && v !== undefined && !isNaN(v)) {
-      return Math.max(0, v);
+      return v;
     }
   }
-  return 0;
+  return undefined;
 }
 
 export const getDataFrameName = (frame: DataFrame, allFrames: DataFrame[]): string => {


### PR DESCRIPTION
Closes #201

## Problems

1. **Stale pan offset** — local `offset` state was seeded from options once at mount and never resynced, so dashboard reloads, editor edits, or another session saving left the map panned to an outdated position.
2. **VIA-chain mutation** — chain data resolution wrote into the `DrawnLink` state objects: the line render loop copied the incoming link's A-side data into each segment leaving a connection node, and the hover handler wrote both backward (A) and forward (Z) chain data into the hovered link. Labels, gradient defs, and collision math all depended on which mutation had happened to run last.
3. **Node status ignored the timeline** — `MapNode` always read the last datapoint, so scrubbing (#158) replayed link values against present-day node colors, which is wrong for incident replay.

## Fixes

- A guarded `useEffect` resyncs `offset` whenever the saved offset changes, skipped while a drag is active (the drag's own mouse-up persists its final offset, as before). No-op when values already match.
- Chain data is resolved **once per render** into `resolvedLinks` — copies produced by a new `withSideData` helper — used by every render loop (lines, gradients, value labels, port labels, collision pass). Hover builds its own resolved copy for the tooltip. The `links` state is never written to.
- **Timeline decision (Option A — replay):** `MapNode` now takes a `scrubTimeMs` prop; while scrubbing, node status resolves the value at the scrub position with the same step-hold `valueAtTime` semantics links use. Live mode still reads the most recent datapoint. Documented at the resolution site.

## Adjacent behavior preserved

- Drag-to-pan and its mouse-up persistence unchanged.
- Rendered VIA output identical: the A-side label of a segment leaving a connection still shows the chain's origin data (locked by test), junction circle radius still uses the incoming link's stroke.
- Direct-link tooltips unchanged (existing direction-label tests still pass).
- Live node status behavior unchanged.

## Tests

- `timeline scrub updates link label value` — slider scrub swaps the label from the latest sample to the historical one.
- `timeline scrub replays node status` — node stroke leaves the status-down color when scrubbed into a healthy period.
- `pan offset resyncs from changed options` — rerender with a changed saved offset moves the map.
- `VIA chain labels and hover tooltip resolve chain data without mutation side effects` — chain A-side data labels both segments, hover tooltip resolves forward-chain data, and the rendered map plus saved options are byte-identical after hover.

## Validation

- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm run test:ci` — 99 tests pass (11 suites)
- `npm run build` — pass
- `node scripts/verify-dist.js` — pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes timeline and state sync so the map follows saved pan offsets, multi-hop VIA chains resolve without mutating state, and node status replays correctly while scrubbing (including negatives).

- Bug Fixes
  - Pan offset resync: a guarded `useEffect` updates local offset when the saved offset changes and skips while dragging.
  - VIA-chain resolution: resolve once per render into `resolvedLinks`; hover builds a resolved copy. Never mutate `links`. Walks back through consecutive connection nodes so multi-VIA chains label correctly regardless of link order.
  - Timeline replay for nodes: `MapNode` takes `scrubTimeMs` and uses raw step-hold `sampleAtTime` to resolve status at the scrub time; preserves negative values and matches live-mode mapping. Live mode still reads the latest sample.

<sup>Written for commit 371f998bfc00e959868507a457fd7733e45a10d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

