### PR TITLE
chore(release): add cloud provider icon set to the 1.5.14 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Features
 
+* **cloud provider icon set — 18 bundled icons** ([#215](https://github.com/allamiro/grafana-network-weathermap-ng/issues/215), PR [#219](https://github.com/allamiro/grafana-network-weathermap-ng/pull/219)): AWS, Azure, and GCP brand logos (Simple Icons, CC0) plus provider-badged device composites (`cloud/aws-router`, `cloud/azure-firewall`, ...) in a new **Cloud** picker group. The official architecture icon packs are not bundled for licensing reasons — `scripts/fetch-cloud-icons.sh` installs them onto your own Grafana, usable via a node's Custom icon URL
 * **vendor icon set — 49 bundled icons** (PR [#190](https://github.com/allamiro/grafana-network-weathermap-ng/pull/190)): 19 brand logos from the Simple Icons project (CC0) — Juniper, F5, Fortinet, Palo Alto Networks, MikroTik, Ubiquiti, Netgear, TP-Link, Huawei, SonicWall, Nokia, Ericsson, OPNsense, pfSense, OpenWrt, Dell, HP, Lenovo, Supermicro — plus 30 composite device icons (e.g. `vendors/juniper-router`, `vendors/f5-load-balancer`) combining Networking shapes with vendor corner badges. New **Vendors** group in the node icon picker; Icon Reference regenerated (1046 icons, 11 sets)
 
 ### Bug Fixes


### PR DESCRIPTION
Records #215 / PR #219 in the 1.5.14 changelog ahead of re-cutting the v1.5.14 tag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Cloud provider icon set entry to the v1.5.14 changelog, documenting 18 bundled AWS/Azure/GCP icons, provider‑badged device composites, and the new Cloud picker group. Notes that official architecture icon packs are excluded for licensing and can be installed locally via `scripts/fetch-cloud-icons.sh`.

<sup>Written for commit 62c012852402a3c3015aac22c0be3aaf0112c080. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

