### PR TITLE
fix: fetch-cloud-icons reports failure when extraction fails

### DIFF
--- a/scripts/fetch-cloud-icons.sh
+++ b/scripts/fetch-cloud-icons.sh
@@ -26,10 +26,11 @@ fetch_azure() {
   mkdir -p "$dest"
   local url="https://arch-center.azureedge.net/icons/Azure_Public_Service_Icons_V21.zip"
   echo "Azure: fetching official icon pack..."
-  if curl -fsSL "$url" -o /tmp/azure-icons.zip; then
-    unzip -qo /tmp/azure-icons.zip -d "$dest" && rm -f /tmp/azure-icons.zip
+  if curl -fsSL "$url" -o /tmp/azure-icons.zip && unzip -qo /tmp/azure-icons.zip -d "$dest"; then
+    rm -f /tmp/azure-icons.zip
     echo "Azure icons -> $dest"
   else
+    rm -f /tmp/azure-icons.zip
     fail_hint "https://learn.microsoft.com/azure/architecture/icons/"
   fi
 }


### PR DESCRIPTION
Cubic follow-up on #219: `fetch_azure` printed the success message even when `unzip` failed (corrupt download, disk full). Download and extraction now share one success path, the failure hint fires otherwise, and the temp zip is cleaned up in both cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Azure icon fetch in `scripts/fetch-cloud-icons.sh` to only report success when both download and unzip succeed. On failure, it now shows the hint and always cleans up the temp zip.

<sup>Written for commit 01f0e6d2a00e3bb47bc1ca4cd62e1d943b340238. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

