### PR TITLE
docs: background URLs accept http and https, not https-only

### DIFF
--- a/website/docs/guide/panel-options.md
+++ b/website/docs/guide/panel-options.md
@@ -9,7 +9,7 @@ Panel-level options apply to the whole weathermap. Open the panel options sideba
 !!! tip "Where do I host my floor plan / map image?"
     The **Image** field takes a URL — the plugin does not upload files. Your options:
 
-    1. **Any `https://` URL** your dashboard viewers' browsers can reach (an internal web server, a wiki attachment, an S3/object-storage link, Wikimedia Commons, ...).
+    1. **Any `http://` or `https://` URL** your dashboard viewers' browsers can reach (an internal web server, a wiki attachment, an S3/object-storage link, Wikimedia Commons, ...). Prefer `https` where you have it — but plain `http` is accepted, which matters for lab and air-gapped intranets.
     2. **Grafana's own `public/` folder** — copy the file onto the Grafana server, e.g. `/usr/share/grafana/public/img/floorplan.png`, then use the relative URL `public/img/floorplan.png`. Works fully air-gapped and survives viewer networks that can't reach external hosts.
     3. **A provisioned sidecar** — the demo dashboards serve their floor-plan and world-map images from the `testing/` stack's exporter container on `:8080`; any tiny static file server works the same way.
 

--- a/website/docs/guide/use-cases.md
+++ b/website/docs/guide/use-cases.md
@@ -74,7 +74,7 @@ Hovering the link shows usage, bandwidth, throughput %, and a mini graph.
 ![Building floor plan demo](../img/use-cases/wm-floorplan.png)
 
 !!! tip "Background image hosting"
-    The background is a **URL** — use any `https://` link, or drop the file in Grafana's `public/` folder and reference it as `public/img/<name>` (air-gap friendly). `data:` URLs are rejected. Details: [Panel Options → Background](panel-options.md#background).
+    The background is a **URL** — any `http://` or `https://` link works, or drop the file in Grafana's `public/` folder and reference it as `public/img/<name>` (air-gap friendly). `data:` URLs are rejected. Details: [Panel Options → Background](panel-options.md#background).
 
 1. **Panel Options → Background → Image**: paste the floor-plan image URL; set **Image Fit** to `contain`.
 2. Enable **Move With Map** so the image scales and pans with the nodes.
@@ -147,7 +147,7 @@ Hovering the link shows usage, bandwidth, throughput %, and a mini graph.
 ![Global backbone demo](../img/use-cases/wm-global-backbone.png)
 
 !!! tip "Background image hosting"
-    The background is a **URL** — use any `https://` link, or drop the file in Grafana's `public/` folder and reference it as `public/img/<name>` (air-gap friendly). `data:` URLs are rejected. Details: [Panel Options → Background](panel-options.md#background).
+    The background is a **URL** — any `http://` or `https://` link works, or drop the file in Grafana's `public/` folder and reference it as `public/img/<name>` (air-gap friendly). `data:` URLs are rejected. Details: [Panel Options → Background](panel-options.md#background).
 
 1. Use a world-map image as the **Background** (public-domain equirectangular SVGs are available on [Wikimedia Commons](https://commons.wikimedia.org/wiki/Category:SVG_blank_maps_of_the_world)); set **Image Fit** to `contain` and enable **Move With Map**.
 2. Place a node per PoP/city at its location on the map; the bundled **Country Flags** icon set (ISO two-letter codes) marks each PoP's country.
@@ -164,7 +164,7 @@ Hovering the link shows usage, bandwidth, throughput %, and a mini graph.
 ![Rack port status demo](../img/use-cases/wm-rack-ports.png)
 
 !!! tip "Background image hosting"
-    The background is a **URL** — use any `https://` link, or drop the file in Grafana's `public/` folder and reference it as `public/img/<name>` (air-gap friendly). `data:` URLs are rejected. Details: [Panel Options → Background](panel-options.md#background).
+    The background is a **URL** — any `http://` or `https://` link works, or drop the file in Grafana's `public/` folder and reference it as `public/img/<name>` (air-gap friendly). `data:` URLs are rejected. Details: [Panel Options → Background](panel-options.md#background).
 
 1. Use a rack/faceplate drawing as the **Background** image.
 2. Add one small node per port (label = port number) positioned over the faceplate; no links needed.
@@ -181,7 +181,7 @@ Hovering the link shows usage, bandwidth, throughput %, and a mini graph.
 ![Rack cabling demo](../img/use-cases/wm-rack-cabling.png)
 
 !!! tip "Background image hosting"
-    The background is a **URL** — use any `https://` link, or drop the file in Grafana's `public/` folder and reference it as `public/img/<name>` (air-gap friendly). `data:` URLs are rejected. Details: [Panel Options → Background](panel-options.md#background).
+    The background is a **URL** — any `http://` or `https://` link works, or drop the file in Grafana's `public/` folder and reference it as `public/img/<name>` (air-gap friendly). `data:` URLs are rejected. Details: [Panel Options → Background](panel-options.md#background).
 
 1. Draw the rack rear elevation (device faceplates, cable channels, PDU strips) as the **Background** image with **Move With Map** enabled.
 2. Add one small node per port/NIC/PSU-inlet/PDU-outlet, placed over the drawn openings, each with a **Status Query** and threshold mappings (`0 → red`, `1 → green`, `2 → gray`).


### PR DESCRIPTION
Correction to #251: the hosting callouts said "any `https://` link", but `isSafeUrl` accepts both `http` and `https` (locked by its unit tests). All five callouts now say so, with a note that plain `http` matters for lab/air-gapped intranets while `https` is preferred where available.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix docs to state that background image URLs can be `http://` or `https://`, matching the sanitizer and `isSafeUrl` tests. Adds a brief note that `https` is preferred, but `http` is allowed for lab and air-gapped intranets.

<sup>Written for commit 5846ffb6d1b54229b07d9ca6e10c4a03ec2d9c14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

