### PR TITLE
docs: drop the Discussions link from the issue chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,1 @@
 blank_issues_enabled: true
-contact_links:
-  - name: 📚 Documentation
-    url: https://allamiro.github.io/grafana-network-weathermap-ng/
-    about: Getting started, use cases, icon reference, and the FAQ — many questions are answered here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: 📚 Documentation
     url: https://allamiro.github.io/grafana-network-weathermap-ng/
     about: Getting started, use cases, icon reference, and the FAQ — many questions are answered here.
-  - name: 💬 Questions & discussion
-    url: https://github.com/allamiro/grafana-network-weathermap-ng/discussions
-    about: Not sure it's a bug? Ask here first.


### PR DESCRIPTION
Removes the **Questions & discussion** contact link from the new-issue chooser (Discussions isn't in use for this repo). The chooser keeps the 🐛/✨ forms, the 📚 Documentation link, and blank issues stay enabled.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove all contact links from the new-issue chooser. The page now offers only the 🐛/✨ forms and a blank issue; Discussions aren’t used in this repo.

<sup>Written for commit 374c1689443901ec72c171a0866a1ddf79f651bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

