### PR TITLE
chore: ignore Playwright runtime output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,9 @@ testing/exporter/wm-prometheus
 
 # Release
 grafana-weathermap-*.zip
+
+# Playwright runtime output — .auth holds login session state (cookies);
+# reports/traces contain UI screenshots. Never commit these.
+playwright/.auth/
+playwright-report/
+test-results/


### PR DESCRIPTION
The E2E runs (#216) generate `playwright/.auth/` (login session state — cookies after a real login), `playwright-report/`, and `test-results/` (traces, screenshots). None were gitignored, so they showed up as untracked files after any local run. Ignored now; nothing sensitive was ever committed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore Playwright runtime output so local E2E runs don’t create untracked files and to avoid committing session data or screenshots. Adds .gitignore entries for `playwright/.auth/`, `playwright-report/`, and `test-results/`.

<sup>Written for commit 942b57d5584a1555654858bfdb26eb2d16bea258. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

