### PR TITLE
test: pre-check the viz picker variant instead of a catch-all fallback

### DIFF
--- a/tests/panel.spec.ts
+++ b/tests/panel.spec.ts
@@ -15,11 +15,17 @@ const setupPanel = async (
   panelEditPage: { setVisualization: (n: string) => Promise<void> },
   page: Page
 ) => {
+  // Pre-check which picker UI is present instead of catching: a failure
+  // inside either path must surface, not silently fall through.
   const changeViz = page.getByRole('button', { name: /Change visualization/i });
-  try {
-    await changeViz.click({ timeout: 5000 });
+  const hasButton = await changeViz
+    .waitFor({ state: 'visible', timeout: 5000 })
+    .then(() => true)
+    .catch(() => false);
+  if (hasButton) {
+    await changeViz.click();
     await page.getByText('Network Weathermap NG', { exact: true }).first().click();
-  } catch {
+  } else {
     await panelEditPage.setVisualization('Network Weathermap NG');
   }
 };


### PR DESCRIPTION
Follow-up to #216 addressing the cubic review finding: the try/catch in `setupPanel` swallowed every error type, so a genuine failure after the 11.x/12.4 button click (e.g. the viz item not found) silently fell through to `setVisualization` with the picker already open. The variant is now detected with a visibility pre-check and failures inside either path propagate.

E2E workflow will be dispatched on this branch to re-verify both Grafana versions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects which visualization picker UI is present via a visibility pre-check in the panel E2E test, replacing the catch-all try/catch. Failures after clicking 'Change visualization' now surface instead of silently falling back to setVisualization, covering Grafana 11.x and 12.4.

<sup>Written for commit c0c5feade38319f78d7711ef3dff27e4ffb0c88d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

