### PR TITLE
docs: redesign the project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,7 @@ Need the official AWS/Azure/GCP architecture packs? <code>scripts/fetch-cloud-ic
 
 Then: <kbd>Add panel</kbd> → pick **Network Weathermap NG** → open the **Map Editor** → add nodes, draw links, bind queries, set thresholds. Done.
 
-<details>
-<summary><b>Manual install (signed release zip)</b></summary>
+### 📦 Manual install (signed release zip)
 
 Grab the versioned zip from the [latest release](https://github.com/allamiro/grafana-network-weathermap-ng/releases/latest), then:
 
@@ -167,10 +166,7 @@ systemctl restart grafana-server
 
 Every release ships a `.zip.md5` checksum, a community signature (`MANIFEST.txt`), and a GitHub build-provenance attestation.
 
-</details>
-
-<details>
-<summary><b>Try the full demo playground (Docker)</b></summary>
+### 🐳 Try the full demo playground (Docker)
 
 ```bash
 cd testing && docker compose up --build
@@ -181,8 +177,6 @@ Grafana starts at **http://localhost:3101** (anonymous admin) with the plugin pr
 ```bash
 GRAFANA_VERSION=11.0.0 docker compose up --build   # pin any Grafana version
 ```
-
-</details>
 
 |  | Requirement | Version |
 |:-:|---|---|
@@ -198,20 +192,17 @@ This fork treats reliability as a feature. Beyond unit coverage, the suite is bu
 - **Playwright E2E** on real Grafana (declared minimum *and* latest) — weekly, on demand, and on every PR that touches the E2E surface.
 - **Release discipline** — packaging layout checks on PRs, API-compatibility gates for Grafana 11→13, signed artifacts with checksums and provenance attestation.
 
-<details>
-<summary><b>What was modernized from the original</b></summary>
+### 🔄 What was modernized from the original
 
-| Area | Change |
-|---|---|
-| Grafana SDK | `@grafana/data` / `runtime` / `ui` updated to 11.x, verified against 13.x |
-| React | 17 → **18** (React 19 / `findDOMNode` crash fixed) |
-| TypeScript | **5.4+**, all `@ts-ignore` overrides removed |
-| Styling | `stylesFactory` → `useStyles2` + `@emotion/css` |
-| Security | URL sanitization for dashboard links, icons, and background images |
-| E2E | deprecated `@grafana/e2e` → `@grafana/plugin-e2e` (Playwright) |
-| CI/CD | signed releases, provenance attestation, docs site, API-compat matrix, packaging checks |
-
-</details>
+| Area | | Change |
+|---|:-:|---|
+| **Grafana SDK** | ![](https://img.shields.io/badge/11.x_→_13.x-F46800?style=flat-square) | `@grafana/data` / `runtime` / `ui` updated and verified against Grafana 13 |
+| **React** | ![](https://img.shields.io/badge/17_→_18-61DAFB?style=flat-square) | React 19 / `findDOMNode` crash fixed |
+| **TypeScript** | ![](https://img.shields.io/badge/5.4+-3178C6?style=flat-square) | all `@ts-ignore` overrides removed |
+| **Styling** | ![](https://img.shields.io/badge/useStyles2-DB7093?style=flat-square) | `stylesFactory` → `useStyles2` + `@emotion/css` |
+| **Security** | ![](https://img.shields.io/badge/sanitized-2ea44f?style=flat-square) | URL sanitization for dashboard links, icons, and background images |
+| **E2E** | ![](https://img.shields.io/badge/Playwright-45BA4B?style=flat-square) | deprecated `@grafana/e2e` → `@grafana/plugin-e2e` |
+| **CI/CD** | ![](https://img.shields.io/badge/signed_+_attested-2ea44f?style=flat-square) | signed releases, provenance attestation, docs site, API-compat matrix, packaging checks |
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,144 +1,231 @@
 <div align="center">
-  <img src="src/img/logo.svg" alt="Network Weathermap NG" width="200" height="200">
 
-  # Network Weathermap NG
+<img src="src/img/logo.svg" alt="Network Weathermap NG" width="170" height="170">
 
-  **A modernized, actively maintained network weathermap panel plugin for Grafana**
+# Network Weathermap NG
 
-  [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-  [![Grafana Version](https://img.shields.io/badge/Grafana-11%2B-orange)](https://grafana.com/)
-  [![Node Version](https://img.shields.io/badge/Node-20%2B-green)](https://github.com/allamiro/grafana-network-weathermap-ng/blob/main/CONTRIBUTING.md)
+**Draw your network. Watch it breathe.**
 
-  This is a continuation of the original [knightss27-weathermap-panel](https://github.com/knightss27/grafana-network-weathermap), updated for modern Grafana environments.
+Live network weathermaps for Grafana — nodes, links, and color scales driven by your real metrics.
+
+[![Release](https://img.shields.io/github/v/release/allamiro/grafana-network-weathermap-ng?style=flat-square&color=F46800&label=release)](https://github.com/allamiro/grafana-network-weathermap-ng/releases/latest)
+[![CI](https://img.shields.io/github/actions/workflow/status/allamiro/grafana-network-weathermap-ng/test.yml?style=flat-square&label=CI)](https://github.com/allamiro/grafana-network-weathermap-ng/actions/workflows/test.yml)
+[![E2E](https://img.shields.io/github/actions/workflow/status/allamiro/grafana-network-weathermap-ng/e2e.yml?style=flat-square&label=E2E%20%C2%B7%20Grafana%2011%E2%86%92latest)](https://github.com/allamiro/grafana-network-weathermap-ng/actions/workflows/e2e.yml)
+[![License](https://img.shields.io/github/license/allamiro/grafana-network-weathermap-ng?style=flat-square&color=blue)](LICENSE)
+[![Grafana](https://img.shields.io/badge/Grafana-11%20%E2%86%92%2013-F46800?style=flat-square&logo=grafana&logoColor=white)](https://grafana.com/)
+[![Signed](https://img.shields.io/badge/plugin-community%20signed-2ea44f?style=flat-square)](https://grafana.com/legal/plugins/)
+
+[**Documentation**](https://allamiro.github.io/grafana-network-weathermap-ng/) ·
+[**Getting Started**](https://allamiro.github.io/grafana-network-weathermap-ng/guide/getting-started/) ·
+[**Use Cases**](https://allamiro.github.io/grafana-network-weathermap-ng/guide/use-cases/) ·
+[**Icon Reference**](https://allamiro.github.io/grafana-network-weathermap-ng/icons/) ·
+[**FAQ**](https://allamiro.github.io/grafana-network-weathermap-ng/faq/)
+
+<img src="src/img/general-example.png" alt="A live network weathermap rendered by the plugin" width="760">
+
 </div>
 
----
-
-## Features
-
-- **Customizable network weathermaps** — draw nodes, links, and color scales that match your infrastructure layout
-- **Real-time data visualization** — dynamic link and node coloring based on live Grafana metrics
-- **PHP Network Weathermap compatibility** — familiar design patterns for teams migrating from classic tools
-- **Multi-source support** — works with Prometheus, InfluxDB, Zabbix, and any Grafana-compatible data source
-- **Intuitive panel editor** — build and modify maps entirely within the Grafana UI, no external tools required
+> A continuation of the archived [knightss27-weathermap-panel](https://github.com/knightss27/grafana-network-weathermap),
+> rebuilt for modern Grafana — React 18, Grafana 11→13, TypeScript 5, and a hardened, regression-tested core.
 
 ---
 
-## Use Cases
+## ✨ What it does
 
-The **[step-by-step Use Cases guide](https://allamiro.github.io/grafana-network-weathermap-ng/guide/use-cases/)** is the fastest way to get started — eleven ready-made scenarios, each with a live screenshot, a recipe, and a demo dashboard you can run locally (`cd testing && docker compose up --build`):
+<table>
+<tr>
+<td width="33%" valign="top">
 
-1. [WAN link utilization](https://allamiro.github.io/grafana-network-weathermap-ng/guide/use-cases/#1-wan-link-utilization-two-sites) · 2. [Capacity planning (p95)](https://allamiro.github.io/grafana-network-weathermap-ng/guide/use-cases/#2-capacity-planning-avg-95th-percentile) · 3. [Incident replay (timeline)](https://allamiro.github.io/grafana-network-weathermap-ng/guide/use-cases/#3-incident-retrospective-timeline-replay) · 4. [Floor plan background](https://allamiro.github.io/grafana-network-weathermap-ng/guide/use-cases/#4-data-center-floor-plan-background-follows-the-map) · 5. [Multi-hop VIAs](https://allamiro.github.io/grafana-network-weathermap-ng/guide/use-cases/#5-multi-hop-path-with-vias) · 6. [Device health](https://allamiro.github.io/grafana-network-weathermap-ng/guide/use-cases/#6-device-health-overview-status-coloring) · 7. [Parallel links / LAG](https://allamiro.github.io/grafana-network-weathermap-ng/guide/use-cases/#7-parallel-links-between-the-same-nodes) · 8. [Clickable drill-down](https://allamiro.github.io/grafana-network-weathermap-ng/guide/use-cases/#8-clickable-drill-down-map) · 9. [Global backbone on a world map](https://allamiro.github.io/grafana-network-weathermap-ng/guide/use-cases/#9-global-backbone-on-a-world-map) · 10. [Rack port status board](https://allamiro.github.io/grafana-network-weathermap-ng/guide/use-cases/#10-rack-switch-port-status-board) · 11. [Rack cabling & power redundancy](https://allamiro.github.io/grafana-network-weathermap-ng/guide/use-cases/#11-rack-cabling-power-redundancy-multi-device-rear-view)
+**🗺️ Maps, not charts**<br>
+Lay out nodes and links to match your real topology — WAN, datacenter, campus, rack, or global backbone on a world map.
 
-<p align="center">
-  <a href="https://allamiro.github.io/grafana-network-weathermap-ng/guide/use-cases/">
-    <img src="website/docs/img/use-cases/wm-rack-cabling.png" alt="Rack cabling use case" width="410">
-    <img src="website/docs/img/use-cases/wm-global-backbone.png" alt="Global backbone use case" width="410">
-  </a>
-</p>
+</td>
+<td width="33%" valign="top">
 
-See also the **[Icon Reference](https://allamiro.github.io/grafana-network-weathermap-ng/icons/)** — nearly 1,000 bundled icons across network devices, rack parts, country flags, platforms, programming languages, and aerospace sets.
+**🌡️ Metrics as color**<br>
+Links and nodes recolor live from any Grafana data source — Prometheus, InfluxDB, Zabbix, anything that returns a series.
 
----
+</td>
+<td width="33%" valign="top">
 
-## Screenshots
+**⏪ Incident replay**<br>
+Scrub the built-in timeline and watch link utilization *and* node status replay history, step by step.
 
-<p align="center">
-  <img src="src/img/general-example.png" alt="Network Weathermap Overview" width="700">
-</p>
+</td>
+</tr>
+<tr>
+<td valign="top">
 
-<p align="center">
-  <img src="src/img/example_00.png" alt="Example 1" width="340">
-  <img src="src/img/example_01.png" alt="Example 2" width="340">
-</p>
+**🎛️ Everything in-panel**<br>
+Nodes, links, VIAs, thresholds, tooltips, drill-down dashboard links — all edited inside Grafana, no external tools.
 
----
+</td>
+<td valign="top">
 
-## Getting Started
+**🧭 PHP Weathermap familiar**<br>
+Classic weathermap design language, so teams migrating from the old tooling feel at home immediately.
 
-### Requirements
+</td>
+<td valign="top">
 
-| Requirement | Minimum Version |
-|---|---|
-| Grafana | 11.0.0 |
-| Node.js | 20.x |
+**🖼️ 1064 bundled icons**<br>
+Twelve icon sets served by the plugin itself — no external image hosting, air-gap friendly.
 
-### Installation
+</td>
+</tr>
+</table>
 
-**Option 1 — Grafana Marketplace (recommended)**
+## 🖼️ Gallery
 
-1. In Grafana, go to **Administration → Plugins → Find more plugins**
-2. Search for **Network Weathermap**
-3. Click **Install**
+<table>
+<tr>
+<td align="center" width="50%">
+<a href="https://allamiro.github.io/grafana-network-weathermap-ng/guide/use-cases/#11-rack-cabling-power-redundancy-multi-device-rear-view">
+<img src="website/docs/img/use-cases/wm-rack-cabling.png" alt="Rack cabling and power redundancy" width="100%"><br>
+<sub><b>Rack cabling & power redundancy</b></sub>
+</a>
+</td>
+<td align="center" width="50%">
+<a href="https://allamiro.github.io/grafana-network-weathermap-ng/guide/use-cases/#9-global-backbone-on-a-world-map">
+<img src="website/docs/img/use-cases/wm-global-backbone.png" alt="Global backbone on a world map" width="100%"><br>
+<sub><b>Global backbone on a world map</b></sub>
+</a>
+</td>
+</tr>
+<tr>
+<td align="center">
+<a href="https://allamiro.github.io/grafana-network-weathermap-ng/guide/use-cases/#3-incident-retrospective-timeline-replay">
+<img src="website/docs/img/use-cases/wm-incident-replay.png" alt="Incident replay with the timeline slider" width="100%"><br>
+<sub><b>Incident replay (timeline slider)</b></sub>
+</a>
+</td>
+<td align="center">
+<a href="https://allamiro.github.io/grafana-network-weathermap-ng/guide/use-cases/#6-device-health-overview-status-coloring">
+<img src="website/docs/img/use-cases/wm-device-health.png" alt="Device health overview with status coloring" width="100%"><br>
+<sub><b>Device health & status coloring</b></sub>
+</a>
+</td>
+</tr>
+</table>
 
-**Option 2 — Manual**
+<div align="center">
+<sub>Eleven ready-made scenarios — each with a recipe and a runnable demo dashboard — in the
+<a href="https://allamiro.github.io/grafana-network-weathermap-ng/guide/use-cases/"><b>Use Cases guide</b></a>.</sub>
+</div>
+
+## 🧩 The icon library
+
+<div align="center">
+
+<img src="src/icons/networking/router.svg" width="42" alt="router">&nbsp;
+<img src="src/icons/cloud/aws.svg" width="42" alt="aws">&nbsp;
+<img src="src/icons/cloud/gcp.svg" width="42" alt="gcp">&nbsp;
+<img src="src/icons/cloud/azure.svg" width="42" alt="azure">&nbsp;
+<img src="src/icons/vendors/juniper.svg" width="42" alt="juniper">&nbsp;
+<img src="src/icons/vendors/fortinet.svg" width="42" alt="fortinet">&nbsp;
+<img src="src/icons/vendors/dell.svg" width="42" alt="dell">&nbsp;
+<img src="src/icons/platforms/kubernetes.svg" width="42" alt="kubernetes">&nbsp;
+<img src="src/icons/databases/redis.svg" width="42" alt="redis">&nbsp;
+<img src="src/icons/languages/python.svg" width="42" alt="python">&nbsp;
+<img src="src/icons/flags/us.svg" width="42" alt="us flag">&nbsp;
+<img src="src/icons/flags/de.svg" width="42" alt="de flag">
+
+**1064 icons · 12 sets** — every one served by the plugin itself
+
+| Networking | Cisco | Vendors | Cloud | Rack | Flags | Databases | Languages | Platforms | Computers | Aerospace |
+|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| 72 | 289 | 49 | 18 | 18 | 522 | 48 | 22 | 9 | 12 | 5 |
+
+<sub>Browse them all in the <a href="https://allamiro.github.io/grafana-network-weathermap-ng/icons/"><b>Icon Reference</b></a>.
+Need the official AWS/Azure/GCP architecture packs? <code>scripts/fetch-cloud-icons.sh</code> installs them onto your own Grafana.</sub>
+
+</div>
+
+## 🚀 Quick start
+
+**From the Grafana catalog** — <kbd>Administration</kbd> → <kbd>Plugins</kbd> → search **Network Weathermap NG** → <kbd>Install</kbd>
+
+Then: <kbd>Add panel</kbd> → pick **Network Weathermap NG** → open the **Map Editor** → add nodes, draw links, bind queries, set thresholds. Done.
+
+<details>
+<summary><b>Manual install (signed release zip)</b></summary>
+
+Grab the versioned zip from the [latest release](https://github.com/allamiro/grafana-network-weathermap-ng/releases/latest), then:
 
 ```bash
-# Download the latest release
-curl -LO https://github.com/allamiro/grafana-network-weathermap-ng/releases/latest/download/tamirsuliman-weathermap-panel.zip
-
-# Extract to your Grafana plugins directory
-unzip tamirsuliman-weathermap-panel.zip -d /var/lib/grafana/plugins/
-
-# Restart Grafana
+unzip tamirsuliman-weathermap-panel-*.zip -d /var/lib/grafana/plugins/
 systemctl restart grafana-server
 ```
 
-### Quick Start
+Every release ships a `.zip.md5` checksum, a community signature (`MANIFEST.txt`), and a GitHub build-provenance attestation.
 
-1. Create or open a dashboard
-2. **Add panel** → search for **Network Weathermap**
-3. Connect a data source (Prometheus, InfluxDB, etc.)
-4. Use the **Map Editor** tab to add nodes and links
-5. Assign metrics to links and configure color thresholds
-6. Save the dashboard
+</details>
 
----
+<details>
+<summary><b>Try the full demo playground (Docker)</b></summary>
 
-## Development
+```bash
+cd testing && docker compose up --build
+```
 
-For local setup, build commands, Docker environment, and contribution guidelines, see [CONTRIBUTING.md](https://github.com/allamiro/grafana-network-weathermap-ng/blob/main/CONTRIBUTING.md).
+Grafana starts at **http://localhost:3101** (anonymous admin) with the plugin pre-loaded, a Prometheus datasource, a simulated-WAN exporter, and all demo dashboards provisioned — WAN utilization, incident replay, rack boards, the world-map backbone, and more.
 
----
+```bash
+GRAFANA_VERSION=11.0.0 docker compose up --build   # pin any Grafana version
+```
 
-## Modernization
+</details>
 
-This plugin modernizes the archived original for current Grafana versions:
+| Requirement | Version |
+|---|---|
+| Grafana | **11.0.0+** (tested through 13.x) |
+| Node.js (development only) | 20+ |
+
+## 🛡️ Built to not break
+
+This fork treats reliability as a feature. Beyond unit coverage, the suite is built around *regression traps* for the bugs that bite weathermaps in production:
+
+- **Hostile-data safe** — malformed or partial saved options, links pointing at deleted nodes, empty data frames, overlapping nodes: the panel renders instead of crashing, guaranteed by tests.
+- **Immutable by construction** — every editor interaction delivers new state; the test harnesses deep-freeze the options object so any in-place mutation fails CI instantly.
+- **Playwright E2E** on real Grafana (declared minimum *and* latest) — weekly, on demand, and on every PR that touches the E2E surface.
+- **Release discipline** — packaging layout checks on PRs, API-compatibility gates for Grafana 11→13, signed artifacts with checksums and provenance attestation.
+
+<details>
+<summary><b>What was modernized from the original</b></summary>
 
 | Area | Change |
 |---|---|
-| Grafana SDK | Updated `@grafana/data`, `@grafana/runtime`, `@grafana/ui` to 11.x |
-| Grafana dependency | Minimum version set to **11.0.0** |
-| React | Upgraded from React 17 to **React 18** |
-| Node.js | Minimum version raised to **20** |
-| TypeScript | Upgraded to **TypeScript 5.4+** |
-| Styling | Migrated from `stylesFactory` to `useStyles2` and `@emotion/css` |
-| Type safety | Removed all `@ts-ignore` overrides; added proper types throughout |
-| Deprecated APIs | Replaced `Vector.get()` with direct array indexing |
-| E2E testing | Migrated from deprecated `@grafana/e2e` to `@grafana/plugin-e2e` (Playwright) |
-| CI/CD | Added release workflow, GitHub Pages docs, and Grafana API compatibility checks |
+| Grafana SDK | `@grafana/data` / `runtime` / `ui` updated to 11.x, verified against 13.x |
+| React | 17 → **18** (React 19 / `findDOMNode` crash fixed) |
+| TypeScript | **5.4+**, all `@ts-ignore` overrides removed |
+| Styling | `stylesFactory` → `useStyles2` + `@emotion/css` |
+| Security | URL sanitization for dashboard links, icons, and background images |
+| E2E | deprecated `@grafana/e2e` → `@grafana/plugin-e2e` (Playwright) |
+| CI/CD | signed releases, provenance attestation, docs site, API-compat matrix, packaging checks |
 
----
+</details>
 
-## Contributing
+## 🤝 Contributing
 
-Contributions are welcome. Please open an issue first to discuss significant changes.
+Issues and PRs are welcome — please open an issue first for significant changes.
 
-- [Report a bug](https://github.com/allamiro/grafana-network-weathermap-ng/issues/new?template=bug_report.md)
-- [Request a feature](https://github.com/allamiro/grafana-network-weathermap-ng/issues/new?template=feature_request.md)
-- [Browse open issues](https://github.com/allamiro/grafana-network-weathermap-ng/issues)
+[Report a bug](https://github.com/allamiro/grafana-network-weathermap-ng/issues/new?template=bug_report.md) ·
+[Request a feature](https://github.com/allamiro/grafana-network-weathermap-ng/issues/new?template=feature_request.md) ·
+[Development guide](CONTRIBUTING.md)
 
----
+## 🧾 Credits & license
 
-## Author
+Created and maintained by **[Tamir Suliman](https://github.com/allamiro)** ([allamiro@gmail.com](mailto:allamiro@gmail.com)).
+A continuation of the archived [knightss27-weathermap-panel](https://github.com/knightss27/grafana-network-weathermap) — thank you to its original author.
 
-**Tamir Suliman** — [allamiro@gmail.com](mailto:allamiro@gmail.com) — [GitHub](https://github.com/allamiro)
+Icon sets bundled under their respective licenses (Simple Icons CC0, devicon MIT, circle-flags MIT, flag-icons MIT) — see [NOTICE](NOTICE). Product names and logos are trademarks of their owners, used for identification only.
 
-## Citing
+**Apache-2.0** — see [LICENSE](LICENSE). Redistributions must retain the [NOTICE](NOTICE) attribution per Apache-2.0 §4(d).
 
-If you use this project in research or publications, please cite it — GitHub's
-**"Cite this repository"** button (powered by [CITATION.cff](CITATION.cff)) provides
-APA and BibTeX entries, e.g.:
+<details>
+<summary><b>Citing this project</b></summary>
+
+GitHub's **"Cite this repository"** button (powered by [CITATION.cff](CITATION.cff)) provides APA and BibTeX entries:
 
 ```bibtex
 @software{Suliman_Network_Weathermap_NG,
@@ -149,6 +236,8 @@ APA and BibTeX entries, e.g.:
 }
 ```
 
-## License
+</details>
 
-Apache-2.0 — see [LICENSE](https://github.com/allamiro/grafana-network-weathermap-ng/blob/main/LICENSE) and [NOTICE](https://github.com/allamiro/grafana-network-weathermap-ng/blob/main/NOTICE) for details. Redistributions must retain the attribution in the NOTICE file per Apache-2.0 §4(d).
+<div align="center">
+<sub>⭐ If this plugin lights up your NOC wall, a star helps others find it.</sub>
+</div>

--- a/README.md
+++ b/README.md
@@ -132,9 +132,17 @@ Twelve icon sets served by the plugin itself — no external image hosting, air-
 
 **1064 icons · 12 sets** — every one served by the plugin itself
 
-| Networking | Cisco | Vendors | Cloud | Rack | Flags | Databases | Languages | Platforms | Computers | Aerospace |
-|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
-| 72 | 289 | 49 | 18 | 18 | 522 | 48 | 22 | 9 | 12 | 5 |
+![Cisco](https://img.shields.io/badge/Cisco-289-1BA0D7?style=flat-square)
+![Flags](https://img.shields.io/badge/Country_Flags-522-4E9F3D?style=flat-square)
+![Networking](https://img.shields.io/badge/Networking-72-5C7CFA?style=flat-square)
+![Vendors](https://img.shields.io/badge/Vendors-49-E8590C?style=flat-square)
+![Databases](https://img.shields.io/badge/Databases-48-B197FC?style=flat-square)
+![Languages](https://img.shields.io/badge/Languages-22-F59F00?style=flat-square)
+![Cloud](https://img.shields.io/badge/Cloud-18-FF9900?style=flat-square)
+![Rack](https://img.shields.io/badge/Rack_Parts-18-868E96?style=flat-square)
+![Computers](https://img.shields.io/badge/Computers-12-63E6BE?style=flat-square)
+![Platforms](https://img.shields.io/badge/Platforms-9-326CE5?style=flat-square)
+![Aerospace](https://img.shields.io/badge/Aerospace-5-D6336C?style=flat-square)
 
 <sub>Browse them all in the <a href="https://allamiro.github.io/grafana-network-weathermap-ng/icons/"><b>Icon Reference</b></a>.
 Need the official AWS/Azure/GCP architecture packs? <code>scripts/fetch-cloud-icons.sh</code> installs them onto your own Grafana.</sub>
@@ -176,10 +184,10 @@ GRAFANA_VERSION=11.0.0 docker compose up --build   # pin any Grafana version
 
 </details>
 
-| Requirement | Version |
-|---|---|
-| Grafana | **11.0.0+** (tested through 13.x) |
-| Node.js (development only) | 20+ |
+|  | Requirement | Version |
+|:-:|---|---|
+| 📊 | **Grafana** | **11.0.0+** — tested through 13.x |
+| ⚙️ | **Node.js** *(development only)* | 20+ |
 
 ## 🛡️ Built to not break
 
@@ -209,9 +217,12 @@ This fork treats reliability as a feature. Beyond unit coverage, the suite is bu
 
 Issues and PRs are welcome — please open an issue first for significant changes.
 
-[Report a bug](https://github.com/allamiro/grafana-network-weathermap-ng/issues/new?template=bug_report.md) ·
-[Request a feature](https://github.com/allamiro/grafana-network-weathermap-ng/issues/new?template=feature_request.md) ·
-[Development guide](CONTRIBUTING.md)
+| | |
+|:-:|---|
+| 🐛 | [**Report a bug**](https://github.com/allamiro/grafana-network-weathermap-ng/issues/new?template=bug_report.md) — crashes, wrong rendering, editor glitches |
+| ✨ | [**Request a feature**](https://github.com/allamiro/grafana-network-weathermap-ng/issues/new?template=feature_request.md) — new icon sets, options, integrations |
+| 🛠️ | [**Development guide**](CONTRIBUTING.md) — local setup, build, and test commands |
+| 💬 | [**Browse open issues**](https://github.com/allamiro/grafana-network-weathermap-ng/issues) — see what's planned or grab something to work on |
 
 ## 🧾 Credits & license
 
@@ -222,10 +233,9 @@ Icon sets bundled under their respective licenses (Simple Icons CC0, devicon MIT
 
 **Apache-2.0** — see [LICENSE](LICENSE). Redistributions must retain the [NOTICE](NOTICE) attribution per Apache-2.0 §4(d).
 
-<details>
-<summary><b>Citing this project</b></summary>
+## 📖 Citing
 
-GitHub's **"Cite this repository"** button (powered by [CITATION.cff](CITATION.cff)) provides APA and BibTeX entries:
+If you use this project in research or publications, please cite it — GitHub's **"Cite this repository"** button (powered by [CITATION.cff](CITATION.cff)) provides APA and BibTeX entries:
 
 ```bibtex
 @software{Suliman_Network_Weathermap_NG,
@@ -235,8 +245,6 @@ GitHub's **"Cite this repository"** button (powered by [CITATION.cff](CITATION.c
   license = {Apache-2.0}
 }
 ```
-
-</details>
 
 <div align="center">
 <sub>⭐ If this plugin lights up your NOC wall, a star helps others find it.</sub>


### PR DESCRIPTION
Full README refresh:

- centered hero (logo, tagline, dynamic shields: release / CI / E2E matrix / license / Grafana range / signed)
- quick-nav docs links + hero screenshot
- 6-cell feature grid, 4-shot use-case gallery with captions
- icon library showcase — a strip of the actual bundled SVGs rendered inline, per-set counts table (1064 / 12 sets)
- quick start with collapsible manual-install and Docker-playground sections (`testing/` on :3101)
- 'Built to not break' section: hostile-data safety, deep-freeze mutation traps, E2E matrix, signed+attested releases
- collapsible modernization table, contributing, credits (original project retained), citing, NOTICE/license

No content lost from the old README — install, requirements, credits, citation, and license are all carried over.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the README for faster onboarding with a clearer hero, richer quick start, a visual gallery, and a reliability + modernization overview. Expanded install and demo details, added colored compatibility badges, and kept all prior content.

- **Highlights**
  - New hero with tagline, screenshot, and live badges (Release, CI, E2E, Grafana 11→13, license, signed).
  - Quick links to docs, getting started, use cases, icons, and FAQ.
  - Feature grid plus a 4-shot use‑case gallery.
  - Icon library strip and per‑set counts (1064 icons across 12 sets).
  - Install: Grafana catalog flow and signed release zip with checksum and provenance; Docker playground at http://localhost:3101 with provisioned demos and optional Grafana version pin.
  - Reliability: hostile‑data safety, immutable state traps, Playwright E2E on min/latest Grafana, signed/attested releases.
  - Modernization: updated `@grafana/data`, `@grafana/runtime`, `@grafana/ui`, React 18+, TypeScript 5, `useStyles2` styling, URL sanitization; section now uses colored badges.
  - Credits, citing, NOTICE, and license retained.

<sup>Written for commit 276294c39b86c3eedbef685e6e891430dc20cc19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

