### PR TITLE
docs: distinguish the two Docker environments in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,19 +35,41 @@ Grafana will be available at `http://localhost:3000` (admin / admin).
 | `npm run dev` | Start webpack in watch mode |
 | `npm run build` | Production build |
 | `npm run test:ci` | Run unit tests |
-| `npm run e2e` | Run Playwright E2E tests |
+| `npm run e2e` | Run Playwright E2E tests (`GRAFANA_URL` targets any instance) |
+| `npm run e2e:local` | E2E against the anonymous-admin `testing/` stack on :3101 |
 | `npm run lint` | ESLint check |
 | `npm run typecheck` | TypeScript type check |
 
-## Docker environment
+## Docker environments
 
-A fully provisioned local environment is provided via Docker Compose:
+There are two Compose environments with different jobs:
+
+**Dev server** (repo root — what `npm run server` runs):
 
 ```bash
-docker-compose up --build
+docker compose up --build
 ```
 
-This starts Grafana at `http://localhost:3000` with the plugin pre-loaded and sample dashboards provisioned from the `provisioning/` directory.
+Grafana at `http://localhost:3000` (admin / admin) with `dist/` mounted as the plugin and the `provisioning/` directory applied. Pair it with `npm run dev` for watch-mode rebuilds.
+
+**Demo & E2E playground** (`testing/`):
+
+```bash
+cd testing && docker compose up --build
+```
+
+Grafana at `http://localhost:3101` (anonymous admin, login form disabled) with the plugin pre-loaded, a Prometheus datasource, a simulated-WAN exporter, and every demo dashboard provisioned — WAN utilization, incident replay, rack boards, the world-map backbone. This is the stack the Use Cases guide, the Grafana review instructions, and `npm run e2e:local` target. Pin a Grafana version with `GRAFANA_VERSION=11.0.0 docker compose up --build`.
+
+### Running E2E locally
+
+```bash
+cd testing && docker compose up -d      # Grafana on :3101
+npm run e2e:local                        # seeds anonymous auth, runs the suite
+# or against any instance with password auth:
+GRAFANA_URL=http://localhost:3000 npm run e2e
+```
+
+`PW_CHANNEL=chrome` reuses your system Chrome instead of downloading Playwright's bundled browser. In CI, the E2E workflow runs weekly, on demand, and on PRs touching `tests/**` or the Playwright config.
 
 ## Submitting changes
 


### PR DESCRIPTION
Fixes a docs inconsistency: README describes the `testing/` stack on **:3101** while CONTRIBUTING's Docker section described the root compose on **:3000** but credited it with the provisioned demo dashboards that actually belong to `testing/`.

CONTRIBUTING now documents both environments with their distinct jobs — root dev server (:3000, `npm run server`, watch-mode pairing) vs demo & E2E playground (:3101, Prometheus + exporter + demo dashboards, `GRAFANA_VERSION` pinning) — plus a local-E2E section covering `npm run e2e:local`, `GRAFANA_URL`, `PW_CHANNEL`, and the CI cadence. Command table gains the `e2e:local` row.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies CONTRIBUTING by separating the two Docker setups: root dev server on :3000 and the demo/E2E stack on :3101. Adds concise local E2E steps and updates the command table.

- **Bug Fixes**
  - Documents both compose environments: root dev server (`npm run server` + `npm run dev`) vs `testing/` demo stack (Prometheus, exporter, demo dashboards, `GRAFANA_VERSION` pinning).
  - Adds local E2E instructions: `npm run e2e:local`, `GRAFANA_URL` targeting any instance, `PW_CHANNEL` option, and CI cadence.
  - Updates the command table with `e2e:local`.

<sup>Written for commit 90af62ad4940a5f2758645363762ad775e31bfc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

