### PR TITLE
test: bound the viz picker click to 5s

### DIFF
--- a/tests/panel.spec.ts
+++ b/tests/panel.spec.ts
@@ -23,7 +23,7 @@ const setupPanel = async (
     .then(() => true)
     .catch(() => false);
   if (hasButton) {
-    await changeViz.click();
+    await changeViz.click({ timeout: 5000 });
     await page.getByText('Network Weathermap NG', { exact: true }).first().click();
   } else {
     await panelEditPage.setVisualization('Network Weathermap NG');


### PR DESCRIPTION
Cubic follow-up on #218: restores the explicit 5s timeout on the picker-button click — a detach between the visibility pre-check and the click otherwise blocks for the 30s default action timeout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the visualization picker click to 5s in panel tests to prevent 30s default action timeouts when the button detaches between the visibility check and the click. This makes failures faster and keeps test runs responsive.

<sup>Written for commit a5180cd68c3509e9671beb67f5d64589f11773db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

