### PR TITLE
docs+test: multi-datasource guide and frame-shape resolution tests (#253)

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -397,7 +397,7 @@ describe('datasource frame shapes resolve (#253)', () => {
       name: 'wm_link_bps {device="core-a", direction="tx"}',
       fields: [
         { name: '_time', type: FieldType.time, values: [1000, 2000] },
-        { name: '_value', type: FieldType.number, values: [42.5, 43.5] },
+        { name: '_value', type: FieldType.number, values: [42.5, 43.5], labels: { device: 'core-a', direction: 'tx' } },
       ],
     });
     expect(getValueField(frame).name).toBe('_value');
@@ -417,16 +417,21 @@ describe('datasource frame shapes resolve (#253)', () => {
     expect(getDataFrameName(frame, [frame])).toBe('core-a→core-b tx');
   });
 
-  test('Elasticsearch shape: @timestamp + aggregation-named value field', () => {
+  test('Elasticsearch shape: @timestamp + aggregation field with an alias', () => {
+    // The query Alias lands as the display name on the value field.
     const frame = toDataFrame({
-      name: 'core-a→core-b tx',
       fields: [
         { name: '@timestamp', type: FieldType.time, values: [1000, 2000] },
-        { name: 'Average bps', type: FieldType.number, values: [7, 9] },
+        {
+          name: 'Average bps',
+          type: FieldType.number,
+          values: [7, 9],
+          config: { displayNameFromDS: 'core-a→core-b tx' },
+        },
       ],
     });
     expect(getValueField(frame).name).toBe('Average bps');
-    expect(getDataFrameName(frame, [frame])).toContain('core-a→core-b tx');
+    expect(getDataFrameName(frame, [frame])).toBe('core-a→core-b tx');
   });
 
   test('Zabbix-like shape: item-named numeric field, no per-field display name', () => {

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,10 +1,11 @@
-import { toDataFrame } from '@grafana/data';
+import { FieldType, toDataFrame } from '@grafana/data';
 import { defaultNodes, getData, legacyWeathermap, theme } from 'testData';
 import { DrawnNode, Weathermap } from 'types';
 import {
   addViaToLink,
   buildQueryOptions,
   getDataFrameName,
+  getValueField,
   resolveLinkChain,
   spreadLabels,
   aggregateFieldValues,
@@ -384,6 +385,63 @@ describe('sampleAtTime (raw step-hold, no clamping)', () => {
 
 // #204: duplicate display names must behave deterministically — the dropdown
 // keeps the first occurrence, and the panel's value map does the same.
+// #253: the panel is datasource-agnostic because getValueField resolves the
+// value field by numeric TYPE and getDataFrameName falls back through
+// Grafana's display-name chain. Lock resolution for the frame shapes the
+// major datasources actually emit — no containers needed.
+describe('datasource frame shapes resolve (#253)', () => {
+  test('InfluxDB Flux shape: typed _time/_value fields, name from tag set', () => {
+    // Real Flux frames mark _time as FieldType.time and carry the tag set in
+    // the frame name; the value field is literally named _value.
+    const frame = toDataFrame({
+      name: 'wm_link_bps {device="core-a", direction="tx"}',
+      fields: [
+        { name: '_time', type: FieldType.time, values: [1000, 2000] },
+        { name: '_value', type: FieldType.number, values: [42.5, 43.5] },
+      ],
+    });
+    expect(getValueField(frame).name).toBe('_value');
+    expect(getDataFrameName(frame, [frame])).toContain('core-a');
+  });
+
+  test('InfluxQL shape: Time/mean fields with an alias', () => {
+    // Alias-by lands as the display name on the value field.
+    const frame = toDataFrame({
+      name: 'wm_link_bps.mean',
+      fields: [
+        { name: 'Time', type: FieldType.time, values: [1000, 2000] },
+        { name: 'mean', type: FieldType.number, values: [10, 20], config: { displayNameFromDS: 'core-a→core-b tx' } },
+      ],
+    });
+    expect(getValueField(frame).name).toBe('mean');
+    expect(getDataFrameName(frame, [frame])).toBe('core-a→core-b tx');
+  });
+
+  test('Elasticsearch shape: @timestamp + aggregation-named value field', () => {
+    const frame = toDataFrame({
+      name: 'core-a→core-b tx',
+      fields: [
+        { name: '@timestamp', type: FieldType.time, values: [1000, 2000] },
+        { name: 'Average bps', type: FieldType.number, values: [7, 9] },
+      ],
+    });
+    expect(getValueField(frame).name).toBe('Average bps');
+    expect(getDataFrameName(frame, [frame])).toContain('core-a→core-b tx');
+  });
+
+  test('Zabbix-like shape: item-named numeric field, no per-field display name', () => {
+    const frame = toDataFrame({
+      name: 'core-a: Interface ge-0/0/1(): Bits sent',
+      fields: [
+        { name: 'Time', values: [1000, 2000] },
+        { name: 'Interface ge-0/0/1(): Bits sent', values: [100, 200] },
+      ],
+    });
+    expect(getValueField(frame).values[1]).toBe(200);
+    expect(getDataFrameName(frame, [frame])).toContain('Bits sent');
+  });
+});
+
 describe('duplicate display names are deterministic (#204)', () => {
   const dupFrame = (refId: string, displayName: string, value: number) =>
     toDataFrame({

--- a/website/docs/guide/datasources.md
+++ b/website/docs/guide/datasources.md
@@ -1,0 +1,119 @@
+# Data Sources
+
+The weathermap is **datasource-agnostic**: it reads whatever time series Grafana hands it. Any datasource that returns a time field and a numeric value field works — Prometheus, InfluxDB, Elasticsearch, Zabbix, and most others.
+
+!!! tip "The one rule that matters everywhere"
+    The panel binds link sides to series by **display name** — the name you see in the link editor's *A/B Side Query* dropdown. Keep your legends/aliases **stable**: renaming a series later breaks the binding, and duplicate display names resolve to the **first** matching series. Always pick series from the dropdown rather than typing names by hand.
+
+## The universal process
+
+Whatever the datasource, building a weathermap dashboard is the same five steps:
+
+1. **Provision the datasource** in Grafana (Connections → Data sources).
+2. **Add the panel queries** — typically one series per link side (A = transmit, Z = receive), one per link.
+3. **Name each series stably** with the datasource's legend/alias feature (examples per source below).
+4. **Bind the series**: in the panel editor open **Links**, select a link, and pick the series in the **A Side Query** and **Z Side Query** dropdowns.
+5. **Set bandwidth and thresholds** so the color scale means something.
+
+The demo stack (`cd testing && docker compose up --build`) runs the same simulated WAN metrics through **Prometheus, InfluxDB, and Elasticsearch simultaneously**, so you can compare the three bindings side by side in the *Datasource Compatibility* dashboard.
+
+---
+
+## Prometheus
+
+The canonical setup — all bundled demo dashboards use it.
+
+**Query** (link utilization in bits/s, one direction):
+
+```promql
+wm_link_bps{device="core-a", peer="core-b", direction="tx"}
+```
+
+**Legend:** set the query's *Legend* field so the display name is stable and readable:
+
+```
+{{device}}→{{peer}} {{iface}} {{direction}}
+```
+
+If your source exposes counters instead of gauges, wrap with `rate()`:
+
+```promql
+rate(ifHCOutOctets{ifName="ge-0/0/1"}[5m]) * 8
+```
+
+**Binding:** the legend text is exactly what appears in the A/B Side Query dropdowns.
+
+---
+
+## InfluxDB
+
+Works with both query languages. The demo stack provisions InfluxDB 2.x (bucket `wm`, org `wm`) on `:8086`, fed by the same simulator.
+
+**Flux:**
+
+```flux
+from(bucket: "wm")
+  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+  |> filter(fn: (r) => r._measurement == "wm_link_bps")
+  |> filter(fn: (r) => r.device == "core-a" and r.direction == "tx")
+  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)
+```
+
+Flux names series from the tag set (e.g. `wm_link_bps {device="core-a", direction="tx", ...}`). To control the display name, add:
+
+```flux
+  |> map(fn: (r) => ({ r with _field: "core-a→core-b tx" }))
+```
+
+**InfluxQL** (v1 compatibility):
+
+```sql
+SELECT mean("value") FROM "wm_link_bps"
+WHERE ("device" = 'core-a' AND "direction" = 'tx') AND $timeFilter
+GROUP BY time($__interval) fill(null)
+```
+
+Use **Alias by** to fix the display name: `core-a→core-b tx`.
+
+**Frame shape note:** Influx value fields arrive named `_value` (Flux) or `mean` (InfluxQL) rather than `Value` — the panel resolves the value field by *numeric type*, not by name, so both bind cleanly. This behavior is locked by unit tests.
+
+---
+
+## Elasticsearch
+
+For metrics stored as documents (e.g. from Beats/Logstash or the demo bridge writing to the `wm-metrics` index on `:9200`).
+
+**Query setup:**
+
+- **Query:** Lucene filter, e.g. `device:core-a AND direction:tx`
+- **Metric:** `Average` of your value field, e.g. `bps`
+- **Group by:** `Date Histogram` on `@timestamp` (interval `auto`)
+- Optional second group: `Terms` on `link.keyword` to fan out one query into per-link series
+
+**Alias:** set the query *Alias* to stabilize the display name, e.g. `{{term link.keyword}} tx` or a literal `core-a→core-b tx`.
+
+**Frame shape note:** ES frames often carry names like `Average bps` combined with the term value; whatever ends up as the display name in Grafana's legend is what the link editor's dropdown shows — pick from the dropdown and it binds.
+
+---
+
+## Zabbix
+
+The [Zabbix datasource plugin](https://grafana.com/grafana/plugins/alexanderzobnin-zabbix-datasource/) works with the weathermap, but it's **not part of the demo stack** (a full Zabbix server + agents is too heavy for a test compose). The pattern:
+
+1. Install and configure the Zabbix plugin datasource.
+2. Query per link side using the Group/Host/Item selectors, e.g.:
+   - **Group:** `Routers` · **Host:** `core-a` · **Item:** `Interface ge-0/0/1(): Bits sent`
+   - Z side: the matching `Bits received` item on the peer, or the same host's receive item — match your monitoring convention.
+3. Zabbix's item name becomes the series display name — item names are stable by nature, which suits the binding rule well.
+4. Use *Functions → Alias* (`setAlias`) in the Zabbix query editor if you want shorter dropdown names.
+
+!!! note "Counters vs gauges"
+    Zabbix network items are usually already rate-calculated (`Bits sent/received` deltas). If yours are raw counters, add the `delta`/`rate` processing on the Zabbix side or via the query editor functions, the same way you'd `rate()` in Prometheus.
+
+---
+
+## Troubleshooting bindings
+
+- **Dropdown shows the series but the link stays `n/a`** — the display name changed after binding (legend edited, label values changed). Re-pick from the dropdown.
+- **Two series share a name** — the panel deterministically uses the **first**; give them distinct aliases.
+- **No value resolves** — confirm the query returns a numeric field; string-only frames are skipped (the panel logs a console warning).

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
       - Panel Options: guide/panel-options.md
       - Interactions & Editing: guide/interactions.md
       - Use Cases: guide/use-cases.md
+      - Data Sources: guide/datasources.md
   - Customization: customization.md
   - Icon Reference: icons.md
   - Reference: reference.md


### PR DESCRIPTION
PR A of #253.

**Docs — new [Data Sources] page** (nav: Tutorial → Data Sources): the golden display-name binding rule in a colored callout, the universal five-step process, and per-source recipes — Prometheus legends, InfluxDB Flux + InfluxQL with alias guidance, Elasticsearch metric/group-by/alias setup, and the Zabbix pattern (documented-only per the plan). Ends with a bindings troubleshooting section.

**Tests — frame-shape resolution locked in CI** (`utils.test.ts`): Flux (`_time`/`_value`, tag-set frame name), InfluxQL (alias via `displayNameFromDS`), Elasticsearch (`@timestamp` + `Average bps`), and Zabbix-like item-named fields all resolve through `getValueField`/`getDataFrameName`. Suite: 165 tests green.

PR B (compose: InfluxDB + Elasticsearch + bridge + compat dashboard) follows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Data Sources guide and tightens datasource-agnostic value/name resolution with tests that mirror real frame shapes to keep link bindings stable across major sources.

- New Features
  - Docs: Added a Data Sources page (Tutorial → Data Sources) covering the display-name binding rule, a 5-step setup, per-source recipes (Prometheus, InfluxDB Flux/InfluxQL, Elasticsearch, Zabbix), and troubleshooting. Updated nav.
  - Tests: Added frame-shape resolution tests in `utils.test.ts` to verify `getValueField` and `getDataFrameName` for Flux (typed `_time`/`_value`, tag set via field labels), InfluxQL (alias via `displayNameFromDS`), Elasticsearch (`@timestamp` + aggregation field with alias via `displayNameFromDS`), and Zabbix (item-named fields). Fixtures type time fields and follow Grafana’s display-name chain.

<sup>Written for commit 55c78302a6091f1313b63d7823befcabc18bb0f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

