### PR TITLE
fix: render blank threshold drafts as empty instead of NaN (#226)

### DIFF
--- a/src/forms/ColorForm.test.tsx
+++ b/src/forms/ColorForm.test.tsx
@@ -120,3 +120,20 @@ test('threshold commit delivers new object references (#225)', () => {
   expect(updated.scale[0].percent).toBe(35);
   expect(initial).toEqual(before);
 });
+
+// #226: a blanked threshold draft must render as an empty field, not a NaN
+// value attribute (React logs "Received NaN for the value attribute").
+test('clearing a threshold renders an empty field without React NaN warnings (#226)', () => {
+  const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  const initial = getData(theme);
+  initial.scale = [{ percent: 10, color: '#111111' }];
+  render(<Harness initial={initial} onChangeSpy={jest.fn()} />);
+
+  const threshold = screen.getByLabelText('Weathermap Threshold 10') as HTMLInputElement;
+  fireEvent.change(threshold, { target: { value: '' } });
+
+  expect(threshold.value).toBe('');
+  const nanWarnings = errorSpy.mock.calls.filter((c) => String(c[0]).includes('Received NaN'));
+  errorSpy.mockRestore();
+  expect(nanWarnings).toEqual([]);
+});

--- a/src/forms/ColorForm.tsx
+++ b/src/forms/ColorForm.tsx
@@ -126,7 +126,9 @@ export const ColorForm = (props: Props) => {
             const raw = e.currentTarget.valueAsNumber;
             setEditedPercents((prev) => prev.map((t, ti) => (ti === i ? { ...t, percent: raw } : t)));
           }}
-          value={editedPercents[i].percent}
+          // A blanked field stores NaN in the draft; render it as '' so React
+          // does not warn about NaN value attributes (#226).
+          value={Number.isFinite(editedPercents[i].percent) ? editedPercents[i].percent : ''}
           aria-label={`Weathermap Threshold ${threshold.percent}`}
           onBlur={(e) => handleNumberChange(e, i)}
           prefix={


### PR DESCRIPTION
Closes #226

The ColorForm draft state stores `NaN` while a threshold field is blanked — saved options are protected (#200), but passing the draft to `Input.value` produced React's "Received NaN for the value attribute" warning (visible in `test:ci` logs). Non-finite drafts now render as `''`; the numeric draft state and commit-on-blur behavior are unchanged (existing #200/#225 ColorForm tests still pass).

Test: clearing a threshold renders an empty field and logs no React NaN warning.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render blank threshold drafts as an empty string in `ColorForm` inputs to prevent React "Received NaN for the value attribute" warnings (fixes #226). Numeric draft state and commit-on-blur behavior remain unchanged; a test asserts no warnings when clearing a threshold.

<sup>Written for commit be71ba147e5a34913497df17cc1ab44e8e6aff37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

