### PR TITLE
fix: disable Zabbix data alignment so per-series frames bind

### DIFF
--- a/testing/grafana/dashboards/wm-wan-zabbix.json
+++ b/testing/grafana/dashboards/wm-wan-zabbix.json
@@ -63,7 +63,7 @@
           "options": {
             "showDisabledItems": false,
             "skipEmptyValues": false,
-            "disableDataAlignment": false,
+            "disableDataAlignment": true,
             "useZabbixValueMapping": false
           }
         }

--- a/testing/scripts/generate-datasource-dashboards.py
+++ b/testing/scripts/generate-datasource-dashboards.py
@@ -96,7 +96,9 @@ zabbix = make(
             "options": {
                 "showDisabledItems": False,
                 "skipEmptyValues": False,
-                "disableDataAlignment": False,
+                # Alignment merges all series into ONE wide frame, which binds
+                # only its first field in the panel's per-frame mapping (#259).
+                "disableDataAlignment": True,
                 "useZabbixValueMapping": False,
             },
         }


### PR DESCRIPTION
The Zabbix dashboard rendered all-n/a with no hover graph. Wire-level probes showed perfect per-series frames — but extracting the **browser-side** frames from Grafana's scene graph revealed the Zabbix frontend's *data alignment* had merged all 204 series into **one wide frame** (Time + 204 value fields). The panel maps one display name per frame (first numeric field), so exactly one series bound.

Fix: `disableDataAlignment: true` on the target keeps one frame per item. Verified in a real browser: 0 n/a labels, healthy nodes, hover tooltip with the In/Out traffic graph — identical to the Prometheus dashboard. The earlier speculative host-prefix rename is removed (wrong hypothesis).

The underlying product gap (wide frames bind only their first field — affects Zabbix defaults and Grafana *join* transformations) is filed separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Zabbix data alignment to keep one frame per series, fixing n/a labels and restoring the hover traffic graph. Panels now bind all series correctly, matching the Prometheus dashboard.

- **Bug Fixes**
  - Set `disableDataAlignment: true` in the Zabbix panel options (dashboard and generator) to prevent wide-frame merges that bind only the first numeric field.
  - Removed the earlier host-prefix rename hypothesis.

<sup>Written for commit fbd46ac0c21e5aa06e5765b8b6c1da280e55e2c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

