### PR TITLE
fix: close the props.value mutation class across all form handlers (#233)

### DIFF
--- a/jest-polyfills.js
+++ b/jest-polyfills.js
@@ -13,3 +13,12 @@ global.IntersectionObserver = class IntersectionObserver {
     return [];
   }
 };
+
+// Polyfill structuredClone for jest-environment-jsdom (browsers have it since
+// 2022; the jsdom environment does not inject Node's global). V8
+// serialize/deserialize matches the real semantics (preserves undefined
+// properties, Dates, Maps — unlike a JSON round-trip).
+if (typeof global.structuredClone !== 'function') {
+  const v8 = require('v8');
+  global.structuredClone = (value) => v8.deserialize(v8.serialize(value));
+}

--- a/src/forms/ColorForm.test.tsx
+++ b/src/forms/ColorForm.test.tsx
@@ -7,10 +7,21 @@ import { getData, theme } from '../testData';
 
 // Stateful harness: the editor only re-renders when onChange delivers a new
 // options object, which is exactly the behavior under test (#162).
+
+// Deep-freeze the value handed to the form: any residual in-place mutation of
+// props.value throws immediately (#233). Handlers must clone before writing.
+const deepFreeze = <T,>(o: T): T => {
+  if (o && typeof o === 'object' && !Object.isFrozen(o)) {
+    Object.values(o as Record<string, unknown>).forEach(deepFreeze);
+    Object.freeze(o);
+  }
+  return o;
+};
+
 const Harness = ({ initial, onChangeSpy }: { initial: Weathermap; onChangeSpy: jest.Mock }) => {
   const [wm, setWm] = useState(initial);
   const props = {
-    value: wm,
+    value: deepFreeze(wm),
     onChange: (v: Weathermap) => {
       onChangeSpy(v);
       setWm(v);

--- a/src/forms/ColorForm.tsx
+++ b/src/forms/ColorForm.tsx
@@ -30,14 +30,14 @@ export const ColorForm = (props: Props) => {
   };
 
   const handleColorChange = (color: any, index: number) => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     weathermap.scale[index].color = color;
     onChange(weathermap);
     setEditedPercents(weathermap.scale);
   };
 
   const addNewValue = () => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     if (value.scale.length === 0) {
       weathermap.scale.push({
         percent: 0,
@@ -54,14 +54,14 @@ export const ColorForm = (props: Props) => {
   };
 
   const clearValues = () => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     weathermap.scale = [];
     onChange(weathermap);
     setEditedPercents(weathermap.scale);
   };
 
   const handleDeletePercent = (currentIndex: number) => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     weathermap.scale.splice(currentIndex, 1);
     onChange(weathermap);
     setEditedPercents(weathermap.scale);

--- a/src/forms/LinkForm.test.tsx
+++ b/src/forms/LinkForm.test.tsx
@@ -26,10 +26,21 @@ const MULTI_SERIES = [
   promFrame('A', 'wm_link_bps{device="rtr-2", direction="tx", interface="ge-0/0/1", job="wm", site="atl"}'),
 ];
 
+
+// Deep-freeze the value handed to the form: any residual in-place mutation of
+// props.value throws immediately (#233). Handlers must clone before writing.
+const deepFreeze = <T,>(o: T): T => {
+  if (o && typeof o === 'object' && !Object.isFrozen(o)) {
+    Object.values(o as Record<string, unknown>).forEach(deepFreeze);
+    Object.freeze(o);
+  }
+  return o;
+};
+
 const Harness = ({ initial, onChangeSpy, frames }: { initial: Weathermap; onChangeSpy: jest.Mock; frames: unknown[] }) => {
   const [wm, setWm] = useState(initial);
   const props = {
-    value: wm,
+    value: deepFreeze(wm),
     onChange: (v: Weathermap) => {
       onChangeSpy(v);
       setWm(v);

--- a/src/forms/LinkForm.tsx
+++ b/src/forms/LinkForm.tsx
@@ -41,7 +41,7 @@ export const LinkForm = (props: Props) => {
   };
 
   const handleBandwidthChange = (amt: number, i: number, side: 'A' | 'Z') => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     // Blank input reports NaN; keep the previous bandwidth instead of saving it.
     weathermap.links[i].sides[side].bandwidth = finiteOrFallback(amt, weathermap.links[i].sides[side].bandwidth ?? 0);
     weathermap.links[i].sides[side].bandwidthQuery = undefined;
@@ -49,14 +49,14 @@ export const LinkForm = (props: Props) => {
   };
 
   const handleBandwidthQueryChange = (frame: string | undefined, i: number, side: 'A' | 'Z') => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     weathermap.links[i].sides[side].bandwidth = 0;
     weathermap.links[i].sides[side].bandwidthQuery = frame;
     onChange(weathermap);
   };
 
   const handleAnchorChange = (anchor: number, i: number, side: 'A' | 'Z') => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     const nodeIndex = findNodeIndex(weathermap.links[i].nodes[side === 'A' ? 0 : 1]);
 
     // remove from old
@@ -68,7 +68,7 @@ export const LinkForm = (props: Props) => {
   };
 
   const handleNodeChange = (node: Node, side: 'A' | 'Z', i: number) => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     const nodeIndex = findNodeIndex(node);
 
     weathermap.nodes[nodeIndex].anchors[weathermap.links[i].sides[side].anchor].numLinks++;
@@ -85,19 +85,19 @@ export const LinkForm = (props: Props) => {
   };
 
   const handleDataChange = (side: 'A' | 'Z', i: number, frameName: string | undefined) => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     weathermap.links[i].sides[side].query = frameName;
     onChange(weathermap);
   };
 
   const handleLabelOffsetChange = (val: number, i: number, side: 'A' | 'Z') => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     weathermap.links[i].sides[side].labelOffset = val;
     onChange(weathermap);
   };
 
   const handleDashboardLinkChange = (val: string, i: number, side: 'A' | 'Z') => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     weathermap.links[i].sides[side].dashboardLink = sanitizeUrl(val);
     onChange(weathermap);
   };
@@ -106,7 +106,7 @@ export const LinkForm = (props: Props) => {
     if (value.nodes.length === 0) {
       throw new Error('There must be >= 1 Nodes to create a link.');
     }
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     const link: Link = {
       id: uuidv4(),
       nodes: [value.nodes[0], value.nodes[0]],
@@ -144,7 +144,7 @@ export const LinkForm = (props: Props) => {
   };
 
   const removeLink = (i: number) => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     let toRemove = weathermap.links[i];
     for (let n = 0; n < weathermap.nodes.length; n++) {
       const node = weathermap.nodes[n];
@@ -166,7 +166,7 @@ export const LinkForm = (props: Props) => {
   };
 
   const clearLinks = () => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     weathermap.links = [];
     for (let i = 0; i < weathermap.nodes.length; i++) {
       weathermap.nodes[i].anchors = {
@@ -346,7 +346,7 @@ export const LinkForm = (props: Props) => {
                           <Input
                             value={side.portLabel ?? ''}
                             onChange={(e) => {
-                              let weathermap: Weathermap = value;
+                              let weathermap: Weathermap = structuredClone(value);
                               weathermap.links[i].sides[sName].portLabel =
                                 e.currentTarget.value || undefined;
                               onChange(weathermap);
@@ -361,7 +361,7 @@ export const LinkForm = (props: Props) => {
                           <Input
                             value={side.directionLabel ?? ''}
                             onChange={(e) => {
-                              let weathermap: Weathermap = value;
+                              let weathermap: Weathermap = structuredClone(value);
                               weathermap.links[i].sides[sName].directionLabel =
                                 e.currentTarget.value || undefined;
                               onChange(weathermap);
@@ -382,7 +382,7 @@ export const LinkForm = (props: Props) => {
                 <InlineField grow label={`Link Units`} style={{ width: '100%' }}>
                   <UnitPicker
                     onChange={(val) => {
-                      let wm = value;
+                      let wm = structuredClone(value);
                       wm.links[i].units = val;
                       onChange(wm);
                     }}
@@ -394,7 +394,7 @@ export const LinkForm = (props: Props) => {
                 <InlineSwitch
                   value={link.showThroughputPercentage}
                   onChange={(e) => {
-                    let wm = value;
+                    let wm = structuredClone(value);
                     wm.links[i].showThroughputPercentage = e.currentTarget.checked;
                     onChange(wm);
                   }}
@@ -409,7 +409,7 @@ export const LinkForm = (props: Props) => {
                 <Input
                   value={link.linkOffset ?? ''}
                   onChange={(e) => {
-                    let wm = value;
+                    let wm = structuredClone(value);
                     const raw = e.currentTarget.value;
                     wm.links[i].linkOffset = parseOptionalFiniteNumber(raw);
                     onChange(wm);
@@ -431,7 +431,7 @@ export const LinkForm = (props: Props) => {
                 <InlineSwitch
                   value={link.singleDirection ?? false}
                   onChange={(e) => {
-                    let options = value;
+                    let options = structuredClone(value);
                     options.links[i].singleDirection = e.currentTarget.checked;
                     onChange(options);
                   }}
@@ -449,7 +449,7 @@ export const LinkForm = (props: Props) => {
                   step={1}
                   value={link.arrowMeetPercent ?? 50}
                   onChange={(num) => {
-                    let options = value;
+                    let options = structuredClone(value);
                     options.links[i].arrowMeetPercent = num;
                     onChange(options);
                   }}
@@ -463,7 +463,7 @@ export const LinkForm = (props: Props) => {
                     value={link.stroke}
                     step={1}
                     onChange={(num) => {
-                      let options = value;
+                      let options = structuredClone(value);
                       options.links[i].stroke = num;
                       onChange(options);
                     }}
@@ -480,7 +480,7 @@ export const LinkForm = (props: Props) => {
                         value={link.arrows.width}
                         step={1}
                         onChange={(num) => {
-                          let options = value;
+                          let options = structuredClone(value);
                           options.links[i].arrows.width = num;
                           onChange(options);
                         }}
@@ -493,7 +493,7 @@ export const LinkForm = (props: Props) => {
                         value={link.arrows.height}
                         step={1}
                         onChange={(num) => {
-                          let options = value;
+                          let options = structuredClone(value);
                           options.links[i].arrows.height = num;
                           onChange(options);
                         }}
@@ -506,7 +506,7 @@ export const LinkForm = (props: Props) => {
                         value={link.arrows.offset}
                         step={1}
                         onChange={(num) => {
-                          let options = value;
+                          let options = structuredClone(value);
                           options.links[i].arrows.offset = num;
                           onChange(options);
                         }}
@@ -518,7 +518,7 @@ export const LinkForm = (props: Props) => {
                   variant="primary"
                   size="md"
                   onClick={() => {
-                    let weathermap: Weathermap = value;
+                    let weathermap: Weathermap = structuredClone(value);
                     for (let link of weathermap.links) {
                       link.arrows = { ...currentLink.arrows };
                       link.stroke = currentLink.stroke;
@@ -534,7 +534,7 @@ export const LinkForm = (props: Props) => {
               <InlineField grow label="Status Query" style={{ width: '100%' }}>
                 <Select
                   onChange={(v) => {
-                    let weathermap: Weathermap = value;
+                    let weathermap: Weathermap = structuredClone(value);
                     weathermap.links[i].statusQuery = v ? v.value : undefined;
                     onChange(weathermap);
                   }}
@@ -550,7 +550,7 @@ export const LinkForm = (props: Props) => {
                 <ColorPicker
                   color={link.statusDownColor || '#d32f2f'}
                   onChange={(color) => {
-                    let weathermap: Weathermap = value;
+                    let weathermap: Weathermap = structuredClone(value);
                     weathermap.links[i].statusDownColor = color;
                     onChange(weathermap);
                   }}
@@ -560,7 +560,7 @@ export const LinkForm = (props: Props) => {
                 <InlineSwitch
                   value={link.statusBlink ?? false}
                   onChange={(e) => {
-                    let weathermap: Weathermap = value;
+                    let weathermap: Weathermap = structuredClone(value);
                     weathermap.links[i].statusBlink = e.currentTarget.checked;
                     onChange(weathermap);
                   }}
@@ -574,7 +574,7 @@ export const LinkForm = (props: Props) => {
                       <Input
                         value={metric.label}
                         onChange={(e) => {
-                          let wm = value;
+                          let wm = structuredClone(value);
                           wm.links[i].tooltipMetrics![mi].label = e.currentTarget.value;
                           onChange(wm);
                         }}
@@ -587,7 +587,7 @@ export const LinkForm = (props: Props) => {
                   <InlineField grow label={`Metric ${mi + 1} Inbound Query`} style={{ width: '100%' }}>
                     <Select
                       onChange={(v) => {
-                        let wm = value;
+                        let wm = structuredClone(value);
                         wm.links[i].tooltipMetrics![mi].queryA = v ? v.value : undefined;
                         onChange(wm);
                       }}
@@ -601,7 +601,7 @@ export const LinkForm = (props: Props) => {
                   <InlineField grow label={`Metric ${mi + 1} Outbound Query`} style={{ width: '100%' }}>
                     <Select
                       onChange={(v) => {
-                        let wm = value;
+                        let wm = structuredClone(value);
                         wm.links[i].tooltipMetrics![mi].queryZ = v ? v.value : undefined;
                         onChange(wm);
                       }}
@@ -615,7 +615,7 @@ export const LinkForm = (props: Props) => {
                   <InlineField grow label={`Metric ${mi + 1} Units`} style={{ width: '100%' }}>
                     <UnitPicker
                       onChange={(val) => {
-                        let wm = value;
+                        let wm = structuredClone(value);
                         wm.links[i].tooltipMetrics![mi].units = val;
                         onChange(wm);
                       }}
@@ -628,7 +628,7 @@ export const LinkForm = (props: Props) => {
                       icon="trash-alt"
                       size="sm"
                       onClick={() => {
-                        let wm = value;
+                        let wm = structuredClone(value);
                         wm.links[i].tooltipMetrics!.splice(mi, 1);
                         onChange(wm);
                       }}
@@ -644,7 +644,7 @@ export const LinkForm = (props: Props) => {
                 icon="plus"
                 size="sm"
                 onClick={() => {
-                  let wm = value;
+                  let wm = structuredClone(value);
                   if (!wm.links[i].tooltipMetrics) {
                     wm.links[i].tooltipMetrics = [];
                   }

--- a/src/forms/NodeForm.test.tsx
+++ b/src/forms/NodeForm.test.tsx
@@ -7,10 +7,21 @@ import { getData, theme } from '../testData';
 
 // Stateful harness: the editor only re-renders when onChange delivers a new
 // options object, which is exactly the behavior under test (#162).
+
+// Deep-freeze the value handed to the form: any residual in-place mutation of
+// props.value throws immediately (#233). Handlers must clone before writing.
+const deepFreeze = <T,>(o: T): T => {
+  if (o && typeof o === 'object' && !Object.isFrozen(o)) {
+    Object.values(o as Record<string, unknown>).forEach(deepFreeze);
+    Object.freeze(o);
+  }
+  return o;
+};
+
 const Harness = ({ initial, onChangeSpy }: { initial: Weathermap; onChangeSpy: jest.Mock }) => {
   const [wm, setWm] = useState(initial);
   const props = {
-    value: wm,
+    value: deepFreeze(wm),
     onChange: (v: Weathermap) => {
       onChangeSpy(v);
       setWm(v);

--- a/src/forms/NodeForm.tsx
+++ b/src/forms/NodeForm.tsx
@@ -66,25 +66,25 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
   };
 
   const handleDashboardLinkChange = (e: React.FormEvent<HTMLInputElement>, i: number) => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     weathermap.nodes[i].dashboardLink = sanitizeUrl(e.currentTarget.value);
     onChange(weathermap);
   };
 
   const handleNodePaddingChange = (num: number, i: number, type: 'vertical' | 'horizontal') => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     weathermap.nodes[i].padding[type] = num;
     onChange(weathermap);
   };
 
   const handleSpacingChange = (e: any, i: number) => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     weathermap.nodes[i].useConstantSpacing = e.currentTarget.checked;
     onChange(weathermap);
   };
 
   const handleCompactChange = (e: any, i: number) => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     weathermap.nodes[i].compactVerticalLinks = e.currentTarget.checked;
     onChange(weathermap);
   };
@@ -118,7 +118,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
   };
 
   const handleIconChange = (icon: string | undefined, i: number) => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
 
     if (icon === undefined) {
       weathermap.nodes[i].nodeIcon = {
@@ -148,7 +148,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
   };
 
   const handleIconSizeChange = (amt: number, i: number, type: 'width' | 'height') => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     const icon = weathermap.nodes[i].nodeIcon!;
     amt = finiteOrFallback(amt, type === 'width' ? icon.size.width : icon.size.height);
     if (lockAspectRatio && icon.size.width > 0 && icon.size.height > 0) {
@@ -167,19 +167,19 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
   };
 
   const handleIconPaddingChange = (amt: number, i: number, type: 'vertical' | 'horizontal') => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     weathermap.nodes[i].nodeIcon!.padding[type] = amt;
     onChange(weathermap);
   };
 
   const handleIconDrawChange = (checked: boolean, i: number) => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     weathermap.nodes[i].nodeIcon!.drawInside = checked;
     onChange(weathermap);
   };
 
   const addNewNode = () => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     const node: Node = {
       id: uuidv4(),
       position: [
@@ -230,7 +230,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
   };
 
   const duplicateNode = (i: number) => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     const source = weathermap.nodes[i];
     const copy: Node = {
       ...JSON.parse(JSON.stringify(source)),
@@ -250,7 +250,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
   };
 
   const removeNode = (i: number) => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     weathermap.links = weathermap.links.filter((link) => {
       for (const node of link.nodes) {
         if (node.id === weathermap.nodes[i].id) {
@@ -264,7 +264,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
   };
 
   const clearNodes = () => {
-    let weathermap: Weathermap = value;
+    let weathermap: Weathermap = structuredClone(value);
     weathermap.nodes = [];
     weathermap.links = [];
     onChange(weathermap);
@@ -400,7 +400,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                   <InlineSwitch
                     value={node.openInSameTab === true}
                     onChange={(e) => {
-                      let options = value;
+                      let options = structuredClone(value);
                       options.nodes[i].openInSameTab = e.currentTarget.checked;
                       onChange(options);
                     }}
@@ -410,7 +410,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                   <InlineSwitch
                     value={node.showLabel !== false}
                     onChange={(e) => {
-                      let options = value;
+                      let options = structuredClone(value);
                       options.nodes[i].showLabel = e.currentTarget.checked;
                       onChange(options);
                     }}
@@ -460,7 +460,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                           type={'text'}
                           name={'iconImageURL'}
                           onChange={(e) => {
-                            let options = value;
+                            let options = structuredClone(value);
                             if (options.nodes[i].nodeIcon) {
                               options.nodes[i].nodeIcon!.src = sanitizeUrl(e.currentTarget.value);
                             }
@@ -528,7 +528,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                     <InlineSwitch
                       value={node.useIconBoundaryForLinks ?? false}
                       onChange={(e) => {
-                        let weathermap: Weathermap = value;
+                        let weathermap: Weathermap = structuredClone(value);
                         weathermap.nodes[i].useIconBoundaryForLinks = e.currentTarget.checked;
                         onChange(weathermap);
                       }}
@@ -582,7 +582,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                     <ColorPicker
                       color={node.colors.statusDown}
                       onChange={(color) => {
-                        let weathermap: Weathermap = value;
+                        let weathermap: Weathermap = structuredClone(value);
                         weathermap.nodes[i].colors.statusDown = color;
                         onChange(weathermap);
                       }}
@@ -622,7 +622,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                           type="number"
                           value={mapping.value}
                           onChange={(e) => {
-                            let weathermap: Weathermap = value;
+                            let weathermap: Weathermap = structuredClone(value);
                             weathermap.nodes[i].statusValueMappings![mi].value = finiteOrFallback(
                               e.currentTarget.valueAsNumber,
                               weathermap.nodes[i].statusValueMappings![mi].value
@@ -637,7 +637,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                         <ColorPicker
                           color={mapping.color}
                           onChange={(color) => {
-                            let weathermap: Weathermap = value;
+                            let weathermap: Weathermap = structuredClone(value);
                             weathermap.nodes[i].statusValueMappings![mi].color = color;
                             onChange(weathermap);
                           }}
@@ -648,7 +648,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                         icon="trash-alt"
                         size="sm"
                         onClick={() => {
-                          let weathermap: Weathermap = value;
+                          let weathermap: Weathermap = structuredClone(value);
                           weathermap.nodes[i].statusValueMappings!.splice(mi, 1);
                           onChange(weathermap);
                         }}
@@ -660,7 +660,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                     icon="plus"
                     size="sm"
                     onClick={() => {
-                      let weathermap: Weathermap = value;
+                      let weathermap: Weathermap = structuredClone(value);
                       const newMapping: NodeStatusValueMapping = { value: 0, color: '#ff0000' };
                       weathermap.nodes[i].statusValueMappings = [
                         ...(weathermap.nodes[i].statusValueMappings || []),
@@ -686,7 +686,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                           <Input
                             value={metric.label}
                             onChange={(e) => {
-                              let weathermap: Weathermap = value;
+                              let weathermap: Weathermap = structuredClone(value);
                               weathermap.nodes[i].tooltipMetrics![mi].label = e.currentTarget.value;
                               onChange(weathermap);
                             }}
@@ -698,7 +698,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                       <InlineField grow label={`Metric ${mi + 1} Query`} style={{ width: '100%' }}>
                         <Select
                           onChange={(v) => {
-                            let weathermap: Weathermap = value;
+                            let weathermap: Weathermap = structuredClone(value);
                             weathermap.nodes[i].tooltipMetrics![mi].query = v ? v.value : undefined;
                             onChange(weathermap);
                           }}
@@ -712,7 +712,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                       <InlineField grow label={`Metric ${mi + 1} Units`} style={{ width: '100%' }}>
                         <UnitPicker
                           onChange={(val) => {
-                            let weathermap: Weathermap = value;
+                            let weathermap: Weathermap = structuredClone(value);
                             weathermap.nodes[i].tooltipMetrics![mi].units = val;
                             onChange(weathermap);
                           }}
@@ -725,7 +725,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                           icon="trash-alt"
                           size="sm"
                           onClick={() => {
-                            let weathermap: Weathermap = value;
+                            let weathermap: Weathermap = structuredClone(value);
                             weathermap.nodes[i].tooltipMetrics!.splice(mi, 1);
                             onChange(weathermap);
                           }}
@@ -741,7 +741,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                     icon="plus"
                     size="sm"
                     onClick={() => {
-                      let weathermap: Weathermap = value;
+                      let weathermap: Weathermap = structuredClone(value);
                       weathermap.nodes[i].tooltipMetrics = [
                         ...(weathermap.nodes[i].tooltipMetrics || []),
                         { label: '', query: undefined },
@@ -770,7 +770,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                         type={'number'}
                         min={0}
                         onChange={(e) => {
-                          let weathermap: Weathermap = value;
+                          let weathermap: Weathermap = structuredClone(value);
                           const v = e.currentTarget.valueAsNumber;
                           weathermap.nodes[i].fontSize = v > 0 ? v : undefined;
                           onChange(weathermap);
@@ -781,7 +781,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                       <InlineSwitch
                         value={node.fontBold ?? false}
                         onChange={(e) => {
-                          let weathermap: Weathermap = value;
+                          let weathermap: Weathermap = structuredClone(value);
                           weathermap.nodes[i].fontBold = e.currentTarget.checked;
                           onChange(weathermap);
                         }}

--- a/src/forms/PanelForm.test.tsx
+++ b/src/forms/PanelForm.test.tsx
@@ -8,10 +8,21 @@ import { PanelForm } from './PanelForm';
 import { Weathermap } from 'types';
 import { getData, theme } from '../testData';
 
+
+// Deep-freeze the value handed to the form: any residual in-place mutation of
+// props.value throws immediately (#233). Handlers must clone before writing.
+const deepFreeze = <T,>(o: T): T => {
+  if (o && typeof o === 'object' && !Object.isFrozen(o)) {
+    Object.values(o as Record<string, unknown>).forEach(deepFreeze);
+    Object.freeze(o);
+  }
+  return o;
+};
+
 const Harness = ({ initial, onChangeSpy }: { initial: Weathermap; onChangeSpy: jest.Mock }) => {
   const [wm, setWm] = useState(initial);
   const props = {
-    value: wm,
+    value: deepFreeze(wm),
     onChange: (v: Weathermap) => {
       onChangeSpy(v);
       setWm(v);

--- a/src/forms/PanelForm.tsx
+++ b/src/forms/PanelForm.tsx
@@ -36,7 +36,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
   };
 
   const handleColorChange = (color: string) => {
-    let options = value;
+    let options = structuredClone(value);
     if (!color.startsWith('image') && options.settings.panel.backgroundColor.startsWith('image')) {
       options.settings.panel.backgroundColor =
         'image|' + color + '|' + options.settings.panel.backgroundColor.split('|', 3)[2];
@@ -74,7 +74,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
                 if (!confirm('Are you sure you want remove the background image?')) {
                   return;
                 }
-                let options = value;
+                let options = structuredClone(value);
                 options.settings.panel.backgroundImage = undefined;
                 onChange(options);
               }}
@@ -83,7 +83,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
           ) : (
             <Button
               onClick={() => {
-                let options = value;
+                let options = structuredClone(value);
                 options.settings.panel.backgroundImage = {
                   url: '',
                   fit: 'contain',
@@ -104,7 +104,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
                 type={'text'}
                 name={'bgImageURL'}
                 onChange={(e) => {
-                  let options = value;
+                  let options = structuredClone(value);
                   if (options.settings.panel.backgroundImage) {
                     options.settings.panel.backgroundImage.url = sanitizeUrl(e.currentTarget.value);
                   }
@@ -115,7 +115,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
             <InlineField grow label="Image Fit" className={styles.inlineField} style={{ marginLeft: '24px' }}>
               <Select
                 onChange={(v) => {
-                  let options = value;
+                  let options = structuredClone(value);
                   if (options.settings.panel.backgroundImage) {
                     options.settings.panel.backgroundImage.fit = v.value ? v.value : 'contain';
                   }
@@ -138,7 +138,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
               <InlineSwitch
                 value={value.settings.panel.backgroundImage.attachToCanvas ?? false}
                 onChange={(e) => {
-                  let options = value;
+                  let options = structuredClone(value);
                   if (options.settings.panel.backgroundImage) {
                     options.settings.panel.backgroundImage.attachToCanvas = e.currentTarget.checked;
                   }
@@ -228,7 +228,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
           <InlineSwitch
             value={value.settings.panel.showTimestamp}
             onChange={(e) => {
-              let wm = value;
+              let wm = structuredClone(value);
               wm.settings.panel.showTimestamp = e.currentTarget.checked;
               onChange(wm);
             }}
@@ -239,7 +239,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
           <InlineSwitch
             value={value.settings.link.showAllWithPercentage}
             onChange={(e) => {
-              let wm = value;
+              let wm = structuredClone(value);
               wm.settings.link.showAllWithPercentage = e.currentTarget.checked;
               onChange(wm);
             }}
@@ -260,7 +260,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
             ]}
             value={value.settings.link.valueMappingMode ?? 'last'}
             onChange={(selected) => {
-              let wm = value;
+              let wm = structuredClone(value);
               wm.settings.link.valueMappingMode = selected.value as ValueMappingMode;
               onChange(wm);
             }}
@@ -274,7 +274,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
           <InlineSwitch
             value={value.settings.link.timeline?.enabled ?? false}
             onChange={(e) => {
-              let wm = value;
+              let wm = structuredClone(value);
               wm.settings.link.timeline = { enabled: e.currentTarget.checked };
               onChange(wm);
             }}
@@ -283,7 +283,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
         <InlineField grow label={'Default Link Units'}>
           <UnitPicker
             onChange={(val) => {
-              let wm = value;
+              let wm = structuredClone(value);
               wm.settings.link.defaultUnits = val;
               onChange(wm);
             }}
@@ -298,7 +298,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
             placeholder="auto"
             value={value.settings.link.linkDecimals ?? ''}
             onChange={(e) => {
-              let wm = value;
+              let wm = structuredClone(value);
               const v = e.currentTarget.valueAsNumber;
               wm.settings.link.linkDecimals = isNaN(v) ? undefined : Math.max(0, Math.floor(v));
               onChange(wm);
@@ -314,7 +314,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
               if (!confirm('Are you sure you want to reset all link units?')) {
                 return;
               }
-              let options = value;
+              let options = structuredClone(value);
               for (let l of options.links) {
                 l.units = undefined;
               }
@@ -329,7 +329,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
           <ColorPicker
             color={value.settings.link.stroke.color}
             onChange={(color) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.link.stroke.color = color;
               onChange(options);
             }}
@@ -342,7 +342,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
             value={value.settings.link.spacing.horizontal}
             step={1}
             onChange={(num) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.link.spacing.horizontal = num;
               onChange(options);
             }}
@@ -355,7 +355,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
             value={value.settings.link.spacing.vertical}
             step={1}
             onChange={(num) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.link.spacing.vertical = num;
               onChange(options);
             }}
@@ -366,7 +366,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
           <ColorPicker
             color={value.settings.link.label.background}
             onChange={(color) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.link.label.background = color;
               onChange(options);
             }}
@@ -377,7 +377,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
           <ColorPicker
             color={value.settings.link.label.border}
             onChange={(color) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.link.label.border = color;
               onChange(options);
             }}
@@ -388,7 +388,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
           <ColorPicker
             color={value.settings.link.label.font}
             onChange={(color) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.link.label.font = color;
               onChange(options);
             }}
@@ -401,7 +401,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
           <InlineSwitch
             value={value.settings.link.gradientColor ?? false}
             onChange={(e) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.link.gradientColor = e.currentTarget.checked;
               onChange(options);
             }}
@@ -411,7 +411,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
           <InlineSwitch
             value={value.settings.link.flowAnimation?.enabled ?? false}
             onChange={(e) => {
-              let options = value;
+              let options = structuredClone(value);
               if (!options.settings.link.flowAnimation) {
                 options.settings.link.flowAnimation = { enabled: false, speed: 2 };
               }
@@ -428,7 +428,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
               value={value.settings.link.flowAnimation?.speed ?? 2}
               step={0.5}
               onChange={(num) => {
-                let options = value;
+                let options = structuredClone(value);
                 if (!options.settings.link.flowAnimation) {
                   options.settings.link.flowAnimation = { enabled: true, speed: 2 };
                 }
@@ -442,7 +442,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
           <InlineSwitch
             value={value.settings.link.dynamicStroke?.enabled ?? false}
             onChange={(e) => {
-              let options = value;
+              let options = structuredClone(value);
               if (!options.settings.link.dynamicStroke) {
                 options.settings.link.dynamicStroke = { enabled: false, minWidth: 1, maxWidth: 10 };
               }
@@ -460,7 +460,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
                 value={value.settings.link.dynamicStroke?.minWidth ?? 1}
                 step={1}
                 onChange={(num) => {
-                  let options = value;
+                  let options = structuredClone(value);
                   options.settings.link.dynamicStroke!.minWidth = num;
                   onChange(options);
                 }}
@@ -473,7 +473,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
                 value={value.settings.link.dynamicStroke?.maxWidth ?? 10}
                 step={1}
                 onChange={(num) => {
-                  let options = value;
+                  let options = structuredClone(value);
                   options.settings.link.dynamicStroke!.maxWidth = num;
                   onChange(options);
                 }}
@@ -488,7 +488,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
             <InlineSwitch
               value={value.settings.panel.grid.enabled}
               onChange={(e) => {
-                let wm = value;
+                let wm = structuredClone(value);
                 wm.settings.panel.grid.enabled = e.currentTarget.checked;
                 wm.settings.panel.grid.guidesEnabled = false;
                 onChange(wm);
@@ -503,7 +503,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
                 value={value.settings.panel.grid.size}
                 step={1}
                 onChange={(num) => {
-                  let options = value;
+                  let options = structuredClone(value);
                   options.settings.panel.grid.size = num;
                   onChange(options);
                 }}
@@ -519,7 +519,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
               <InlineSwitch
                 value={value.settings.panel.grid.guidesEnabled}
                 onChange={(e) => {
-                  let wm = value;
+                  let wm = structuredClone(value);
                   wm.settings.panel.grid.guidesEnabled = e.currentTarget.checked;
                   onChange(wm);
                 }}
@@ -537,7 +537,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
             value={value.settings.fontSizing.node}
             step={1}
             onChange={(num) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.fontSizing.node = num;
               onChange(options);
             }}
@@ -550,7 +550,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
             value={value.settings.fontSizing.link}
             step={1}
             onChange={(num) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.fontSizing.link = num;
               onChange(options);
             }}
@@ -566,7 +566,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
           <InlineSwitch
             value={value.settings.link.hoverHighlight ?? false}
             onChange={(e) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.link.hoverHighlight = e.currentTarget.checked;
               onChange(options);
             }}
@@ -581,7 +581,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
           <InlineSwitch
             value={value.settings.link.labelCollision ?? false}
             onChange={(e) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.link.labelCollision = e.currentTarget.checked;
               onChange(options);
             }}
@@ -601,7 +601,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
             step={1}
             value={value.settings.link.labelHideZoom ?? 0}
             onChange={(num) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.link.labelHideZoom = num;
               onChange(options);
             }}
@@ -617,7 +617,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
           <InlineSwitch
             value={value.settings.statusLegend?.enabled ?? false}
             onChange={(e) => {
-              let options = value;
+              let options = structuredClone(value);
               if (!options.settings.statusLegend) {
                 options.settings.statusLegend = {
                   enabled: e.currentTarget.checked,
@@ -643,7 +643,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
                 step={1}
                 value={value.settings.statusLegend.position.x}
                 onChange={(num) => {
-                  let options = value;
+                  let options = structuredClone(value);
                   options.settings.statusLegend!.position.x = num;
                   onChange(options);
                 }}
@@ -656,7 +656,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
                 step={1}
                 value={value.settings.statusLegend.position.y}
                 onChange={(num) => {
-                  let options = value;
+                  let options = structuredClone(value);
                   options.settings.statusLegend!.position.y = num;
                   onChange(options);
                 }}
@@ -669,7 +669,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
                   <ColorPicker
                     color={item.color}
                     onChange={(color) => {
-                      let options = value;
+                      let options = structuredClone(value);
                       options.settings.statusLegend!.items[li].color = color;
                       onChange(options);
                     }}
@@ -680,7 +680,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
                     value={item.label}
                     type={'text'}
                     onChange={(e) => {
-                      let options = value;
+                      let options = structuredClone(value);
                       options.settings.statusLegend!.items[li].label = e.currentTarget.value;
                       onChange(options);
                     }}
@@ -692,7 +692,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
                   size="sm"
                   aria-label="Remove legend item"
                   onClick={() => {
-                    let options = value;
+                    let options = structuredClone(value);
                     options.settings.statusLegend!.items.splice(li, 1);
                     onChange(options);
                   }}
@@ -704,7 +704,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
               icon="plus"
               size="sm"
               onClick={() => {
-                let options = value;
+                let options = structuredClone(value);
                 options.settings.statusLegend!.items.push({ color: '#FF9830', label: 'label', id: uuidv4() });
                 onChange(options);
               }}
@@ -721,7 +721,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
           <ColorPicker
             color={value.settings.tooltip.backgroundColor}
             onChange={(color) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.tooltip.backgroundColor = color;
               onChange(options);
             }}
@@ -732,7 +732,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
           <ColorPicker
             color={value.settings.tooltip.textColor}
             onChange={(color) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.tooltip.textColor = color;
               onChange(options);
             }}
@@ -745,7 +745,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
             value={value.settings.tooltip.fontSize}
             step={1}
             onChange={(num) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.tooltip.fontSize = num;
               onChange(options);
             }}
@@ -756,7 +756,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
           <ColorPicker
             color={value.settings.tooltip.inboundColor}
             onChange={(color) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.tooltip.inboundColor = color;
               onChange(options);
             }}
@@ -767,7 +767,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
           <ColorPicker
             color={value.settings.tooltip.outboundColor}
             onChange={(color) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.tooltip.outboundColor = color;
               onChange(options);
             }}
@@ -777,7 +777,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
           <InlineSwitch
             value={value.settings.tooltip.scaleToBandwidth}
             onChange={(e) => {
-              let wm = value;
+              let wm = structuredClone(value);
               wm.settings.tooltip.scaleToBandwidth = e.currentTarget.checked;
               onChange(wm);
             }}
@@ -791,7 +791,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
             type={'text'}
             name={'scaleTitle'}
             onChange={(e) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.scale.title = e.currentTarget.value;
               onChange(options);
             }}
@@ -804,7 +804,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
             value={value.settings.scale.size.width}
             step={1}
             onChange={(num) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.scale.size.width = num;
               onChange(options);
             }}
@@ -817,7 +817,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
             value={value.settings.scale.size.height}
             step={10}
             onChange={(num) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.scale.size.height = num;
               onChange(options);
             }}
@@ -830,7 +830,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
             value={value.settings.scale.position.x}
             step={1}
             onChange={(num) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.scale.position.x = num;
               onChange(options);
             }}
@@ -843,7 +843,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
             value={value.settings.scale.position.y}
             step={1}
             onChange={(num) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.scale.position.y = num;
               onChange(options);
             }}
@@ -856,7 +856,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
             value={value.settings.scale.fontSizing.title}
             step={1}
             onChange={(num) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.scale.fontSizing.title = num;
               onChange(options);
             }}
@@ -869,7 +869,7 @@ export const PanelForm = ({ value, onChange }: Props) => {
             value={value.settings.scale.fontSizing.threshold}
             step={1}
             onChange={(num) => {
-              let options = value;
+              let options = structuredClone(value);
               options.settings.scale.fontSizing.threshold = num;
               onChange(options);
             }}

--- a/src/testData.ts
+++ b/src/testData.ts
@@ -21,15 +21,19 @@ export const defaultNodes = [
 ];
 
 export const getData = (theme: any): Weathermap => {
+  // Build from clones: defaultNodes is a shared module-level fixture, and
+  // mutating it here leaked state between tests (and broke once a test froze
+  // a previously returned map).
+  const nodes: Node[] = defaultNodes.map((d, i) => {
+    const v: Node = structuredClone(d);
+    v.anchors[i === 0 ? Anchor.Right : Anchor.Left].numLinks = 1;
+    return v;
+  });
   return {
     version: 1,
     id: 'testing',
-    nodes: defaultNodes.map((d, i) => {
-      let v: Node = d;
-      v.anchors[i === 0 ? Anchor.Right : Anchor.Left].numLinks = 1;
-      return v;
-    }),
-    links: [generateBasicLink([defaultNodes[0], defaultNodes[1]])].map((l, i) => {
+    nodes,
+    links: [generateBasicLink([nodes[0], nodes[1]])].map((l, i) => {
       l.id = `nw-link-${i}`;
       l.sides.A.dashboardLink = 'https://example.com/';
       l.sides.Z.dashboardLink = 'https://example.com/';


### PR DESCRIPTION
Closes #233

## Problem
After #225/#229, ~116 editor handlers across LinkForm/NodeForm/ColorForm/PanelForm still aliased `props.value` and mutated it in place before `onChange` — the review kept (correctly) finding them one by one.

## Fix — close the class, not another instance
Every `let wm/options/weathermap = value;` alias is now `structuredClone(value)`: each handler operates on a fresh deep copy and delivers all-new references. Values, ordering, and behavior are unchanged — the diff is mechanical. `structuredClone` is baseline in every browser Grafana 11+ supports; the jest jsdom environment lacks it, so the test polyfills add a faithful V8 serialize/deserialize implementation.

## Enforcement so it stays closed
All four form test harnesses now **deep-freeze** `props.value` — any future in-place write throws a TypeError in tests immediately. The entire 152-test suite passes under this enforcement.

## Bonus fix the freeze exposed
`testData.getData` mutated the shared module-level `defaultNodes` fixture on every call, silently leaking state between tests. It now builds from clones.

## Validation
typecheck / lint / test:ci (152 tests, freeze active) / build / verify-dist — all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make all form handlers immutable by cloning `props.value` before updates to stop in-place mutations and ensure correct re-renders. Adds test enforcement and a `structuredClone` polyfill; behavior is unchanged.

- **Bug Fixes**
  - Replaced all `value` aliases with `structuredClone(value)` across LinkForm, NodeForm, ColorForm, and PanelForm to return new references on every change.
  - Fixed `testData.getData` to clone shared fixtures to avoid state leaks between tests.

- **Tests**
  - Deep-freeze `props.value` in all form harnesses to immediately catch any in-place writes; entire suite passes.
  - Polyfilled `structuredClone` in `jest-environment-jsdom` using `v8` serialize/deserialize.

<sup>Written for commit 32674b26483b01c928be8f16d273fe710b4042bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

