### PR TITLE
docs: bound the Node guidance to the toolchain's actual support (20–24)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to the Network Weathermap plugin.
 
 ## Prerequisites
 
-- Node.js 20+
+- Node.js 20 – 24 (`.nvmrc` pins 24; the E2E toolchain caps at 24)
 - npm 9+
 - Docker (for the local Grafana environment)
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ GRAFANA_VERSION=11.0.0 docker compose up --build   # pin any Grafana version
 |  | Requirement | Version |
 |:-:|---|---|
 | 📊 | **Grafana** | **11.0.0+** — tested through 13.x |
-| ⚙️ | **Node.js** *(development only)* | 20+ |
+| ⚙️ | **Node.js** *(development only)* | 20 – 24 (`.nvmrc` pins 24) |
 
 ## 🛡️ Built to not break
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "webpack-livereload-plugin": "^3.0.2"
       },
       "engines": {
-        "node": ">=20",
+        "node": ">=20 <=24",
         "npm": ">=9"
       }
     },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "webpack-livereload-plugin": "^3.0.2"
   },
   "engines": {
-    "node": ">=20",
+    "node": ">=20 <=24",
     "npm": ">=9"
   },
   "dependencies": {


### PR DESCRIPTION
Review follow-up: `engines.node` said `>=20` and the docs said "20+", but `@grafana/plugin-e2e@3.9.1` declares `>=20 <=24`, so Node 25+ produces `EBADENGINE` warnings on `npm ci`. `engines`, README, and CONTRIBUTING now state **20 – 24**, consistent with `.nvmrc` (24) and CI (Node 22).

Also re-verified the compose ports cited in the docs: root `docker-compose.yaml` → 3000:3000; `testing/docker-compose.yml` → Grafana 3101:3000, Prometheus 9090, exporter 8080.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound Node support to 20–24 across `engines`, README, and CONTRIBUTING to match `@grafana/plugin-e2e`, preventing EBADENGINE warnings on Node 25+. Also corrected the documented Docker Compose port mappings.

- **Migration**
  - Use Node 20–24 for development (`nvm use` will pick `.nvmrc`).

<sup>Written for commit 39909d7dad9102045bfb9d660d58f97a3183aa50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/247?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

