### PR TITLE
fix: repair current-version maps with incomplete settings (#224)

### DIFF
--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -512,6 +512,20 @@ describe('renders empty or missing weathermap without throwing (#198)', () => {
     const { container } = renderWith({ id: 'partial', links: [] });
     expect(container).toBeInTheDocument();
   });
+
+  // #224: a CURRENT-version map with missing nested settings must also repair
+  // through migration instead of crashing on direct dereferences.
+  test.each(['panel', 'tooltip', 'scale', 'link'])(
+    'current-version weathermap missing settings.%s renders',
+    (key) => {
+      const wm = handleVersionedStateUpdates(getData(theme), theme) as unknown as {
+        settings: Record<string, unknown>;
+      };
+      delete wm.settings[key];
+      const { container } = renderWith(wm);
+      expect(container.querySelector('#nw-testing')).toBeInTheDocument();
+    }
+  );
 });
 
 // #199: the panel must not call onOptionsChange during the render phase and

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -44,6 +44,7 @@ import {
   calculateRectangleAutoWidth,
   calculateRectangleAutoHeight,
   CURRENT_VERSION,
+  needsMigration,
   handleVersionedStateUpdates,
   resolveLinkChain,
   spreadLabels,
@@ -127,7 +128,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
   // panel has no saved weathermap yet).
   const wm = useMemo(() => {
     const normalized = normalizeWeathermap(options.weathermap);
-    if (normalized && normalized.version !== CURRENT_VERSION) {
+    if (normalized && needsMigration(normalized)) {
       return handleVersionedStateUpdates(JSON.parse(JSON.stringify(normalized)), theme);
     }
     return normalized;
@@ -139,9 +140,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
   // component renders). The render above already uses the migrated copy, so
   // nothing is visually stale while the write is pending. Once it lands,
   // options.weathermap.version === CURRENT_VERSION and this effect goes quiet.
-  const needsMigrationPersist = Boolean(
-    options.weathermap && (!options.weathermap.version || options.weathermap.version !== CURRENT_VERSION)
-  );
+  const needsMigrationPersist = Boolean(options.weathermap && needsMigration(options.weathermap));
   useEffect(() => {
     if (needsMigrationPersist) {
       onOptionsChange({ weathermap: wm });

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -43,7 +43,6 @@ import {
   nearestMultiple,
   calculateRectangleAutoWidth,
   calculateRectangleAutoHeight,
-  CURRENT_VERSION,
   needsMigration,
   handleVersionedStateUpdates,
   resolveLinkChain,

--- a/src/forms/WeathermapBuilder.test.tsx
+++ b/src/forms/WeathermapBuilder.test.tsx
@@ -57,6 +57,21 @@ test('initializes and renders the default weathermap when no value is saved', ()
   expect(screen.getByText('Tooltip Font Size')).toBeInTheDocument();
 });
 
+// #224: the editor must also repair current-version maps with missing nested
+// settings — child forms read settings.tooltip/settings.scale directly.
+test('renders the editor for a current-version map with missing settings (#224)', () => {
+  const wm = JSON.parse(JSON.stringify(legacyWeathermap));
+  wm.version = CURRENT_VERSION;
+  delete wm.settings.tooltip;
+  delete wm.settings.scale;
+  const onChange = renderBuilder(wm);
+
+  expect(screen.getByText('Tooltip Font Size')).toBeInTheDocument();
+  expect(screen.getByText('Scale Title')).toBeInTheDocument();
+  expect(onChange).toHaveBeenCalledTimes(1);
+  expect(onChange.mock.calls[0][0].settings.tooltip).toBeDefined();
+});
+
 // #199: migration/defaulting must not mutate props.value and must not fire
 // onChange during the render phase — only from an effect after commit.
 describe('render purity (#199)', () => {

--- a/src/forms/WeathermapBuilder.test.tsx
+++ b/src/forms/WeathermapBuilder.test.tsx
@@ -70,6 +70,7 @@ test('renders the editor for a current-version map with missing settings (#224)'
   expect(screen.getByText('Scale Title')).toBeInTheDocument();
   expect(onChange).toHaveBeenCalledTimes(1);
   expect(onChange.mock.calls[0][0].settings.tooltip).toBeDefined();
+  expect(onChange.mock.calls[0][0].settings.scale).toBeDefined();
 });
 
 // #199: migration/defaulting must not mutate props.value and must not fire

--- a/src/forms/WeathermapBuilder.tsx
+++ b/src/forms/WeathermapBuilder.tsx
@@ -7,7 +7,7 @@ import { ColorForm } from './ColorForm';
 import { PanelForm } from './PanelForm';
 import { v4 as uuidv4 } from 'uuid';
 import { useTheme2 } from '@grafana/ui';
-import { generateBasicNode, CURRENT_VERSION, generateBasicLink, handleVersionedStateUpdates } from 'utils';
+import { generateBasicNode, CURRENT_VERSION, generateBasicLink, handleVersionedStateUpdates, needsMigration } from 'utils';
 
 interface Settings {
   placeholder: string;
@@ -108,7 +108,7 @@ export const WeathermapBuilder = (props: Props) => {
     if (!value) {
       return defaultValue;
     }
-    if (!value.version || value.version !== CURRENT_VERSION) {
+    if (needsMigration(value)) {
       return handleVersionedStateUpdates(value, theme);
     }
     return value;

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -17,6 +17,7 @@ import {
   isSafeUrl,
   measureText,
   nearestMultiple,
+  needsMigration,
   parseOptionalFiniteNumber,
   getTimeField,
   removeVia,
@@ -81,6 +82,44 @@ describe('numeric input helpers (#200)', () => {
     expect(parseOptionalFiniteNumber('abc')).toBeUndefined();
     expect(parseOptionalFiniteNumber('0')).toBe(0);
     expect(parseOptionalFiniteNumber('-3.5')).toBe(-3.5);
+  });
+});
+
+// #224: a current-version map with incomplete nested settings must repair
+// through the migration path — render code dereferences these shapes directly.
+describe('needsMigration (#224)', () => {
+  const migrated = () => handleVersionedStateUpdates(JSON.parse(JSON.stringify(legacyWeathermap)), theme);
+
+  test('false for a fully migrated map', () => {
+    expect(needsMigration(migrated())).toBe(false);
+  });
+
+  test('true for missing or old versions', () => {
+    const wm = migrated() as unknown as Record<string, unknown>;
+    delete wm.version;
+    expect(needsMigration(wm as never)).toBe(true);
+    wm.version = 3;
+    expect(needsMigration(wm as never)).toBe(true);
+  });
+
+  test.each(['panel', 'tooltip', 'scale', 'link', 'fontSizing'])(
+    'true for a current-version map missing settings.%s',
+    (key) => {
+      const wm = migrated() as unknown as { settings: Record<string, unknown> };
+      delete wm.settings[key];
+      expect(needsMigration(wm as never)).toBe(true);
+    }
+  );
+
+  test('true for a current-version map missing a nested shape (panel.panelSize)', () => {
+    const wm = migrated() as unknown as { settings: { panel: Record<string, unknown> } };
+    delete wm.settings.panel.panelSize;
+    expect(needsMigration(wm as never)).toBe(true);
+  });
+
+  test('nullish input does not throw', () => {
+    expect(needsMigration(undefined)).toBe(false);
+    expect(needsMigration(null)).toBe(false);
   });
 });
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -117,6 +117,12 @@ describe('needsMigration (#224)', () => {
     expect(needsMigration(wm as never)).toBe(true);
   });
 
+  test('true for malformed nested objects with missing leaves (panelSize: {})', () => {
+    const wm = migrated() as unknown as { settings: { panel: Record<string, unknown> } };
+    wm.settings.panel.panelSize = {};
+    expect(needsMigration(wm as never)).toBe(true);
+  });
+
   test('nullish input does not throw', () => {
     expect(needsMigration(undefined)).toBe(false);
     expect(needsMigration(null)).toBe(false);

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -123,6 +123,12 @@ describe('needsMigration (#224)', () => {
     expect(needsMigration(wm as never)).toBe(true);
   });
 
+  test('true for malformed scale fontSizing ({} passes object checks)', () => {
+    const wm = migrated() as unknown as { settings: { scale: Record<string, unknown> } };
+    wm.settings.scale.fontSizing = {};
+    expect(needsMigration(wm as never)).toBe(true);
+  });
+
   test('nullish input does not throw', () => {
     expect(needsMigration(undefined)).toBe(false);
     expect(needsMigration(null)).toBe(false);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -329,7 +329,8 @@ export function needsMigration(wm: Weathermap | undefined | null): boolean {
     num(get(st, 'scale', 'position', 'y')) &&
     num(get(st, 'scale', 'size', 'width')) &&
     num(get(st, 'scale', 'size', 'height')) &&
-    get(st, 'scale', 'fontSizing')
+    num(get(st, 'scale', 'fontSizing', 'title')) &&
+    num(get(st, 'scale', 'fontSizing', 'threshold'))
   );
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -291,6 +291,43 @@ export function parseOptionalFiniteNumber(raw: string): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
+/**
+ * Whether a saved weathermap needs the defaults deep-merge before render.
+ * True for old/missing schema versions AND for current-version maps whose
+ * nested settings are incomplete (hand-edited or provisioned JSON) — render
+ * code dereferences these shapes directly, so a malformed current-version
+ * map must repair through the same migration path (#224).
+ */
+export function needsMigration(wm: Weathermap | undefined | null): boolean {
+  if (!wm) {
+    return false;
+  }
+  if (!wm.version || wm.version !== CURRENT_VERSION) {
+    return true;
+  }
+  const st = wm.settings as unknown as Record<string, unknown> | undefined;
+  const panel = st?.panel as Record<string, unknown> | undefined;
+  const scale = st?.scale as Record<string, unknown> | undefined;
+  const link = st?.link as Record<string, unknown> | undefined;
+  return !(
+    st &&
+    link &&
+    (link.spacing as unknown) &&
+    (link.stroke as unknown) &&
+    (link.label as unknown) &&
+    (st.fontSizing as unknown) &&
+    panel &&
+    (panel.panelSize as unknown) &&
+    (panel.offset as unknown) &&
+    (panel.grid as unknown) &&
+    (st.tooltip as unknown) &&
+    scale &&
+    (scale.position as unknown) &&
+    (scale.size as unknown) &&
+    (scale.fontSizing as unknown)
+  );
+}
+
 export function handleVersionedStateUpdates(wm: Weathermap, theme: GrafanaTheme2): Weathermap {
   const modelWeathermap: Weathermap = {
     version: CURRENT_VERSION,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -305,26 +305,31 @@ export function needsMigration(wm: Weathermap | undefined | null): boolean {
   if (!wm.version || wm.version !== CURRENT_VERSION) {
     return true;
   }
-  const st = wm.settings as unknown as Record<string, unknown> | undefined;
-  const panel = st?.panel as Record<string, unknown> | undefined;
-  const scale = st?.scale as Record<string, unknown> | undefined;
-  const link = st?.link as Record<string, unknown> | undefined;
+  const num = (v: unknown) => typeof v === 'number' && Number.isFinite(v);
+  const get = (o: unknown, ...keys: string[]): unknown =>
+    keys.reduce((acc: unknown, k) => (acc && typeof acc === 'object' ? (acc as Record<string, unknown>)[k] : undefined), o);
+  const st = wm.settings as unknown;
+  // Validate the numeric leaves render code dereferences — presence of an
+  // empty object (e.g. panelSize: {}) must also trigger repair.
   return !(
     st &&
-    link &&
-    (link.spacing as unknown) &&
-    (link.stroke as unknown) &&
-    (link.label as unknown) &&
-    (st.fontSizing as unknown) &&
-    panel &&
-    (panel.panelSize as unknown) &&
-    (panel.offset as unknown) &&
-    (panel.grid as unknown) &&
-    (st.tooltip as unknown) &&
-    scale &&
-    (scale.position as unknown) &&
-    (scale.size as unknown) &&
-    (scale.fontSizing as unknown)
+    num(get(st, 'link', 'spacing', 'horizontal')) &&
+    num(get(st, 'link', 'spacing', 'vertical')) &&
+    get(st, 'link', 'stroke') &&
+    get(st, 'link', 'label') &&
+    num(get(st, 'fontSizing', 'node')) &&
+    num(get(st, 'fontSizing', 'link')) &&
+    num(get(st, 'panel', 'panelSize', 'width')) &&
+    num(get(st, 'panel', 'panelSize', 'height')) &&
+    num(get(st, 'panel', 'offset', 'x')) &&
+    num(get(st, 'panel', 'offset', 'y')) &&
+    get(st, 'panel', 'grid') &&
+    get(st, 'tooltip') &&
+    num(get(st, 'scale', 'position', 'x')) &&
+    num(get(st, 'scale', 'position', 'y')) &&
+    num(get(st, 'scale', 'size', 'width')) &&
+    num(get(st, 'scale', 'size', 'height')) &&
+    get(st, 'scale', 'fontSizing')
   );
 }
 


### PR DESCRIPTION
Closes #224

## Problem
`normalizeWeathermap` only fills `nodes`/`links`/`scale` and migration only runs when `version !== CURRENT_VERSION` — so a hand-edited/provisioned map with `version: 14` but missing `settings.panel`/`settings.tooltip`/etc. bypasses repair and crashes on direct dereferences (`settings.panel.panelSize`, `settings.panel.grid`, ...), in both the panel and the editor.

## Fix
Shared `needsMigration(wm)` predicate in utils: true for missing/old versions **or** an incomplete current-version settings shape (checks the subtrees render code dereferences: `link.spacing/stroke/label`, `fontSizing`, `panel.panelSize/offset/grid`, `tooltip`, `scale.position/size/fontSizing`). The panel's render memo + persist effect and the editor's memo all use it; the existing deep-merge migrator does the repair.

## Adjacent behavior preserved
Well-formed current-version maps evaluate the predicate to false — no migration work, no `onOptionsChange` writes (locked by the existing #199 test). Old-version migration behavior unchanged.

## Tests
- Predicate: false for migrated maps; true for missing/old version, each missing settings subtree, and a missing nested shape; nullish-safe.
- Panel: current-version maps missing each of `panel`/`tooltip`/`scale`/`link` render the map.
- Editor: current-version map missing `tooltip`+`scale` renders and persists the repaired copy once.

## Validation
typecheck / lint / affected suites (104 tests) pass; full test:ci + build in CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repair current-version weathermaps with missing or malformed nested settings by running the migration path, preventing panel/editor crashes on direct dereferences. A shared `needsMigration` predicate now detects incomplete shapes (including empty nested objects) and triggers the deep-merge repair before render.

- **Bug Fixes**
  - Added `needsMigration` in `utils` to flag missing/old versions and incomplete current-version settings (panel, tooltip, scale, link, fontSizing), validating numeric leaves (e.g., panel.panelSize.*, scale.fontSizing.title/threshold).
  - Panel uses it in the render memo and persist effect; the editor uses it on init, so malformed maps render and auto-repair instead of crashing.
  - Well-formed current-version maps still skip migration and avoid writes.
  - Expanded tests for the predicate (missing subtrees, malformed nested objects, empty `scale.fontSizing`), panel/editor repair flows, and builder repair of `tooltip` and `scale`; removed an unused import.

<sup>Written for commit f73483becc8e064385d413f25898b32bd95ba77b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

