### PR TITLE
ci: run E2E on pull requests that touch the E2E surface (#227)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,13 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1'
+  # Weekly/manual by design — too heavy to gate every PR. But PRs that touch
+  # the E2E surface itself must get a browser pass before merge (#227).
+  pull_request:
+    paths:
+      - 'tests/**'
+      - 'playwright.config.ts'
+      - '.github/workflows/e2e.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
Closes #227

E2E stays weekly/manual by design (documented in the workflow header) — but PRs that modify the E2E surface itself (`tests/**`, `playwright.config.ts`, the workflow) could previously merge without a browser pass. Those paths now trigger the Grafana 11/latest matrix on the PR; all other PRs remain fast.

Note: this PR touches the workflow, so it should itself trigger the E2E matrix — self-verifying.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the E2E workflow on PRs that modify the E2E surface (`tests/**`, `playwright.config.ts`, or `.github/workflows/e2e.yml`), while keeping E2E weekly/manual for all other PRs. These PRs now run the Grafana 11/latest matrix before merge.

<sup>Written for commit 365adc94a06e38bb52f9fd0ace80cd5c86787b7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

