### PR TITLE
fix: clone before VIA add/remove — the helpers mutate their argument (#238)

### DIFF
--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -827,3 +827,31 @@ test('pan persistence delivers a new object without mutating options (#225)', ()
   // The frozen original is untouched.
   expect(weathermap.settings.panel.offset).toEqual({ x: 0, y: 0 });
 });
+
+// #238: VIA insert/remove must not mutate the rendered options — the helpers
+// mutate their argument by design, so the panel must hand them a clone.
+// Deep-freezing makes any residual in-place write throw.
+test('VIA insert and remove leave the rendered options untouched (#238)', () => {
+  const deepFreeze = (o: unknown): unknown => {
+    if (o && typeof o === 'object' && !Object.isFrozen(o)) {
+      Object.values(o as Record<string, unknown>).forEach(deepFreeze);
+      Object.freeze(o);
+    }
+    return o;
+  };
+  getSearchSpy = jest.spyOn(locationService, 'getSearch').mockReturnValue(new URLSearchParams('editPanel=1'));
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  deepFreeze(weathermap);
+  const spy = jest.fn();
+  render(<WeathermapPanel {...{ ...mPanelProps, options: { weathermap }, onOptionsChange: spy }} />);
+
+  // Insert a VIA by double-clicking the link.
+  fireEvent.doubleClick(screen.getByTestId('link'));
+
+  expect(spy).toHaveBeenCalled();
+  const inserted = spy.mock.calls[spy.mock.calls.length - 1][0].weathermap;
+  expect(inserted).not.toBe(weathermap);
+  expect(inserted.nodes.filter((n: { isConnection?: boolean }) => n.isConnection)).toHaveLength(1);
+  // The frozen original never gained the connection node.
+  expect(weathermap.nodes.some((n) => n.isConnection)).toBe(false);
+});

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -833,7 +833,9 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
     }
     e.preventDefault();
     e.stopPropagation();
-    const updated = addViaToLink(wm, linkId, theme);
+    // addViaToLink mutates its argument by design — hand it a clone so the
+    // rendered wm (and the saved options) stay untouched (#238).
+    const updated = addViaToLink(structuredClone(wm), linkId, theme);
     onOptionsChange({ ...options, weathermap: updated });
   };
 
@@ -843,7 +845,8 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
     }
     e.preventDefault();
     e.stopPropagation();
-    const updated = removeVia(wm, node.id);
+    // removeVia mutates its argument by design — clone first (#238).
+    const updated = removeVia(structuredClone(wm), node.id);
     onOptionsChange({ ...options, weathermap: updated });
   };
 


### PR DESCRIPTION
Closes #238

## Problem
The last remaining props-mutation path after #225/#233: `handleAddVia`/`handleRemoveVia` passed the rendered `wm` directly into `addViaToLink`/`removeVia`, which mutate their argument by design (links/nodes arrays, link sides).

## Fix
Hand the helpers a `structuredClone` at both call sites — the helpers stay as-is (their mutate-the-argument contract is fine for a private copy), the rendered map and saved options stay untouched.

## Test
VIA insert driven against a **deep-frozen** options object: any in-place write throws; asserts the persisted copy is a new object carrying the connection node while the frozen original never gains one.

## Validation
typecheck / lint / test:ci (160 tests) / build / verify-dist — all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents mutation of rendered weathermap options when adding or removing VIA nodes by cloning before calling the mutating helpers. Adds a regression test to ensure the original options never change (fixes #238).

- **Bug Fixes**
  - Pass `structuredClone(wm)` to `addViaToLink` and `removeVia` so rendered options and saved state stay untouched.
  - Add test that deep-freezes options and verifies VIA insert creates a new object while the original remains unchanged.

<sup>Written for commit 652379db5203f42c24aacbc1ba5c53761d6b9d2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

