### PR TITLE
fix: resolve @opentelemetry/core advisory via override, keep Grafana packages at 11.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2652,9 +2652,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
-      "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "form-data": "4.0.6",
     "@grafana/ui": {
       "uuid": "11.1.1"
-    }
+    },
+    "@opentelemetry/core": "^2.8.0"
   }
 }


### PR DESCRIPTION
Supersedes #141.

The dependabot multi-bump raised `@grafana/runtime`/`@grafana/ui` **two majors** (11.6.15 → 13.1.0) solely to reach a patched transitive `@opentelemetry/core` — a risky jump for the packages the plugin builds against while `plugin.json` declares Grafana ≥11 support (its latest-compat check was failing accordingly). And since `@grafana/*` are webpack externals, none of that chain ships in the plugin archive — the exposure is dev/lockfile-only.

Instead, a same-major npm `overrides` pin (`@opentelemetry/core: ^2.8.0`, resolves to 2.9.0) fixes the advisory directly:

```
@grafana/runtime@11.6.15 → faro-web-sdk → otlp-transformer → @opentelemetry/core@2.9.0 ✅
```

Validation: typecheck / test:ci (152) / build / verify-dist all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `@opentelemetry/core` advisory by adding an npm override, avoiding risky major upgrades. Keeps `@grafana/runtime` and `@grafana/ui` on 11.x to preserve Grafana ≥11 compatibility.

- **Dependencies**
  - Added npm `overrides` for `@opentelemetry/core` to `^2.8.0` (resolves to 2.9.0).
  - Prevented major bumps of `@grafana/*` to 13.x; they remain 11.x and are webpack externals (no runtime impact).

<sup>Written for commit 61a60a2d3e4992e8fbcb9a2ece56b56f576b439a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

