### PR TITLE
docs: colored hosting guidance for background images

### DIFF
--- a/website/docs/guide/panel-options.md
+++ b/website/docs/guide/panel-options.md
@@ -6,12 +6,21 @@ Panel-level options apply to the whole weathermap. Open the panel options sideba
 
 ## Background
 
+!!! tip "Where do I host my floor plan / map image?"
+    The **Image** field takes a URL — the plugin does not upload files. Your options:
+
+    1. **Any `https://` URL** your dashboard viewers' browsers can reach (an internal web server, a wiki attachment, an S3/object-storage link, Wikimedia Commons, ...).
+    2. **Grafana's own `public/` folder** — copy the file onto the Grafana server, e.g. `/usr/share/grafana/public/img/floorplan.png`, then use the relative URL `public/img/floorplan.png`. Works fully air-gapped and survives viewer networks that can't reach external hosts.
+    3. **A provisioned sidecar** — the demo dashboards serve their floor-plan and world-map images from the `testing/` stack's exporter container on `:8080`; any tiny static file server works the same way.
+
+    SVG or PNG both work; prefer SVG for crisp zooming with **Move With Map**.
+
+!!! warning "Image URLs are validated"
+    Only relative Grafana paths and `http`/`https` URLs are accepted. `data:`, `file:`, `javascript:` and other schemes are **rejected** by the plugin's URL sanitization — pasting a base64 data URL will not work.
+
 - **Color** — the canvas background color.
 - **Image** — set a background image by URL (floor plan, geographic map, building outline, network zones). Choose an **Image Fit** (contain / cover / auto).
 - **Move With Map** — when enabled, the background image is drawn *inside* the map canvas so it **pans and zooms together** with the nodes and links. When off (default), the image stays fixed like a wallpaper.
-
-!!! warning "Image URLs are validated"
-    Only relative Grafana paths and `http`/`https` URLs are allowed; unsafe schemes are rejected.
 
 ---
 

--- a/website/docs/guide/use-cases.md
+++ b/website/docs/guide/use-cases.md
@@ -73,6 +73,9 @@ Hovering the link shows usage, bandwidth, throughput %, and a mini graph.
 
 ![Building floor plan demo](../img/use-cases/wm-floorplan.png)
 
+!!! tip "Background image hosting"
+    The background is a **URL** — use any `https://` link, or drop the file in Grafana's `public/` folder and reference it as `public/img/<name>` (air-gap friendly). `data:` URLs are rejected. Details: [Panel Options → Background](panel-options.md#background).
+
 1. **Panel Options → Background → Image**: paste the floor-plan image URL; set **Image Fit** to `contain`.
 2. Enable **Move With Map** so the image scales and pans with the nodes.
 3. Place nodes on top of the plan at their physical locations; use the **Grid** for alignment.
@@ -143,6 +146,9 @@ Hovering the link shows usage, bandwidth, throughput %, and a mini graph.
 
 ![Global backbone demo](../img/use-cases/wm-global-backbone.png)
 
+!!! tip "Background image hosting"
+    The background is a **URL** — use any `https://` link, or drop the file in Grafana's `public/` folder and reference it as `public/img/<name>` (air-gap friendly). `data:` URLs are rejected. Details: [Panel Options → Background](panel-options.md#background).
+
 1. Use a world-map image as the **Background** (public-domain equirectangular SVGs are available on [Wikimedia Commons](https://commons.wikimedia.org/wiki/Category:SVG_blank_maps_of_the_world)); set **Image Fit** to `contain` and enable **Move With Map**.
 2. Place a node per PoP/city at its location on the map; the bundled **Country Flags** icon set (ISO two-letter codes) marks each PoP's country.
 3. Add the submarine/backbone links between them with per-direction queries and capacities; use **Port Labels** for the cable/system names.
@@ -157,6 +163,9 @@ Hovering the link shows usage, bandwidth, throughput %, and a mini graph.
 
 ![Rack port status demo](../img/use-cases/wm-rack-ports.png)
 
+!!! tip "Background image hosting"
+    The background is a **URL** — use any `https://` link, or drop the file in Grafana's `public/` folder and reference it as `public/img/<name>` (air-gap friendly). `data:` URLs are rejected. Details: [Panel Options → Background](panel-options.md#background).
+
 1. Use a rack/faceplate drawing as the **Background** image.
 2. Add one small node per port (label = port number) positioned over the faceplate; no links needed.
 3. Set each node's **Status Query** to that port's status series and add **Threshold Mappings** — e.g. `0 → red` (down), `1 → green` (up), `2 → gray` (admin-disabled) — with **Color Target = Background**.
@@ -170,6 +179,9 @@ Hovering the link shows usage, bandwidth, throughput %, and a mini graph.
 **Goal:** one rack's rear elevation — router, firewall, switches, servers — with the actual cable runs between ports **and** the A/B power feeds, so a failed feed or unpatched port is visible at a glance.
 
 ![Rack cabling demo](../img/use-cases/wm-rack-cabling.png)
+
+!!! tip "Background image hosting"
+    The background is a **URL** — use any `https://` link, or drop the file in Grafana's `public/` folder and reference it as `public/img/<name>` (air-gap friendly). `data:` URLs are rejected. Details: [Panel Options → Background](panel-options.md#background).
 
 1. Draw the rack rear elevation (device faceplates, cable channels, PDU strips) as the **Background** image with **Move With Map** enabled.
 2. Add one small node per port/NIC/PSU-inlet/PDU-outlet, placed over the drawn openings, each with a **Status Query** and threshold mappings (`0 → red`, `1 → green`, `2 → gray`).


### PR DESCRIPTION
Closes the gap found while reviewing the background-image docs: recipes said *"paste the image URL"* without saying where that URL comes from.

- **Panel Options → Background** now opens with a green **tip admonition** — the three hosting options (any `https://` URL · Grafana's `public/` folder with a relative path for air-gapped setups · a static sidecar like the demo exporter on :8080) plus an SVG-over-PNG hint — and an expanded orange **warning admonition** that `data:`/`file:` schemes are rejected by sanitization.
- All four background-based use cases (**#4 floor plan, #9 world map, #10 rack ports, #11 rack rear**) get a compact colored callout with the essentials and a link to the full guidance.

mkdocs-material renders these as the colored callout boxes (green tip / orange warning), so the guidance is impossible to miss.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds clear hosting guidance for background images in the Weathermap docs. A tip in Panel Options → Background lists three options (`https://` URL, Grafana `public/` path, or a small sidecar) with an SVG-over-PNG hint; the warning now states only relative Grafana paths and `http`/`https` are accepted (rejects `data:`/`file:`), and each background-based use case gets a compact callout linking to the full guidance.

<sup>Written for commit 8e5a0db7c45394bf458a1ab9a1cb8efd4f79ac2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

