### PR TITLE
test: cover VIA remove against a deep-frozen options object

### DIFF
--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -855,3 +855,37 @@ test('VIA insert and remove leave the rendered options untouched (#238)', () => 
   // The frozen original never gained the connection node.
   expect(weathermap.nodes.some((n) => n.isConnection)).toBe(false);
 });
+
+test('VIA remove leaves the rendered options untouched (#238)', () => {
+  const deepFreeze = (o: unknown): unknown => {
+    if (o && typeof o === 'object' && !Object.isFrozen(o)) {
+      Object.values(o as Record<string, unknown>).forEach(deepFreeze);
+      Object.freeze(o);
+    }
+    return o;
+  };
+  getSearchSpy = jest.spyOn(locationService, 'getSearch').mockReturnValue(new URLSearchParams('editPanel=1'));
+  // Start from a map that already has a VIA (connection node between two links).
+  const weathermap = handleVersionedStateUpdates(getConnectedLinkData(theme), theme);
+  const viaCount = weathermap.nodes.filter((n) => n.isConnection).length;
+  expect(viaCount).toBe(1);
+  deepFreeze(weathermap);
+  const spy = jest.fn();
+  const { container } = render(
+    <WeathermapPanel {...{ ...mPanelProps, options: { weathermap }, onOptionsChange: spy }} />
+  );
+
+  // Right-click the connection node to remove the VIA. Connection nodes render
+  // as small transparent rects; find its group via the drawn node transform.
+  const connection = container.querySelector('g[cursor="move"] rect[fill="transparent"]')!.closest('g')!;
+  fireEvent.contextMenu(connection);
+
+  expect(spy).toHaveBeenCalled();
+  const removed = spy.mock.calls[spy.mock.calls.length - 1][0].weathermap;
+  expect(removed).not.toBe(weathermap);
+  expect(removed.nodes.filter((n: { isConnection?: boolean }) => n.isConnection)).toHaveLength(0);
+  expect(removed.links).toHaveLength(1);
+  // The frozen original still holds its VIA — nothing was written in place.
+  expect(weathermap.nodes.filter((n) => n.isConnection)).toHaveLength(1);
+  expect(weathermap.links).toHaveLength(2);
+});


### PR DESCRIPTION
Review follow-up on #238: the mutation fix covered both `addViaToLink` and `removeVia`, but the regression test only drove the insert path. The remove path (right-click on the connection node) is now tested against a **deep-frozen** map with a pre-existing VIA: the persisted copy drops the connection node and merges the segments back to one link, while the frozen original keeps its VIA and both segments — any in-place write would throw.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add regression test for VIA removal against a deep‑frozen options object to ensure no in‑place mutation. The test removes a connection node via context menu and asserts the saved options merge two segments back into one link while the original frozen options still keep the VIA and both segments.

<sup>Written for commit 2ab75aa8e7b62bd794412dff0a1665d16630bef4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

