### PR TITLE
feat: OpenSky Network live aviation feed for the demo stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ grafana-weathermap-*.zip
 playwright/.auth/
 playwright-report/
 test-results/
+
+# Local demo credentials (OpenSky API client, #274)
+testing/.env

--- a/testing/.env.example
+++ b/testing/.env.example
@@ -1,0 +1,14 @@
+# OpenSky Network API credentials for the live aviation feed (#274).
+# Copy to testing/.env (git-ignored) and fill in your API client values from
+# https://opensky-network.org account settings. The exporter only starts with
+# the "opensky" compose profile:  docker compose --profile opensky up -d
+OPENSKY_CLIENT_ID=
+OPENSKY_CLIENT_SECRET=
+
+# Optional overrides (defaults shown). Keep the bounding box under 25 square
+# degrees so each poll costs 1 API credit; 30s polling spends ~2,880 of the
+# 4,000 standard daily credits.
+#OPENSKY_POLL_SECONDS=30
+#OPENSKY_BBOX=49.5,2.5,52.5,7.5
+#OPENSKY_CORRIDOR_KM=30
+#OPENSKY_ROUTES=[{"route":"AMS-BRU","a":[52.31,4.76],"z":[50.90,4.48]}]

--- a/testing/docker-compose.yml
+++ b/testing/docker-compose.yml
@@ -87,6 +87,26 @@ services:
       # default 128M PHP memory_limit (API returns 500). The web image wires
       # ZBX_MEMORYLIMIT into php-fpm's memory_limit.
       - ZBX_MEMORYLIMIT=1024M
+  # OpenSky live aviation feed (#274): real flight positions exported as
+  # moving_entity_* metrics for the aviation demo. Opt-in profile so the
+  # default stack never spends API credits:
+  #   cp .env.example .env   (fill in credentials)
+  #   docker compose --profile opensky up -d
+  opensky:
+    build:
+      context: opensky
+      dockerfile: Dockerfile
+    profiles:
+      - opensky
+    ports:
+      - 9101:9101
+    environment:
+      - OPENSKY_CLIENT_ID=${OPENSKY_CLIENT_ID:-}
+      - OPENSKY_CLIENT_SECRET=${OPENSKY_CLIENT_SECRET:-}
+      - OPENSKY_POLL_SECONDS=${OPENSKY_POLL_SECONDS:-30}
+      - OPENSKY_BBOX=${OPENSKY_BBOX:-49.5,2.5,52.5,7.5}
+      - OPENSKY_CORRIDOR_KM=${OPENSKY_CORRIDOR_KM:-30}
+      - OPENSKY_ROUTES=${OPENSKY_ROUTES:-}
   bridge:
     build:
       context: bridge

--- a/testing/exporter/prometheus.yml
+++ b/testing/exporter/prometheus.yml
@@ -22,3 +22,10 @@ scrape_configs:
       - targets:
           - localhost:9090
           - exporter:8080
+  # OpenSky live aviation feed (#274). Only up when the compose "opensky"
+  # profile is running; otherwise the target is simply reported down.
+  - job_name: opensky
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - opensky:9101

--- a/testing/opensky/Dockerfile
+++ b/testing/opensky/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.12-alpine
+COPY opensky_exporter.py /opensky_exporter.py
+CMD ["python", "/opensky_exporter.py"]

--- a/testing/opensky/README.md
+++ b/testing/opensky/README.md
@@ -1,0 +1,106 @@
+# OpenSky Network → Prometheus exporter
+
+Live aviation feed for the demo environment (#274). Polls the
+[OpenSky Network](https://opensky-network.org) REST API for real aircraft
+positions and exposes them as Prometheus metrics, following the project's
+standard demo architecture:
+
+```text
+Open data (OpenSky REST API, OAuth2)
+  → custom Prometheus exporter (this directory, stdlib Python)
+  → Prometheus scrape
+  → Grafana query
+  → Network Weathermap NG (route links; moving-entity overlay per #266)
+```
+
+## Setup
+
+1. Create an API client in your OpenSky account settings.
+2. Copy the env template and fill in the credentials (the real file is
+   git-ignored — never commit it):
+
+   ```sh
+   cd testing
+   cp .env.example .env
+   ```
+
+3. Start the stack with the opt-in profile (the default stack never spends
+   API credits):
+
+   ```sh
+   docker compose --profile opensky up -d --build
+   ```
+
+4. Metrics: <http://localhost:9101/metrics>, scraped by the bundled
+   Prometheus as job `opensky`.
+
+## Credit budget
+
+Standard API access grants **4,000 credits/day**. A `/states/all` call with a
+bounding box under 25 square degrees costs 1 credit; the defaults (15 sq-deg
+box, 30 s poll) spend ~2,880/day. Live remaining credits are exported as
+`opensky_api_credits_remaining` (from the `X-Rate-Limit-Remaining` header) so
+a dashboard stat panel can watch the budget. Feeding ADS-B data to OpenSky
+unlocks a higher allowance — see their "Learn how to feed" documentation.
+
+## Metrics
+
+Feed health and aggregates:
+
+| Metric | Meaning |
+|---|---|
+| `opensky_up` | last poll succeeded (1/0) |
+| `opensky_api_credits_remaining` | remaining daily API credits |
+| `opensky_aircraft_in_bbox` | aircraft inside the configured bounding box |
+| `opensky_route_aircraft{route_id}` | aircraft currently inside a route corridor |
+
+Per-entity series use the generic `moving_entity_*` scheme so the weathermap
+moving-entity overlay (#266) stays domain-agnostic:
+
+| Metric | Meaning |
+|---|---|
+| `moving_entity_progress_ratio{entity_id,route_id}` | 0..1 progress of the tracked aircraft along the corridor (schematic mode input) |
+| `moving_entity_latitude{entity_id,mode="aircraft"}` | position, for a future geospatial mode |
+| `moving_entity_longitude{entity_id,mode="aircraft"}` | position, for a future geospatial mode |
+| `moving_entity_altitude_meters{entity_id}` | barometric altitude |
+| `moving_entity_speed_mps{entity_id}` | ground speed |
+| `moving_entity_heading_degrees{entity_id}` | true track |
+
+Schematic-mode binding (`Airport A ── ✈ 61% ── Airport B`): query
+`moving_entity_progress_ratio` with legend format `{{route_id}} progress` and
+bind that display name in the panel. `entity_id` is the flight callsign
+(ICAO 24-bit address when no callsign is broadcast).
+
+## Route corridors
+
+A route is an A→Z airport pair. An aircraft counts as "on route" when its
+perpendicular distance to the corridor centerline is under
+`OPENSKY_CORRIDOR_KM` (default 30 km); progress is its projection onto the
+segment, clamped to 0..1. The exporter keeps following the same aircraft
+while it stays inside the corridor, so progress moves smoothly instead of
+jumping between corridor occupants.
+
+Defaults are three corridors inside the default Benelux box (AMS-BRU,
+AMS-DUS, BRU-DUS — dense overflight traffic, so values move even when no
+flight is literally flying that city pair). Override via `OPENSKY_ROUTES`
+(JSON, see `.env.example`), and keep custom bounding boxes under 25 square
+degrees to stay at 1 credit per poll.
+
+## Configuration
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `OPENSKY_CLIENT_ID` | — | API client ID (required) |
+| `OPENSKY_CLIENT_SECRET` | — | API client secret (required) |
+| `OPENSKY_POLL_SECONDS` | `30` | poll interval (floor 15 s) |
+| `OPENSKY_BBOX` | `49.5,2.5,52.5,7.5` | `lamin,lomin,lamax,lomax` |
+| `OPENSKY_CORRIDOR_KM` | `30` | corridor half-width |
+| `OPENSKY_ROUTES` | 3 Benelux corridors | JSON route list |
+| `OPENSKY_PORT` | `9101` | metrics port |
+
+## Scope
+
+Demo/testing infrastructure only — not part of the shipped plugin, not an
+ADS-B receiver, and not flight-tracking software (see the scope boundaries
+in #272). A failed poll marks `opensky_up 0` and the exporter keeps serving
+metrics; it never crashes the stack.

--- a/testing/opensky/opensky_exporter.py
+++ b/testing/opensky/opensky_exporter.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""OpenSky Network -> Prometheus exporter for the live aviation demo (#274).
+
+Polls the OpenSky REST API (OAuth2 client-credentials) for aircraft state
+vectors inside a bounding box. Feed health and aggregates use opensky_*
+names; the per-aircraft series use the generic moving_entity_* scheme so the
+weathermap's moving-entity overlay (#266) stays domain-agnostic:
+
+  opensky_up                              last poll succeeded (1/0)
+  opensky_api_credits_remaining           X-Rate-Limit-Remaining from the API
+  opensky_aircraft_in_bbox                aircraft inside the bounding box
+  opensky_route_aircraft{route_id}        aircraft currently inside a corridor
+  moving_entity_progress_ratio{entity_id,route_id}  0..1 corridor progress
+  moving_entity_latitude{entity_id,mode="aircraft"}  position (geospatial,
+  moving_entity_longitude{entity_id,mode="aircraft"} for future map mode)
+  moving_entity_altitude_meters{entity_id}
+  moving_entity_speed_mps{entity_id}
+  moving_entity_heading_degrees{entity_id}
+
+Schematic mode binds progress_ratio per route (Grafana legend
+{{route_id}} progress); the lat/lon/alt/heading series are exported now so
+a later geospatial mode needs no exporter change.
+
+Credit budget: a bounding box under 25 square degrees costs 1 credit per
+/states/all call; the standard allowance is 4,000/day. The default 30s poll
+spends ~2,880/day. Stdlib only, matching testing/bridge/bridge.py.
+"""
+
+import json
+import math
+import os
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+TOKEN_URL = (
+    "https://auth.opensky-network.org/auth/realms/opensky-network"
+    "/protocol/openid-connect/token"
+)
+STATES_URL = "https://opensky-network.org/api/states/all"
+
+CLIENT_ID = os.environ.get("OPENSKY_CLIENT_ID", "")
+CLIENT_SECRET = os.environ.get("OPENSKY_CLIENT_SECRET", "")
+POLL_SECONDS = max(15, int(os.environ.get("OPENSKY_POLL_SECONDS", "30")))
+PORT = int(os.environ.get("OPENSKY_PORT", "9101"))
+# lamin,lomin,lamax,lomax — default is a 15 sq-deg box over the Benelux /
+# west-Germany corridor (dense traffic, 1 credit per call).
+BBOX = [float(v) for v in os.environ.get("OPENSKY_BBOX", "49.5,2.5,52.5,7.5").split(",")]
+# Perpendicular distance from the corridor centerline within which an
+# aircraft counts as "on route".
+CORRIDOR_KM = float(os.environ.get("OPENSKY_CORRIDOR_KM", "30"))
+
+# Route corridors as airport pairs inside the default bbox. Override with
+# OPENSKY_ROUTES='[{"route":"AMS-BRU","a":[52.31,4.76],"z":[50.90,4.48]}]'.
+DEFAULT_ROUTES = [
+    {"route": "AMS-BRU", "a": [52.31, 4.76], "z": [50.90, 4.48]},
+    {"route": "AMS-DUS", "a": [52.31, 4.76], "z": [51.29, 6.77]},
+    {"route": "BRU-DUS", "a": [50.90, 4.48], "z": [51.29, 6.77]},
+]
+ROUTES = json.loads(os.environ.get("OPENSKY_ROUTES", "")) if os.environ.get("OPENSKY_ROUTES") else DEFAULT_ROUTES
+
+KM_PER_DEG = 111.32
+
+state_lock = threading.Lock()
+metrics = {
+    "up": 0,
+    "credits": float("nan"),
+    "aircraft_in_bbox": 0,
+    # route -> {"aircraft": n, "progress": p, "velocity": v} (progress/velocity
+    # omitted when no aircraft is tracked on the corridor)
+    "routes": {},
+}
+# route -> icao24 of the aircraft currently tracked, so progress follows one
+# aircraft across polls instead of jumping between corridor occupants.
+tracked = {}
+
+token_cache = {"token": None, "expires_at": 0.0}
+
+
+def get_token():
+    now = time.time()
+    if token_cache["token"] and now < token_cache["expires_at"] - 60:
+        return token_cache["token"]
+    body = urllib.parse.urlencode(
+        {
+            "grant_type": "client_credentials",
+            "client_id": CLIENT_ID,
+            "client_secret": CLIENT_SECRET,
+        }
+    ).encode()
+    req = urllib.request.Request(
+        TOKEN_URL, data=body, headers={"Content-Type": "application/x-www-form-urlencoded"}
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        payload = json.loads(resp.read())
+    token_cache["token"] = payload["access_token"]
+    token_cache["expires_at"] = now + float(payload.get("expires_in", 1800))
+    return token_cache["token"]
+
+
+def fetch_states():
+    params = urllib.parse.urlencode(
+        {"lamin": BBOX[0], "lomin": BBOX[1], "lamax": BBOX[2], "lomax": BBOX[3]}
+    )
+    req = urllib.request.Request(
+        f"{STATES_URL}?{params}", headers={"Authorization": f"Bearer {get_token()}"}
+    )
+    try:
+        resp = urllib.request.urlopen(req, timeout=20)
+    except urllib.error.HTTPError as err:
+        if err.code == 401:
+            # Token invalidated server-side before its stated expiry: refetch once.
+            token_cache["token"] = None
+            req = urllib.request.Request(
+                f"{STATES_URL}?{params}", headers={"Authorization": f"Bearer {get_token()}"}
+            )
+            resp = urllib.request.urlopen(req, timeout=20)
+        else:
+            raise
+    with resp:
+        credits = resp.headers.get("X-Rate-Limit-Remaining")
+        payload = json.loads(resp.read())
+    return payload.get("states") or [], credits
+
+
+def project_km(lat, lon, ref_lat):
+    """Equirectangular projection good enough for <500 km corridors."""
+    return lon * KM_PER_DEG * math.cos(math.radians(ref_lat)), lat * KM_PER_DEG
+
+
+def corridor_position(route, lat, lon):
+    """Return (progress 0..1, cross-track km) of a point along route a->z."""
+    (a_lat, a_lon), (z_lat, z_lon) = route["a"], route["z"]
+    ref = (a_lat + z_lat) / 2
+    ax, ay = project_km(a_lat, a_lon, ref)
+    zx, zy = project_km(z_lat, z_lon, ref)
+    px, py = project_km(lat, lon, ref)
+    dx, dy = zx - ax, zy - ay
+    length_sq = dx * dx + dy * dy
+    if length_sq == 0:
+        return 0.0, float("inf")
+    t = ((px - ax) * dx + (py - ay) * dy) / length_sq
+    cross = abs((px - ax) * dy - (py - ay) * dx) / math.sqrt(length_sq)
+    return t, cross
+
+
+def update_routes(states):
+    routes = {}
+    for route in ROUTES:
+        occupants = {}
+        for s in states:
+            icao24, callsign, lon, lat = s[0], s[1], s[5], s[6]
+            baro_alt, on_ground, velocity, heading = s[7], s[8], s[9], s[10]
+            if lat is None or lon is None or on_ground:
+                continue
+            t, cross = corridor_position(route, lat, lon)
+            if cross <= CORRIDOR_KM and -0.05 <= t <= 1.05:
+                occupants[icao24] = {
+                    "progress": max(0.0, min(1.0, t)),
+                    "cross": cross,
+                    "entity_id": (callsign or "").strip() or icao24,
+                    "lat": lat,
+                    "lon": lon,
+                    "altitude": baro_alt,
+                    "speed": velocity,
+                    "heading": heading,
+                }
+        entry = {"aircraft": len(occupants)}
+        if occupants:
+            # Keep following the previously tracked aircraft while it stays in
+            # the corridor; otherwise adopt the one nearest the centerline.
+            key = tracked.get(route["route"])
+            if key not in occupants:
+                key = min(occupants, key=lambda k: occupants[k]["cross"])
+                tracked[route["route"]] = key
+            entry["entity"] = occupants[key]
+        else:
+            tracked.pop(route["route"], None)
+        routes[route["route"]] = entry
+    return routes
+
+
+def poll_loop():
+    while True:
+        try:
+            states, credits = fetch_states()
+            routes = update_routes(states)
+            with state_lock:
+                metrics["up"] = 1
+                metrics["aircraft_in_bbox"] = len(states)
+                metrics["routes"] = routes
+                if credits is not None:
+                    metrics["credits"] = float(credits)
+        except Exception as err:  # noqa: BLE001 - any poll failure marks the feed down
+            print(f"opensky poll failed: {err}", flush=True)
+            with state_lock:
+                metrics["up"] = 0
+        time.sleep(POLL_SECONDS)
+
+
+def render_metrics():
+    with state_lock:
+        up = metrics["up"]
+        credits = metrics["credits"]
+        in_bbox = metrics["aircraft_in_bbox"]
+        routes = dict(metrics["routes"])
+    lines = [
+        "# HELP opensky_up Whether the last OpenSky poll succeeded.",
+        "# TYPE opensky_up gauge",
+        f"opensky_up {up}",
+        "# HELP opensky_aircraft_in_bbox Aircraft inside the configured bounding box.",
+        "# TYPE opensky_aircraft_in_bbox gauge",
+        f"opensky_aircraft_in_bbox {in_bbox}",
+    ]
+    if not math.isnan(credits):
+        lines += [
+            "# HELP opensky_api_credits_remaining Remaining daily OpenSky API credits.",
+            "# TYPE opensky_api_credits_remaining gauge",
+            f"opensky_api_credits_remaining {credits}",
+        ]
+    lines += [
+        "# HELP opensky_route_aircraft Aircraft currently inside the route corridor.",
+        "# TYPE opensky_route_aircraft gauge",
+    ]
+    for name, entry in routes.items():
+        lines.append(f'opensky_route_aircraft{{route_id="{name}"}} {entry["aircraft"]}')
+
+    entities = {
+        name: entry["entity"] for name, entry in routes.items() if "entity" in entry
+    }
+    lines += [
+        "# HELP moving_entity_progress_ratio Progress (0-1) of the tracked entity along its route.",
+        "# TYPE moving_entity_progress_ratio gauge",
+    ]
+    for name, e in entities.items():
+        lines.append(
+            f'moving_entity_progress_ratio{{entity_id="{e["entity_id"]}",route_id="{name}"}}'
+            f' {e["progress"]:.4f}'
+        )
+    scalar_fields = [
+        ("moving_entity_latitude", "lat", "Latitude of the tracked entity.", 'mode="aircraft",'),
+        ("moving_entity_longitude", "lon", "Longitude of the tracked entity.", 'mode="aircraft",'),
+        ("moving_entity_altitude_meters", "altitude", "Barometric altitude in meters.", ""),
+        ("moving_entity_speed_mps", "speed", "Ground speed in m/s.", ""),
+        ("moving_entity_heading_degrees", "heading", "True track in degrees.", ""),
+    ]
+    # One aircraft can be tracked on several corridors; scalar series carry
+    # only entity_id, so dedupe to avoid duplicate Prometheus samples.
+    unique_entities = {e["entity_id"]: e for e in entities.values()}
+    for metric, field, help_text, extra in scalar_fields:
+        lines += [f"# HELP {metric} {help_text}", f"# TYPE {metric} gauge"]
+        for e in unique_entities.values():
+            if e.get(field) is not None:
+                lines.append(f'{metric}{{{extra}entity_id="{e["entity_id"]}"}} {e[field]:.4f}')
+    return "\n".join(lines) + "\n"
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802 - http.server API
+        if self.path != "/metrics":
+            self.send_response(404)
+            self.end_headers()
+            return
+        body = render_metrics().encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; version=0.0.4")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):  # keep container logs to poll errors only
+        pass
+
+
+def main():
+    if not CLIENT_ID or not CLIENT_SECRET:
+        raise SystemExit(
+            "OPENSKY_CLIENT_ID and OPENSKY_CLIENT_SECRET must be set "
+            "(see testing/.env.example)"
+        )
+    threading.Thread(target=poll_loop, daemon=True).start()
+    print(f"opensky exporter on :{PORT}, bbox={BBOX}, poll={POLL_SECONDS}s", flush=True)
+    HTTPServer(("", PORT), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #274

## What

Adds `testing/opensky/` — a stdlib-Python Prometheus exporter that polls the OpenSky Network REST API (OAuth2 client credentials) for real aircraft positions, following the project's standard demo architecture:

```text
Open data (OpenSky REST API)
  → custom Prometheus exporter
  → Prometheus scrape
  → Grafana query
  → Network Weathermap NG (route links today; moving-entity overlay per #266)
```

## Metric scheme

Feed health and aggregates are `opensky_*`; per-aircraft series use the **generic `moving_entity_*` scheme** so the future moving-entity overlay (#266) stays domain-agnostic:

```text
moving_entity_progress_ratio{entity_id="KLM30E",route_id="AMS-BRU"} 0.61
moving_entity_latitude{entity_id="KLM30E",mode="aircraft"} 52.3056
moving_entity_longitude{entity_id="KLM30E",mode="aircraft"} 4.7722
moving_entity_altitude_meters{entity_id="KLM30E"} 1424.94
moving_entity_speed_mps{entity_id="KLM30E"} 230
moving_entity_heading_degrees{entity_id="KLM30E"} 278
```

Schematic mode (`Airport A ── ✈ 61% ── Airport B`) binds `progress_ratio` per route via legend `{{route_id}} progress`; lat/lon/alt/heading are exported now so a later geospatial mode needs no exporter change.

## Design points

- **Route corridors**: A→Z airport pairs; an aircraft is "on route" when its cross-track distance to the corridor centerline is < 30 km (configurable). Progress = clamped projection onto the segment. The exporter keeps following the same aircraft while it stays in the corridor so progress moves smoothly instead of jumping between occupants.
- **Credit budget**: default 15 sq-deg Benelux bbox = 1 credit per `/states/all` call; 30 s poll ≈ 2,880 of the 4,000 daily standard credits. Remaining credits exported as `opensky_api_credits_remaining` from the `X-Rate-Limit-Remaining` header.
- **Opt-in compose profile**: `docker compose --profile opensky up` — the default stack is untouched and never spends credits. Credentials come from git-ignored `testing/.env` (`.env.example` template added; `OPENSKY_CLIENT_ID`/`OPENSKY_CLIENT_SECRET` also stored as repo Actions secrets for future CI use).
- **Resilience**: token refresh 60 s before expiry plus one retry on early 401; a failed poll marks `opensky_up 0` and never crashes the exporter. No external Python dependencies (same pattern as `testing/bridge/bridge.py`).

## Verified live

Ran against the real API with the standard-access client:

- OAuth token flow and refresh path work; 178 aircraft in the default bbox; `opensky_api_credits_remaining 3999`.
- Three corridors tracked real flights (`DLH4J`, `KLM30E`, `BEL6KU`) and progress moved between polls (DLH4J 0.936 → 0.925 over 35 s).
- Duplicate-sample bug caught and fixed during verification: one aircraft matching two corridors previously emitted its scalar series twice; now deduped by `entity_id`.
- `docker compose config` validates; default (no-profile) stack behavior unchanged.

## Notes

- Demo/testing infrastructure only — not part of the shipped plugin (scope boundaries: #272). No plugin `src/` changes, so the jest/E2E suites are unaffected.
- Draft on purpose — **do not merge**; parked for review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in OpenSky live aviation feed to the demo stack: a stdlib Python Prometheus exporter that polls the OpenSky REST API and exposes `opensky_*` and `moving_entity_*` metrics. Implements the live data requirement of #274 without changing default stack behavior.

- **New Features**
  - Prometheus exporter (`testing/opensky/opensky_exporter.py`) with OAuth2 client credentials; metrics include `opensky_up`, `opensky_api_credits_remaining`, `opensky_aircraft_in_bbox`, `opensky_route_aircraft`, and per-entity `moving_entity_*` (progress, lat/lon/alt/speed/heading), deduped by `entity_id`.
  - Route corridors (A→Z) with cross-track gating (`OPENSKY_CORRIDOR_KM`); progress via clamped projection; follows the same aircraft across polls for smooth updates.
  - Credit-aware defaults (15 sq-deg bbox, 30s polling); remaining credits exported from `X-Rate-Limit-Remaining`.
  - Opt-in compose profile `opensky`; Prometheus scrape job added; `.env.example` for credentials and `.gitignore` updated; minimal `Dockerfile` and README included.
  - Resilience: token refresh before expiry, one retry on early 401, and failures set `opensky_up 0` without crashing.

- **Migration**
  - Copy `testing/.env.example` to `testing/.env` and set `OPENSKY_CLIENT_ID`/`OPENSKY_CLIENT_SECRET`.
  - Start: docker compose --profile opensky up -d --build
  - Metrics at http://localhost:9101/metrics; scraped as Prometheus job `opensky`.

<sup>Written for commit 1fd261ba5a8b8a80f66aee5eb7dcb94e452ab1f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

