### PR TITLE
chore(release): bump version to 1.5.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [1.5.14](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.14) (2026-07-04)
 
+### Features
+
+* **vendor icon set — 49 bundled icons** (PR [#190](https://github.com/allamiro/grafana-network-weathermap-ng/pull/190)): 19 brand logos from the Simple Icons project (CC0) — Juniper, F5, Fortinet, Palo Alto Networks, MikroTik, Ubiquiti, Netgear, TP-Link, Huawei, SonicWall, Nokia, Ericsson, OPNsense, pfSense, OpenWrt, Dell, HP, Lenovo, Supermicro — plus 30 composite device icons (e.g. `vendors/juniper-router`, `vendors/f5-load-balancer`) combining Networking shapes with vendor corner badges. New **Vendors** group in the node icon picker; Icon Reference regenerated (1046 icons, 11 sets)
+
 ### Bug Fixes
 
 * **panel crash resilience for malformed or partial weathermap options** — missing/partial `options.weathermap`, links referencing deleted nodes, and overlapping nodes (zero-length arrow vectors) no longer crash the panel; options are normalized before any dereference, malformed links are skipped, and SVG geometry can no longer contain `NaN` ([#198](https://github.com/allamiro/grafana-network-weathermap-ng/issues/198), PR [#206](https://github.com/allamiro/grafana-network-weathermap-ng/pull/206))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.5.14](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.14) (2026-07-04)
+
+### Bug Fixes
+
+* **panel crash resilience for malformed or partial weathermap options** — missing/partial `options.weathermap`, links referencing deleted nodes, and overlapping nodes (zero-length arrow vectors) no longer crash the panel; options are normalized before any dereference, malformed links are skipped, and SVG geometry can no longer contain `NaN` ([#198](https://github.com/allamiro/grafana-network-weathermap-ng/issues/198), PR [#206](https://github.com/allamiro/grafana-network-weathermap-ng/pull/206))
+* **render purity** — the options-schema migration no longer mutates the incoming saved options object, and neither the panel nor the editor calls `onOptionsChange`/`onChange` during render; migrated options are persisted from guarded effects after commit ([#199](https://github.com/allamiro/grafana-network-weathermap-ng/issues/199), PR [#210](https://github.com/allamiro/grafana-network-weathermap-ng/pull/210))
+* **numeric inputs never store `NaN`** — blank or mid-edit numeric fields (positions, panel size, zoom, offsets, icon sizes, thresholds, bandwidth) keep the previous valid value instead of writing `NaN` into saved options; `0` remains valid; the color-scale editor no longer leaks `NaN` into options through shared local edit state ([#200](https://github.com/allamiro/grafana-network-weathermap-ng/issues/200), PR [#211](https://github.com/allamiro/grafana-network-weathermap-ng/pull/211))
+* **timeline and state synchronization** — the pan offset resyncs when saved options change externally (dashboard reload, another session); VIA-chain data resolution no longer mutates rendered link state (multi-VIA chains included); node status now replays the timeline scrub position with raw step-hold sampling, matching link values during incident replay ([#201](https://github.com/allamiro/grafana-network-weathermap-ng/issues/201), PR [#212](https://github.com/allamiro/grafana-network-weathermap-ng/pull/212))
+* **self-link anchor accounting** — removing a self-link now decrements its shared anchor by 2 (mirroring add) and clamps at 0, so link spacing no longer drifts on affected nodes ([#202](https://github.com/allamiro/grafana-network-weathermap-ng/issues/202), PR [#209](https://github.com/allamiro/grafana-network-weathermap-ng/pull/209))
+* **SVG export hardening** — relative, root-relative, and absolute icon URLs resolve correctly; `data:`/`blob:` hrefs (any scheme casing) are left untouched; a failed or CORS-blocked icon fetch keeps the original href instead of aborting the whole export ([#203](https://github.com/allamiro/grafana-network-weathermap-ng/issues/203), PR [#207](https://github.com/allamiro/grafana-network-weathermap-ng/pull/207))
+* **deterministic mapping for duplicate display names** — when two series share a display name, link values now resolve from the first frame, consistently with the query dropdown and node status, instead of silently taking whichever duplicate arrived last ([#204](https://github.com/allamiro/grafana-network-weathermap-ng/issues/204), PR [#213](https://github.com/allamiro/grafana-network-weathermap-ng/pull/213))
+
+### Chores (not part of the plugin archive)
+
+* CI hardening — dedicated E2E workflow (weekly + manual) against Grafana 11 and latest, broader push path filters (including `.config/**`), consistent dependency installs between test and release, and a PR-time plugin archive layout check that reads the plugin id from `dist/plugin.json` ([#205](https://github.com/allamiro/grafana-network-weathermap-ng/issues/205), PR [#208](https://github.com/allamiro/grafana-network-weathermap-ng/pull/208))
+
 ## [1.5.13](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.13) (2026-07-04)
 
 ### Bug Fixes

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,5 +8,5 @@ authors:
 repository-code: "https://github.com/allamiro/grafana-network-weathermap-ng"
 url: "https://allamiro.github.io/grafana-network-weathermap-ng/"
 license: Apache-2.0
-version: 1.5.13
-date-released: "2026-07-03"
+version: 1.5.14
+date-released: "2026-07-04"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.13",
+  "version": "1.5.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamirsuliman-weathermap-panel",
-      "version": "1.5.13",
+      "version": "1.5.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.13",
+  "version": "1.5.14",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Version bump for the 1.5.14 hardening release. Changelog covers the eight hardening issues (#198–#205) resolved by PRs #206–#213:

- panel crash resilience for malformed/partial options (#198)
- pure migration + commit-phase option writes (#199)
- numeric inputs never store NaN (#200)
- timeline and state synchronization (#201)
- symmetrical self-link anchor accounting (#202)
- SVG export hardening (#203)
- deterministic duplicate display-name mapping (#204)
- CI: E2E workflow, path filters, install consistency, packaging checks (#205)

After merge, tagging `v1.5.14` triggers the signed release workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release 1.5.14 adds a vendor icon set (49 bundled icons with a new Vendors group) and ships hardening fixes for crash resilience, state sync, NaN writes, and SVG export, plus CI tightening. Tagging `v1.5.14` triggers the signed release workflow.

- **New Features**
  - Vendor icon set — 49 bundled icons (19 brand logos + 30 composite device icons like `vendors/juniper-router`); new Vendors group in the icon picker.

- **Bug Fixes**
  - Prevent panel crashes from malformed/partial options and bad links (normalize before use).
  - Make options migration pure; persist migrated options after commit only.
  - Numeric inputs never store NaN; blanks keep last value; 0 stays valid.
  - Keep timeline, node status, and links in sync; resync pan offset on external changes.
  - Fix self-link anchor accounting to prevent spacing drift.
  - Harden SVG export: resolve icon URLs; tolerate CORS/fetch failures.
  - Deterministic mapping when display names collide (use first frame).

<sup>Written for commit 107cc4db8d094fd634cb79981d1a31806a2f43f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

