### PR TITLE
fix: immutable updates on interaction persistence paths (#225)

### DIFF
--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -781,3 +781,35 @@ test('duplicate display names resolve deterministically to the first frame (#204
   expect(container.textContent).toContain('53');
   expect(container.textContent).not.toContain('97');
 });
+
+// #225: interaction persistence must not mutate the rendered options object.
+// Deep-freeze makes any in-place write throw, and the persisted payload must
+// be a new object carrying the change.
+test('pan persistence delivers a new object without mutating options (#225)', () => {
+  const deepFreeze = (o: unknown): unknown => {
+    if (o && typeof o === 'object') {
+      Object.values(o as Record<string, unknown>).forEach(deepFreeze);
+      Object.freeze(o);
+    }
+    return o;
+  };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  deepFreeze(weathermap);
+  const spy = jest.fn();
+  const testProps = { ...mPanelProps, options: { weathermap }, onOptionsChange: spy };
+
+  const { container } = render(<WeathermapPanel {...testProps} />);
+  fireEvent.mouseDown(container.querySelector('#nw-testing')!);
+  fireEvent(
+    container.querySelector('#nw-testing')!,
+    new MouseMoveEvent({ movementX: 25, movementY: 10, buttons: 4, bubbles: true })
+  );
+  fireEvent.mouseUp(container.querySelector('#nw-testing')!);
+
+  expect(spy).toHaveBeenCalled();
+  const persisted = spy.mock.calls[spy.mock.calls.length - 1][0].weathermap;
+  expect(persisted).not.toBe(weathermap);
+  expect(persisted.settings.panel.offset).not.toEqual({ x: 0, y: 0 });
+  // The frozen original is untouched.
+  expect(weathermap.settings.panel.offset).toEqual({ x: 0, y: 0 });
+});

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -1316,9 +1316,14 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
           }}
           onMouseUp={() => {
             setDragging(false);
-            let panned = wm;
-            panned.settings.panel.offset = offset;
-            onOptionsChange({ weathermap: panned });
+            // Persist through a clone: mutating wm in place hands the same
+            // reference back to Grafana and can skip downstream re-renders (#225).
+            onOptionsChange({
+              weathermap: {
+                ...wm,
+                settings: { ...wm.settings, panel: { ...wm.settings.panel, offset } },
+              },
+            });
           }}
           onDoubleClick={() => {
             setSelectedNodes([]);
@@ -1833,26 +1838,23 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                     onStop: (e, position) => {
                       // setDraggedNode(null as unknown as DrawnNode);
                       setDraggedNode(null as unknown as DrawnNode);
-                      let current: Weathermap = wm;
-                      current.nodes[i].position = [
+                      // Build the persisted positions immutably: writing into
+                      // wm.nodes[..] hands Grafana the same references (#225).
+                      const movedIndexes = new Set<number>([i, ...selectedNodes.map((n) => n.index)]);
+                      const snappedPosition = (index: number): [number, number] => [
                         wm.settings.panel.grid.enabled
-                          ? nearestMultiple(nodes[i].x, wm.settings.panel.grid.size)
-                          : nodes[i].x,
+                          ? nearestMultiple(nodes[index].x, wm.settings.panel.grid.size)
+                          : nodes[index].x,
                         wm.settings.panel.grid.enabled
-                          ? nearestMultiple(nodes[i].y, wm.settings.panel.grid.size)
-                          : nodes[i].y,
+                          ? nearestMultiple(nodes[index].y, wm.settings.panel.grid.size)
+                          : nodes[index].y,
                       ];
-
-                      for (let node of selectedNodes) {
-                        current.nodes[node.index].position = [
-                          wm.settings.panel.grid.enabled
-                            ? nearestMultiple(nodes[node.index].x, wm.settings.panel.grid.size)
-                            : nodes[node.index].x,
-                          wm.settings.panel.grid.enabled
-                            ? nearestMultiple(nodes[node.index].y, wm.settings.panel.grid.size)
-                            : nodes[node.index].y,
-                        ];
-                      }
+                      const current: Weathermap = {
+                        ...wm,
+                        nodes: wm.nodes.map((n, ni) =>
+                          movedIndexes.has(ni) ? { ...n, position: snappedPosition(ni) } : n
+                        ),
+                      };
 
                       onOptionsChange({
                         ...options,
@@ -1862,13 +1864,10 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                     onClick: (e) => {
                       if ((e.ctrlKey || e.metaKey) && isEditMode) {
                         setSelectedNodes((v) => {
-                          let cIndex = v.findIndex((n) => n.id === tempNodes[i].id);
-                          if (cIndex > -1) {
-                            v.splice(cIndex, 1);
-                          } else {
-                            v.push(tempNodes[i]);
-                          }
-                          return v;
+                          // Return a NEW array: mutating and returning the same
+                          // reference makes React skip selection re-renders (#225).
+                          const cIndex = v.findIndex((n) => n.id === tempNodes[i].id);
+                          return cIndex > -1 ? v.filter((_, vi) => vi !== cIndex) : [...v, tempNodes[i]];
                         });
                       } else if (!isEditMode && tempNodes[i].dashboardLink) {
                         openDashboardLink(tempNodes[i].dashboardLink, tempNodes[i].openInSameTab);

--- a/src/forms/ColorForm.test.tsx
+++ b/src/forms/ColorForm.test.tsx
@@ -101,3 +101,22 @@ describe('number inputs do not store NaN (#200)', () => {
     expect(updated.scale[0].percent).toBe(0);
   });
 });
+
+// #225: the threshold commit must deliver a new weathermap/scale reference.
+test('threshold commit delivers new object references (#225)', () => {
+  const initial = getData(theme);
+  initial.scale = [{ percent: 10, color: '#111111' }];
+  const before = JSON.parse(JSON.stringify(initial));
+  const spy = jest.fn();
+  render(<Harness initial={initial} onChangeSpy={spy} />);
+
+  const threshold = screen.getByLabelText('Weathermap Threshold 10');
+  fireEvent.change(threshold, { target: { value: '35' } });
+  fireEvent.blur(threshold);
+
+  const updated: Weathermap = spy.mock.calls[spy.mock.calls.length - 1][0];
+  expect(updated).not.toBe(initial);
+  expect(updated.scale).not.toBe(initial.scale);
+  expect(updated.scale[0].percent).toBe(35);
+  expect(initial).toEqual(before);
+});

--- a/src/forms/ColorForm.tsx
+++ b/src/forms/ColorForm.tsx
@@ -17,15 +17,16 @@ export const ColorForm = (props: Props) => {
   const { value, onChange } = props;
 
   const handleNumberChange = (e: any, currentIndex: number) => {
-    let weathermap: Weathermap = value;
-    // Blank input reports NaN; keep the previous threshold instead of saving it.
-    weathermap.scale[currentIndex].percent = finiteOrFallback(
-      e.currentTarget.valueAsNumber,
-      weathermap.scale[currentIndex].percent
+    // Immutable update (#225); blank input reports NaN — keep the previous
+    // threshold instead of saving it (#200).
+    const scale = value.scale.map((t, ti) =>
+      ti === currentIndex
+        ? { ...t, percent: finiteOrFallback(e.currentTarget.valueAsNumber, t.percent) }
+        : t
     );
-    weathermap.scale.sort((a, b) => a.percent - b.percent);
-    onChange(weathermap);
-    setEditedPercents(weathermap.scale);
+    scale.sort((a, b) => a.percent - b.percent);
+    onChange({ ...value, scale });
+    setEditedPercents(scale);
   };
 
   const handleColorChange = (color: any, index: number) => {

--- a/src/forms/NodeForm.test.tsx
+++ b/src/forms/NodeForm.test.tsx
@@ -102,3 +102,26 @@ describe('number inputs do not store NaN (#200)', () => {
     expect(lastValue(spy).nodes.find((n) => n.label === 'Node A')!.position[0]).toBe(250);
   });
 });
+
+// #225: form updates must deliver new object references, not mutations of
+// props.value.
+test('position change delivers a new weathermap and node reference (#225)', async () => {
+  const initial = getData(theme);
+  const before = JSON.parse(JSON.stringify(initial));
+  const spy = jest.fn();
+  const { container } = render(<Harness initial={initial} onChangeSpy={spy} />);
+  const picker = screen.getAllByRole('combobox')[0];
+  fireEvent.keyDown(picker, { key: 'ArrowDown' });
+  fireEvent.click(await screen.findByText('Node A'));
+
+  fireEvent.change(container.querySelector('input[name="X"]')!, { target: { value: '321' } });
+
+  const updated = spy.mock.calls[spy.mock.calls.length - 1][0];
+  expect(updated).not.toBe(initial);
+  expect(updated.nodes).not.toBe(initial.nodes);
+  const idx = updated.nodes.findIndex((n: { label?: string }) => n.label === 'Node A');
+  expect(updated.nodes[idx]).not.toBe(initial.nodes[idx]);
+  expect(updated.nodes[idx].position[0]).toBe(321);
+  // The original object is untouched.
+  expect(initial).toEqual(before);
+});

--- a/src/forms/NodeForm.test.tsx
+++ b/src/forms/NodeForm.test.tsx
@@ -125,3 +125,27 @@ test('position change delivers a new weathermap and node reference (#225)', asyn
   // The original object is untouched.
   expect(initial).toEqual(before);
 });
+
+// #225 follow-up (review): color/status/connection handlers must also deliver
+// new references.
+test('node color change delivers new node and colors references (#225)', async () => {
+  const initial = getData(theme);
+  const before = JSON.parse(JSON.stringify(initial));
+  const spy = jest.fn();
+  render(<Harness initial={initial} onChangeSpy={spy} />);
+  const picker = screen.getAllByRole('combobox')[0];
+  fireEvent.keyDown(picker, { key: 'ArrowDown' });
+  fireEvent.click(await screen.findByText('Node A'));
+
+  // The apply-to-all button (inside the Colors collapse) exercises the bulk
+  // path without opening color pickers.
+  fireEvent.click(screen.getByText('Colors'));
+  fireEvent.click(screen.getByText(/Apply to All/i));
+
+  const updated = spy.mock.calls[spy.mock.calls.length - 1][0];
+  expect(updated).not.toBe(initial);
+  expect(updated.nodes).not.toBe(initial.nodes);
+  expect(updated.nodes[0]).not.toBe(initial.nodes[0]);
+  expect(updated.nodes[0].colors).not.toBe(initial.nodes[0].colors);
+  expect(initial).toEqual(before);
+});

--- a/src/forms/NodeForm.tsx
+++ b/src/forms/NodeForm.tsx
@@ -89,31 +89,32 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
     onChange(weathermap);
   };
 
+  // Immutable single-node update (#225): clone the touched node so onChange
+  // delivers new references instead of mutating props.value in place.
+  const updateNode = (i: number, patch: Partial<Node>) => {
+    onChange({
+      ...value,
+      nodes: value.nodes.map((n, ni) => (ni === i ? { ...n, ...patch } : n)),
+    });
+  };
+
   const handleConnectionChange = (e: React.FormEvent<HTMLInputElement>, i: number): void => {
-    let weathermap: Weathermap = value;
-    weathermap.nodes[i].isConnection = e.currentTarget.checked;
-    weathermap.nodes[i].label = 'C' + connectionCounter;
-    onChange(weathermap);
+    updateNode(i, { isConnection: e.currentTarget.checked, label: 'C' + connectionCounter });
   };
 
   const handleStatusQueryChange = (query: string | undefined, i: number) => {
-    let weathermap: Weathermap = value;
-    weathermap.nodes[i].statusQuery = query;
-    onChange(weathermap);
+    updateNode(i, { statusQuery: query });
   };
 
   const handleColorChange = (color: string, i: number, type: string) => {
-    let weathermap: Weathermap = value;
-    weathermap.nodes[i].colors[type as 'font' | 'background' | 'border'] = color;
-    onChange(weathermap);
+    updateNode(i, { colors: { ...value.nodes[i].colors, [type as 'font' | 'background' | 'border']: color } });
   };
 
   const applyNodeColorToAll = () => {
-    let weathermap: Weathermap = value;
-    for (let node of weathermap.nodes) {
-      node.colors = { ...currentNode.colors };
-    }
-    onChange(weathermap);
+    onChange({
+      ...value,
+      nodes: value.nodes.map((n) => ({ ...n, colors: { ...currentNode.colors } })),
+    });
   };
 
   const handleIconChange = (icon: string | undefined, i: number) => {

--- a/src/forms/NodeForm.tsx
+++ b/src/forms/NodeForm.tsx
@@ -52,15 +52,17 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
   }
 
   const handleChange = (e: React.FormEvent<HTMLInputElement>, i: number) => {
-    let weathermap: Weathermap = value;
+    // Immutable update (#225): clone the touched node so onChange delivers a
+    // new reference instead of mutating props.value in place.
+    const node = { ...value.nodes[i], position: [...value.nodes[i].position] as [number, number] };
     if (e.currentTarget.name === 'X') {
-      weathermap.nodes[i].position[0] = finiteOrFallback(e.currentTarget.valueAsNumber, weathermap.nodes[i].position[0]);
+      node.position[0] = finiteOrFallback(e.currentTarget.valueAsNumber, node.position[0]);
     } else if (e.currentTarget.name === 'Y') {
-      weathermap.nodes[i].position[1] = finiteOrFallback(e.currentTarget.valueAsNumber, weathermap.nodes[i].position[1]);
+      node.position[1] = finiteOrFallback(e.currentTarget.valueAsNumber, node.position[1]);
     } else if (e.currentTarget.name === 'label') {
-      weathermap.nodes[i].label = e.currentTarget.value;
+      node.label = e.currentTarget.value;
     }
-    onChange(weathermap);
+    onChange({ ...value, nodes: value.nodes.map((n, ni) => (ni === i ? node : n)) });
   };
 
   const handleDashboardLinkChange = (e: React.FormEvent<HTMLInputElement>, i: number) => {

--- a/src/forms/PanelForm.test.tsx
+++ b/src/forms/PanelForm.test.tsx
@@ -89,3 +89,19 @@ describe('number inputs do not store NaN (#200)', () => {
     expect(containsNaN(updated)).toBe(false);
   });
 });
+
+// #225: panel-settings updates must deliver new object references.
+test('viewbox width change delivers a new weathermap object (#225)', () => {
+  const initial = getData(theme);
+  const before = JSON.parse(JSON.stringify(initial));
+  const spy = jest.fn();
+  const { container } = render(<Harness initial={initial} onChangeSpy={spy} />);
+
+  fireEvent.change(container.querySelector('input[name="panelWidth"]')!, { target: { value: '850' } });
+
+  const updated = lastValue(spy);
+  expect(updated).not.toBe(initial);
+  expect(updated.settings.panel).not.toBe(initial.settings.panel);
+  expect(updated.settings.panel.panelSize.width).toBe(850);
+  expect(initial).toEqual(before);
+});

--- a/src/forms/PanelForm.tsx
+++ b/src/forms/PanelForm.tsx
@@ -26,6 +26,15 @@ interface Props extends StandardEditorProps<Weathermap, Settings> {}
 export const PanelForm = ({ value, onChange }: Props) => {
   const styles = useStyles2(getStyles);
 
+  // Immutable panel-settings update (#225): clone the settings path so
+  // onChange delivers new references instead of mutating props.value.
+  const updatePanelSettings = (patch: Partial<Weathermap['settings']['panel']>) => {
+    onChange({
+      ...value,
+      settings: { ...value.settings, panel: { ...value.settings.panel, ...patch } },
+    });
+  };
+
   const handleColorChange = (color: string) => {
     let options = value;
     if (!color.startsWith('image') && options.settings.panel.backgroundColor.startsWith('image')) {
@@ -148,12 +157,12 @@ export const PanelForm = ({ value, onChange }: Props) => {
             type={'number'}
             name={'panelWidth'}
             onChange={(e) => {
-              let options = value;
-              options.settings.panel.panelSize.width = finiteOrFallback(
-                e.currentTarget.valueAsNumber,
-                options.settings.panel.panelSize.width
-              );
-              onChange(options);
+              updatePanelSettings({
+                panelSize: {
+                  ...value.settings.panel.panelSize,
+                  width: finiteOrFallback(e.currentTarget.valueAsNumber, value.settings.panel.panelSize.width),
+                },
+              });
             }}
           ></Input>
         </InlineField>
@@ -164,12 +173,12 @@ export const PanelForm = ({ value, onChange }: Props) => {
             type={'number'}
             name={'panelHeight'}
             onChange={(e) => {
-              let options = value;
-              options.settings.panel.panelSize.height = finiteOrFallback(
-                e.currentTarget.valueAsNumber,
-                options.settings.panel.panelSize.height
-              );
-              onChange(options);
+              updatePanelSettings({
+                panelSize: {
+                  ...value.settings.panel.panelSize,
+                  height: finiteOrFallback(e.currentTarget.valueAsNumber, value.settings.panel.panelSize.height),
+                },
+              });
             }}
           ></Input>
         </InlineField>
@@ -179,9 +188,9 @@ export const PanelForm = ({ value, onChange }: Props) => {
             placeholder={'Zoom Scale'}
             type={'number'}
             onChange={(e) => {
-              let options = value;
-              options.settings.panel.zoomScale = finiteOrFallback(e.currentTarget.valueAsNumber, options.settings.panel.zoomScale);
-              onChange(options);
+              updatePanelSettings({
+                zoomScale: finiteOrFallback(e.currentTarget.valueAsNumber, value.settings.panel.zoomScale),
+              });
             }}
           ></Input>
         </InlineField>
@@ -191,9 +200,12 @@ export const PanelForm = ({ value, onChange }: Props) => {
             placeholder={'Offset X'}
             type={'number'}
             onChange={(e) => {
-              let options = value;
-              options.settings.panel.offset.x = finiteOrFallback(e.currentTarget.valueAsNumber, options.settings.panel.offset.x);
-              onChange(options);
+              updatePanelSettings({
+                offset: {
+                  ...value.settings.panel.offset,
+                  x: finiteOrFallback(e.currentTarget.valueAsNumber, value.settings.panel.offset.x),
+                },
+              });
             }}
           ></Input>
         </InlineField>
@@ -203,9 +215,12 @@ export const PanelForm = ({ value, onChange }: Props) => {
             placeholder={'Offset Y'}
             type={'number'}
             onChange={(e) => {
-              let options = value;
-              options.settings.panel.offset.y = finiteOrFallback(e.currentTarget.valueAsNumber, options.settings.panel.offset.y);
-              onChange(options);
+              updatePanelSettings({
+                offset: {
+                  ...value.settings.panel.offset,
+                  y: finiteOrFallback(e.currentTarget.valueAsNumber, value.settings.panel.offset.y),
+                },
+              });
             }}
           ></Input>
         </InlineField>


### PR DESCRIPTION
Closes #225

## Problem
Interaction paths still mutated `wm`/`props.value` in place before calling change handlers: pan-offset mouse-up, node drag persistence, the selected-nodes state updater (spliced and returned the same array — React skips re-renders on identical references), and the NodeForm/PanelForm/ColorForm handlers named in the review.

## Fix
Targeted immutable updates at exactly those sites — spread-clones of the touched path, a shared `updatePanelSettings` helper in PanelForm, and a filter/spread selection updater. No architectural changes; every other handler is untouched.

## Adjacent behavior preserved
Same values persisted (grid snapping, multi-select drag, NaN guards from #200 all intact); only reference identity changes. Locked by running the pan flow against a **deep-frozen** options object — any in-place write now throws.

## Tests
- Pan persistence works with deep-frozen options and delivers a new weathermap object with the moved offset.
- NodeForm/PanelForm/ColorForm: change handlers deliver new object/array references; the input object stays byte-identical.

## Validation
typecheck / lint / test:ci (141 tests) / build / verify-dist — all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #225 by replacing in-place mutations with immutable updates across interaction and form paths to prevent skipped re-renders and ensure safe persistence. Behavior is unchanged; only object/array references now change.

- **Bug Fixes**
  - Pan offset: clone `settings.panel.offset` on mouse-up.
  - Node drag: build moved nodes immutably with grid snapping.
  - Selection: updater returns a new array (no splice-in-place).
  - Forms: NodeForm updates are all immutable (position/label, connection/status/color, and Apply to All via `updateNode`); PanelForm uses `updatePanelSettings`; ColorForm threshold commits are immutable; NaN guards from #200 preserved.
  - Tests: deep-freeze pan and reference-identity checks, including NodeForm Apply to All/colors path.

<sup>Written for commit 6a27e61d8228116c747776d352ad4815e42a5be6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

