### PR TITLE
fix: deterministic value resolution for duplicate display names (#204)

### DIFF
--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -752,3 +752,32 @@ describe('timeline and state synchronization (#201)', () => {
     expect(nodeRect().getAttribute('stroke')).toBe('#aa0000');
   });
 });
+
+// #204: with two frames sharing a display name, the resolved link value must
+// come from the FIRST frame — matching the dropdown's de-duplication — not
+// from whichever duplicate happens to arrive last in data.series.
+test('duplicate display names resolve deterministically to the first frame (#204)', () => {
+  const testProps = { ...mPanelProps };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  weathermap.links[0].sides.A.query = 'dup-series';
+  testProps.options = { weathermap };
+  const mkFrame = (refId: string, v: number) =>
+    toDataFrame({
+      refId,
+      fields: [
+        { name: 'Time', values: [1, 2] },
+        { name: 'Value', values: [v, v], config: { displayNameFromDS: 'dup-series' } },
+      ],
+    });
+  testProps.data = {
+    state: LoadingState.Done,
+    series: [mkFrame('A', 53), mkFrame('B', 97)],
+    timeRange: getDefaultRelativeTimeRange(),
+  } as unknown as PanelProps<SimpleOptions>['data'];
+  testProps.onOptionsChange = jest.fn();
+
+  const { container } = render(<WeathermapPanel {...testProps} />);
+
+  expect(container.textContent).toContain('53');
+  expect(container.textContent).not.toContain('97');
+});

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -572,7 +572,16 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                 effectiveScrub
               )
             : aggregateFieldValues(fieldValues, mode);
-        map.set(getDataFrameName(frame, data.series), resolvedValue);
+        const name = getDataFrameName(frame, data.series);
+        // Duplicate display names (#204): keep the FIRST frame's value. The
+        // query dropdown de-duplicates by first occurrence (buildQueryOptions)
+        // and node status resolution takes the first match, so a last-wins
+        // overwrite here silently resolved a different series than the one
+        // the user picked. TODO: true disambiguation needs a stable
+        // frame/field id in the stored link config, not just a display name.
+        if (!map.has(name)) {
+          map.set(name, resolvedValue);
+        }
       } catch (e) {
         console.warn('Network Weathermap: Error while attempting to access query data.', e);
       }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -317,6 +317,27 @@ describe('sampleAtTime (raw step-hold, no clamping)', () => {
   });
 });
 
+// #204: duplicate display names must behave deterministically — the dropdown
+// keeps the first occurrence, and the panel's value map does the same.
+describe('duplicate display names are deterministic (#204)', () => {
+  const dupFrame = (refId: string, displayName: string, value: number) =>
+    toDataFrame({
+      refId,
+      fields: [
+        { name: 'Time', values: [1, 2] },
+        { name: 'Value', values: [value, value], config: { displayNameFromDS: displayName } },
+      ],
+    });
+
+  test('buildQueryOptions keeps the first frame for a duplicated name', () => {
+    const frames = [dupFrame('A', 'dup-series', 1), dupFrame('B', 'dup-series', 2), dupFrame('C', 'unique', 3)];
+    const options = buildQueryOptions(frames);
+
+    // One option per distinct name; the duplicate collapses to one entry.
+    expect(options.map((o) => o.value)).toEqual(['dup-series', 'unique']);
+  });
+});
+
 describe('timeline helpers (valueAtTime / getTimeField)', () => {
   const times = [1000, 2000, 3000];
   const values = [10, 20, 30];


### PR DESCRIPTION
Closes #204

## Problem

Query matching is display-name based. The dropdown de-duplicates names keeping the **first** occurrence (`buildQueryOptions`), and node status resolution also takes the first matching frame — but the panel's `dataFrameMap` was populated with `map.set` per frame, so the **last** duplicate silently won. A link could resolve its value from a different series than the one the user picked, depending on nothing but frame order.

## Fix

`dataFrameMap` now keeps the first frame's value for a duplicated display name, making all three resolution paths (dropdown, link values, node status) consistently first-occurrence-wins. The choice and its limitation are documented at the site, with a TODO noting that true disambiguation requires a stable frame/field id in the stored link config rather than a display name — a schema change out of scope here.

## Adjacent behavior preserved

- Unique display names resolve exactly as before.
- Dropdown labeling behavior (#49/#191) untouched.
- Node status resolution untouched (already first-wins).

## Tests

- `buildQueryOptions keeps the first frame for a duplicated name` (utils).
- `duplicate display names resolve deterministically to the first frame` (panel): two frames share a name with different values; the rendered link label shows the first frame's value and never the second's.

## Validation

- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm run test:ci` — 97 tests pass (11 suites)
- `npm run build` — pass
- `node scripts/verify-dist.js` — pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nondeterministic value resolution when multiple series share a display name. Now the first matching frame is used everywhere, so links and node status match the dropdown choice (#204).

- Bug Fixes
  - In the panel, `dataFrameMap` keeps the first value for a duplicated name instead of letting later frames overwrite it.
  - Added tests for first-wins behavior in `buildQueryOptions` and panel rendering.
  - Preserves behavior for unique names; no changes to dropdown labels or node status.

<sup>Written for commit 10204c18c1665e6225fe7b5ce7f25475e618eb98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

