### PR TITLE
chore(release): add E2E baseline tests to the 1.5.14 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Chores (not part of the plugin archive)
 
+* **E2E baseline tests** ([#38](https://github.com/allamiro/grafana-network-weathermap-ng/issues/38), PR [#216](https://github.com/allamiro/grafana-network-weathermap-ng/pull/216)): Playwright/@grafana/plugin-e2e coverage for the core editor workflow — panel renders, add node, add link between two nodes, threshold change updates the color-scale legend — verified in CI against Grafana 11.0.0 and latest; version-tolerant visualization-picker driving, `GRAFANA_URL`/`PW_CHANNEL` targeting, and `npm run e2e:local` for the anonymous-admin testing stack. Includes stable `inputId`s on the link editor side selects (#167 pattern)
 * CI hardening — dedicated E2E workflow (weekly + manual) against Grafana 11 and latest, broader push path filters (including `.config/**`), consistent dependency installs between test and release, and a PR-time plugin archive layout check that reads the plugin id from `dist/plugin.json` ([#205](https://github.com/allamiro/grafana-network-weathermap-ng/issues/205), PR [#208](https://github.com/allamiro/grafana-network-weathermap-ng/pull/208))
 
 ## [1.5.13](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.13) (2026-07-04)


### PR DESCRIPTION
Records #38 / PR #216 in the 1.5.14 changelog ahead of re-cutting the v1.5.14 tag to include the E2E work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an E2E baseline tests entry to the 1.5.14 changelog. Documents Playwright/`@grafana/plugin-e2e` coverage for core editor flows and CI verification against Grafana 11.0.0 and latest ahead of re-cutting v1.5.14.

<sup>Written for commit 49267bb2a988a01c16776f17aa0137906ca242cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

