### PR TITLE
docs: link the plugin catalog and step-number the quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,17 @@ Need the official AWS/Azure/GCP architecture packs? <code>scripts/fetch-cloud-ic
 
 ## 🚀 Quick start
 
-**From the Grafana catalog** — <kbd>Administration</kbd> → <kbd>Plugins</kbd> → search **Network Weathermap NG** → <kbd>Install</kbd>
+**Install from the [Grafana plugin catalog](https://grafana.com/grafana/plugins/all-plugins/):**
 
-Then: <kbd>Add panel</kbd> → pick **Network Weathermap NG** → open the **Map Editor** → add nodes, draw links, bind queries, set thresholds. Done.
+1. In Grafana, go to <kbd>Administration</kbd> → <kbd>Plugins and data</kbd> → <kbd>Plugins</kbd>
+2. Search for **Network Weathermap NG** and click <kbd>Install</kbd>
+
+**Build your first map:**
+
+1. <kbd>Add panel</kbd> → pick **Network Weathermap NG** as the visualization
+2. Open the **Map Editor** in the panel options
+3. Add nodes, draw links between them, bind each link side to a query
+4. Set your color-scale thresholds — the map starts breathing 🌡️
 
 ### 📦 Manual install (signed release zip)
 

--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ Need the official AWS/Azure/GCP architecture packs? <code>scripts/fetch-cloud-ic
 
 ## 🚀 Quick start
 
-**Install from the [Grafana plugin catalog](https://grafana.com/grafana/plugins/all-plugins/):**
+**Install (from within Grafana):**
 
-1. In Grafana, go to <kbd>Administration</kbd> → <kbd>Plugins and data</kbd> → <kbd>Plugins</kbd>
+1. Go to <kbd>Administration</kbd> → <kbd>Plugins and data</kbd> → <kbd>Plugins</kbd>
 2. Search for **Network Weathermap NG** and click <kbd>Install</kbd>
 
 **Build your first map:**


### PR DESCRIPTION
The README quick start now links to the [Grafana plugin catalog](https://grafana.com/grafana/plugins/all-plugins/) and splits install and first-map into two clean numbered step lists with `<kbd>` UI paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the README quick start with two numbered flows—install (from within Grafana) and first map—with corrected Grafana UI paths. Removes the external plugin catalog link to keep setup fully in-app.

<sup>Written for commit 7e5cca1213d1f4bcdf4ed3fa719ba97935dc4845. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

