### PR TITLE
docs: two-environment comparison table in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,17 +166,19 @@ systemctl restart grafana-server
 
 Every release ships a `.zip.md5` checksum, a community signature (`MANIFEST.txt`), and a GitHub build-provenance attestation.
 
-### 🐳 Try the full demo playground (Docker)
+### 🐳 Local environments — know which one you want
 
-```bash
-cd testing && docker compose up --build
-```
+The repo ships **two** Docker Compose environments with different jobs:
 
-Grafana starts at **http://localhost:3101** (anonymous admin) with the plugin pre-loaded, a Prometheus datasource, a simulated-WAN exporter, and all demo dashboards provisioned — WAN utilization, incident replay, rack boards, the world-map backbone, and more.
+| | 🛠️ Dev server | 🐳 Demo & E2E playground |
+|---|---|---|
+| **Start** | `npm run server` *(repo root)* | `cd testing && docker compose up --build` |
+| **URL** | `http://localhost:3000` — admin / admin | `http://localhost:3101` — anonymous admin |
+| **Contains** | your local `dist/` build + root `provisioning/` | plugin + Prometheus + simulated-WAN exporter + **all demo dashboards** |
+| **Use it for** | plugin development (pair with `npm run dev` watch mode) | trying every use case, plugin review, `npm run e2e:local` |
+| **Pin Grafana** | `GRAFANA_VERSION=11.0.0 npm run server` | `GRAFANA_VERSION=11.0.0 docker compose up --build` |
 
-```bash
-GRAFANA_VERSION=11.0.0 docker compose up --build   # pin any Grafana version
-```
+The playground provisions WAN utilization, incident replay, rack boards, the world-map backbone, and more — every scenario from the [Use Cases guide](https://allamiro.github.io/grafana-network-weathermap-ng/guide/use-cases/), ready to click through.
 
 |  | Requirement | Version |
 |:-:|---|---|


### PR DESCRIPTION
Companion to #246: the README's demo section now distinguishes the **root dev compose (:3000, `npm run server`)** from the **`testing/` demo & E2E playground (:3101)** in a side-by-side table — start command, URL/auth, contents, purpose, and Grafana-version pinning for each — so readers pick the right one immediately. Consistent with the CONTRIBUTING environments section.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the two local Docker Compose environments in the README with a side-by-side table: the root dev server at :3000 and the `testing/` demo & E2E playground at :3101. The table lists start commands (`npm run server`, `cd testing && docker compose up --build`), URL/auth, contents, purpose, and `GRAFANA_VERSION` pinning to help readers pick the right one.

<sup>Written for commit 95509f9dcdea0638d4722fbe5bf5eb57593dcc3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

