### PR TITLE
feat: moving entity overlay with live OpenSky aviation demo

### DIFF
--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getDefaultRelativeTimeRange, getTimeZone, LoadingState, PanelProps, toDataFrame } from '@grafana/data';
+import { FieldType, getDefaultRelativeTimeRange, getTimeZone, LoadingState, PanelProps, toDataFrame } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { WeathermapPanel } from 'WeathermapPanel';
@@ -95,6 +95,76 @@ test('Creating a weathermap', () => {
   expect(prevTranslation).not.toEqual(newTranslation);
 
   // TODO: find a working way to check node dragging
+});
+
+test('moving entity renders along its link at the progress position (#266)', () => {
+  let testProps = { ...mPanelProps };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  weathermap.entities = [
+    {
+      id: 'entity-1',
+      label: 'ICE-72',
+      linkId: weathermap.links[0].id,
+      progressQuery: 'route progress',
+      icon: '✈',
+      size: 14,
+      showLabel: true,
+    },
+  ];
+  testProps.options = { weathermap };
+  testProps.data = {
+    ...mPanelProps.data,
+    series: [
+      toDataFrame({
+        refId: 'A',
+        fields: [
+          { name: 'Time', type: FieldType.time, values: [1000, 2000] },
+          { name: 'Value', type: FieldType.number, values: [0.2, 0.5], config: { displayNameFromDS: 'route progress' } },
+        ],
+      }),
+    ],
+  };
+  testProps.onOptionsChange = () => {};
+
+  render(<WeathermapPanel {...testProps} />);
+
+  const entity = screen.getByTestId('moving-entity');
+  expect(entity.textContent).toContain('✈');
+  expect(entity.textContent).toContain('ICE-72');
+
+  // Progress 0.5 (last value) places the entity strictly between the two
+  // nodes (x=200 and x=400, both at y=300).
+  const transform = entity.getAttribute('transform') || '';
+  const match = transform.match(/translate\(([\d.-]+),([\d.-]+)\)/);
+  expect(match).not.toBeNull();
+  const x = parseFloat(match![1]);
+  const y = parseFloat(match![2]);
+  expect(x).toBeGreaterThan(200);
+  expect(x).toBeLessThan(400);
+  expect(y).toBeCloseTo(300, 0);
+});
+
+test('moving entity hides when its progress series is missing (#266)', () => {
+  let testProps = { ...mPanelProps };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  weathermap.entities = [
+    {
+      id: 'entity-1',
+      label: 'ICE-72',
+      linkId: weathermap.links[0].id,
+      progressQuery: 'route progress',
+    },
+  ];
+  testProps.options = { weathermap };
+  testProps.data = { ...mPanelProps.data, series: [] };
+  testProps.onOptionsChange = () => {};
+
+  render(<WeathermapPanel {...testProps} />);
+
+  // No series resolves the progress query: the entity is hidden, and the
+  // rest of the map still renders (nodes, link).
+  expect(screen.queryByTestId('moving-entity')).toBeNull();
+  expect(screen.getAllByTestId('link')).toHaveLength(1);
 });
 
 test('Uses explicit per-side direction labels in the link tooltip when set', () => {

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -56,6 +56,7 @@ import {
   valueAtTime,
   addViaToLink,
   removeVia,
+  progressToPosition,
 } from 'utils';
 import MapNode from './components/MapNode';
 import ColorScale from 'components/ColorScale';
@@ -1884,6 +1885,59 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                   }}
                 />
               ))}
+            </g>
+            <g>
+              {(wm.entities ?? []).map((entity) => {
+                const link = links.find((l) => l.id === entity.linkId);
+                if (!link || !entity.progressQuery) {
+                  return null;
+                }
+                // Progress resolves through the same display-name map as link
+                // values, so timeline scrubbing replays entity movement (#266).
+                // Missing or non-finite progress hides the entity entirely.
+                const raw = dataFrameMap.get(entity.progressQuery);
+                if (raw === undefined || raw === null || !Number.isFinite(raw)) {
+                  return null;
+                }
+                const pos = progressToPosition([link.lineStartA, link.lineStartZ], raw);
+                if (!pos) {
+                  return null;
+                }
+                const size = entity.size ?? 14;
+                return (
+                  <g
+                    key={entity.id}
+                    data-testid="moving-entity"
+                    transform={`translate(${pos.x},${pos.y})`}
+                    // Purely visual overlay: never intercept node dragging or
+                    // link hover on the elements underneath.
+                    pointerEvents="none"
+                  >
+                    <text
+                      textAnchor="middle"
+                      dominantBaseline="central"
+                      alignmentBaseline="central"
+                      fontSize={`${size}px`}
+                      fill={wm.settings.link.label.font}
+                    >
+                      {entity.icon || '●'}
+                    </text>
+                    {entity.showLabel !== false && entity.label !== '' ? (
+                      <text
+                        y={size}
+                        textAnchor="middle"
+                        dominantBaseline="hanging"
+                        fontSize={`${Math.max(7, Math.round(size / 2))}px`}
+                        fill={wm.settings.link.label.font}
+                      >
+                        {entity.label}
+                      </text>
+                    ) : (
+                      ''
+                    )}
+                  </g>
+                );
+              })}
             </g>
           </g>
         </svg>

--- a/src/forms/EntityForm.tsx
+++ b/src/forms/EntityForm.tsx
@@ -1,0 +1,205 @@
+import React, { useState } from 'react';
+import { css } from '@emotion/css';
+import { Button, InlineField, InlineSwitch, Input, Select, useStyles2 } from '@grafana/ui';
+import { SelectableValue, StandardEditorProps } from '@grafana/data';
+import { v4 as uuidv4 } from 'uuid';
+import { Weathermap, Link, MovingEntity } from 'types';
+import { FormDivider } from './FormDivider';
+import { buildQueryOptions, finiteOrFallback } from 'utils';
+
+interface Settings {
+  placeholder: string;
+}
+
+interface Props extends StandardEditorProps<Weathermap, Settings> {}
+
+// Editor for moving entities (#266): markers that travel along a link,
+// positioned by a 0..1 progress metric. Follows the LinkForm patterns —
+// structuredClone before every write, explicit inputIds (#167).
+export const EntityForm = (props: Props) => {
+  const { value, onChange, context } = props;
+  const styles = useStyles2(getStyles);
+
+  const [currentEntity, setCurrentEntity] = useState('null' as unknown as MovingEntity);
+
+  const entities = value.entities ?? [];
+  const queryOptions = buildQueryOptions(context.data);
+
+  const updateEntity = (i: number, patch: Partial<MovingEntity>) => {
+    let weathermap: Weathermap = structuredClone(value);
+    weathermap.entities = weathermap.entities ?? [];
+    weathermap.entities[i] = { ...weathermap.entities[i], ...patch };
+    onChange(weathermap);
+    setCurrentEntity(weathermap.entities[i]);
+  };
+
+  const addNewEntity = () => {
+    if (value.links.length === 0) {
+      throw new Error('There must be >= 1 Links to create a moving entity.');
+    }
+    let weathermap: Weathermap = structuredClone(value);
+    const entity: MovingEntity = {
+      id: uuidv4(),
+      label: `Entity ${(weathermap.entities?.length ?? 0) + 1}`,
+      linkId: value.links[0].id,
+      progressQuery: undefined,
+      icon: '●',
+      size: 14,
+      showLabel: true,
+    };
+    weathermap.entities = [...(weathermap.entities ?? []), entity];
+    onChange(weathermap);
+    setCurrentEntity(entity);
+  };
+
+  const removeEntity = (i: number) => {
+    let weathermap: Weathermap = structuredClone(value);
+    weathermap.entities = (weathermap.entities ?? []).filter((_, ei) => ei !== i);
+    onChange(weathermap);
+    setCurrentEntity('null' as unknown as MovingEntity);
+  };
+
+  const linkLabel = (link: Link | undefined) =>
+    link && link.nodes.length > 0 ? `${link.nodes[0]?.label} <> ${link.nodes[1]?.label}` : '';
+
+  return (
+    <React.Fragment>
+      <h6
+        style={{
+          padding: '10px 0px 5px 5px',
+          marginTop: '10px',
+          borderTop: '1px solid var(--in-content-button-background)',
+        }}
+      >
+        Moving Entities
+      </h6>
+      <Select
+        inputId="nwm-entity-picker"
+        onChange={(v) => {
+          setCurrentEntity(v as MovingEntity);
+        }}
+        value={currentEntity}
+        options={entities}
+        getOptionLabel={(e) => e?.label ?? ''}
+        getOptionValue={(e) => e?.id ?? ''}
+        className={styles.entitySelect}
+        placeholder={'Select a moving entity'}
+        isClearable
+      ></Select>
+
+      {entities.map((entity: MovingEntity, i) => {
+        if (currentEntity && entity.id === currentEntity.id) {
+          return (
+            <React.Fragment key={entity.id}>
+              <FormDivider title="Entity Options" />
+              <InlineField grow label="Label" labelWidth={'auto'}>
+                <Input
+                  id={`nwm-entity-label-${i}`}
+                  value={entity.label}
+                  placeholder="Entity label"
+                  onChange={(e) => updateEntity(i, { label: e.currentTarget.value })}
+                />
+              </InlineField>
+              <InlineField grow label="Link" labelWidth={'auto'}>
+                <Select
+                  inputId={`nwm-entity-link-${i}`}
+                  onChange={(v) => updateEntity(i, { linkId: (v as Link).id })}
+                  value={value.links.find((l) => l.id === entity.linkId)}
+                  options={value.links}
+                  getOptionLabel={(link) => linkLabel(link as Link)}
+                  getOptionValue={(link) => (link as Link).id as unknown as Link}
+                  placeholder={'Select a link'}
+                ></Select>
+              </InlineField>
+              <InlineField grow label="Progress query (0..1)" labelWidth={'auto'}>
+                <Select
+                  inputId={`nwm-entity-progress-${i}`}
+                  onChange={(v) => updateEntity(i, { progressQuery: (v as SelectableValue<string>)?.value })}
+                  value={entity.progressQuery}
+                  options={queryOptions}
+                  placeholder={'Select a query'}
+                  isClearable
+                ></Select>
+              </InlineField>
+              <InlineField grow label="Icon (text/emoji)" labelWidth={'auto'}>
+                <Input
+                  id={`nwm-entity-icon-${i}`}
+                  value={entity.icon ?? ''}
+                  placeholder="●"
+                  onChange={(e) => updateEntity(i, { icon: e.currentTarget.value })}
+                />
+              </InlineField>
+              <InlineField grow label="Size" labelWidth={'auto'}>
+                <Input
+                  id={`nwm-entity-size-${i}`}
+                  value={entity.size ?? 14}
+                  type="number"
+                  onChange={(e) =>
+                    updateEntity(i, { size: finiteOrFallback(e.currentTarget.valueAsNumber, entity.size ?? 14) })
+                  }
+                />
+              </InlineField>
+              <InlineField grow label="Show label" labelWidth={'auto'}>
+                <InlineSwitch
+                  id={`nwm-entity-show-label-${i}`}
+                  value={entity.showLabel !== false}
+                  onChange={(e) => updateEntity(i, { showLabel: e.currentTarget.checked })}
+                />
+              </InlineField>
+              <Button variant="destructive" icon="trash-alt" size="md" onClick={() => removeEntity(i)}>
+                Remove Entity
+              </Button>
+            </React.Fragment>
+          );
+        }
+        return null;
+      })}
+
+      <Button
+        variant="secondary"
+        icon="plus"
+        size="md"
+        onClick={addNewEntity}
+        className={styles.addNew}
+        disabled={value.links.length === 0}
+      >
+        Add Entity
+      </Button>
+      <Button
+        variant="secondary"
+        icon="trash-alt"
+        size="md"
+        onClick={() => {
+          let weathermap: Weathermap = structuredClone(value);
+          weathermap.entities = [];
+          onChange(weathermap);
+          setCurrentEntity('null' as unknown as MovingEntity);
+        }}
+        className={styles.clearAll}
+        disabled={entities.length === 0}
+      >
+        Clear All
+      </Button>
+    </React.Fragment>
+  );
+};
+
+const getStyles = () => {
+  return {
+    entitySelect: css`
+      margin: 0px 0px;
+    `,
+    addNew: css`
+      width: calc(50% - 10px);
+      justify-content: center;
+      margin: 10px 0px;
+      margin-right: 5px;
+    `,
+    clearAll: css`
+      width: calc(50% - 10px);
+      justify-content: center;
+      margin: 10px 0px;
+      margin-left: 5px;
+    `,
+  };
+};

--- a/src/forms/WeathermapBuilder.tsx
+++ b/src/forms/WeathermapBuilder.tsx
@@ -3,6 +3,7 @@ import { StandardEditorProps } from '@grafana/data';
 import { Anchor, Weathermap } from 'types';
 import { NodeForm } from './NodeForm';
 import { LinkForm } from './LinkForm';
+import { EntityForm } from './EntityForm';
 import { ColorForm } from './ColorForm';
 import { PanelForm } from './PanelForm';
 import { v4 as uuidv4 } from 'uuid';
@@ -130,6 +131,7 @@ export const WeathermapBuilder = (props: Props) => {
     <React.Fragment>
       <NodeForm {...props} value={wm}></NodeForm>
       <LinkForm {...props} value={wm}></LinkForm>
+      <EntityForm {...props} value={wm}></EntityForm>
       <ColorForm {...props} value={wm}></ColorForm>
       <PanelForm {...props} value={wm}></PanelForm>
     </React.Fragment>

--- a/src/types.ts
+++ b/src/types.ts
@@ -298,11 +298,31 @@ export interface TrafficPanelSettings {
   };
 }
 
+// A marker that travels along a link, positioned by a 0..1 progress metric
+// (#266): trains between stations, aircraft between airports, replication
+// jobs between sites. Purely visual — progress 0 sits at the A side, 1 at
+// the Z side, and a missing/non-finite value hides the entity.
+export interface MovingEntity {
+  id: string;
+  label: string;
+  // Which link the entity travels along, by link id (stable across edits).
+  linkId: string;
+  // Display name of the series holding the 0..1 progress value.
+  progressQuery?: string;
+  // Glyph drawn at the entity position (any short text/emoji, e.g. ✈ 🚆 ●).
+  icon?: string;
+  // Glyph font size in px.
+  size?: number;
+  showLabel?: boolean;
+}
+
 export interface Weathermap {
   version: number;
   id: string;
   nodes: Node[];
   links: Link[];
+  // Optional: absent on all pre-existing maps, so no migration is required.
+  entities?: MovingEntity[];
   scale: Threshold[];
   settings: WeathermapSettings;
 }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -6,6 +6,7 @@ import {
   buildQueryOptions,
   getDataFrameName,
   getValueField,
+  progressToPosition,
   resolveLinkChain,
   spreadLabels,
   aggregateFieldValues,
@@ -511,6 +512,55 @@ describe('timeline helpers (valueAtTime / getTimeField)', () => {
       ],
     };
     expect(getTimeField(frame)).toBeUndefined();
+  });
+});
+
+describe('progressToPosition (#266)', () => {
+  test('interpolates along a single segment', () => {
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+    ];
+    expect(progressToPosition(pts, 0)).toEqual({ x: 0, y: 0 });
+    expect(progressToPosition(pts, 0.5)).toEqual({ x: 50, y: 0 });
+    expect(progressToPosition(pts, 1)).toEqual({ x: 100, y: 0 });
+  });
+
+  test('clamps out-of-range and non-finite progress', () => {
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 10, y: 0 },
+    ];
+    expect(progressToPosition(pts, -3)).toEqual({ x: 0, y: 0 });
+    expect(progressToPosition(pts, 42)).toEqual({ x: 10, y: 0 });
+    expect(progressToPosition(pts, NaN)).toEqual({ x: 0, y: 0 });
+  });
+
+  test('accumulates real length across multiple segments (VIA-style path)', () => {
+    // Two segments of 100 and 300: t=0.5 is 200 into the path, i.e. 100
+    // into the second segment.
+    const pts = [
+      { x: 0, y: 0 },
+      { x: 100, y: 0 },
+      { x: 100, y: 300 },
+    ];
+    expect(progressToPosition(pts, 0.5)).toEqual({ x: 100, y: 100 });
+    expect(progressToPosition(pts, 0.25)).toEqual({ x: 100, y: 0 });
+  });
+
+  test('degenerate inputs resolve instead of throwing', () => {
+    expect(progressToPosition([], 0.5)).toBeNull();
+    expect(progressToPosition([{ x: 7, y: 9 }], 0.5)).toEqual({ x: 7, y: 9 });
+    // Coincident points (zero total length) pin to the first point.
+    expect(
+      progressToPosition(
+        [
+          { x: 5, y: 5 },
+          { x: 5, y: 5 },
+        ],
+        0.9
+      )
+    ).toEqual({ x: 5, y: 5 });
   });
 });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -430,6 +430,47 @@ export function handleVersionedStateUpdates(wm: Weathermap, theme: GrafanaTheme2
 }
 
 /**
+ * Position along a polyline for a 0..1 progress ratio (#266). Progress is
+ * clamped, distances accumulate across segments so VIA-style multi-segment
+ * paths interpolate by real length, and degenerate inputs resolve rather
+ * than throw: a single point returns itself, no points returns null.
+ */
+export function progressToPosition(
+  points: Array<{ x: number; y: number }>,
+  progress: number
+): { x: number; y: number } | null {
+  if (points.length === 0) {
+    return null;
+  }
+  if (points.length === 1) {
+    return { x: points[0].x, y: points[0].y };
+  }
+  const t = Number.isFinite(progress) ? Math.min(1, Math.max(0, progress)) : 0;
+  const lengths: number[] = [];
+  let total = 0;
+  for (let i = 0; i < points.length - 1; i++) {
+    const len = Math.hypot(points[i + 1].x - points[i].x, points[i + 1].y - points[i].y);
+    lengths.push(len);
+    total += len;
+  }
+  if (total === 0) {
+    return { x: points[0].x, y: points[0].y };
+  }
+  let remaining = t * total;
+  for (let i = 0; i < lengths.length; i++) {
+    if (remaining <= lengths[i] || i === lengths.length - 1) {
+      const f = lengths[i] === 0 ? 0 : remaining / lengths[i];
+      return {
+        x: points[i].x + (points[i + 1].x - points[i].x) * f,
+        y: points[i].y + (points[i + 1].y - points[i].y) * f,
+      };
+    }
+    remaining -= lengths[i];
+  }
+  return { x: points[points.length - 1].x, y: points[points.length - 1].y };
+}
+
+/**
  * Returns the first numeric field in a data frame, falling back to fields[1].
  * Non-standard datasources (Check MK, etc.) may not put the value at index 1 —
  * they may omit the time field, reorder fields, or return table-style frames.

--- a/testing/grafana/dashboards/wm-opensky-aviation.json
+++ b/testing/grafana/dashboards/wm-opensky-aviation.json
@@ -1,0 +1,880 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 0,
+  "links": [],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "weathermap",
+    "demo",
+    "opensky"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Aviation Demo \u2014 OpenSky Live",
+  "description": "Real aircraft from the OpenSky Network moving along schematic AMS/BRU/DUS route corridors. Requires the opensky compose profile (docker compose --profile opensky up).",
+  "uid": "wm-opensky-aviation",
+  "version": 1,
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 2,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "title": "Aircraft in bounding box",
+      "type": "stat",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "opensky_aircraft_in_bbox",
+          "range": false,
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 2,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 3,
+      "title": "OpenSky API credits remaining",
+      "type": "stat",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "opensky_api_credits_remaining",
+          "range": false,
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 2,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 4,
+      "title": "Feed up",
+      "type": "stat",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "opensky_up",
+          "range": false,
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      }
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 15,
+        "w": 16,
+        "x": 0,
+        "y": 2
+      },
+      "id": 1,
+      "title": "Aviation routes \u2014 live OpenSky feed",
+      "type": "tamirsuliman-weathermap-panel",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "opensky_route_aircraft",
+          "legendFormat": "{{route_id}} aircraft",
+          "range": true,
+          "format": "time_series"
+        },
+        {
+          "refId": "B",
+          "expr": "moving_entity_progress_ratio",
+          "legendFormat": "{{route_id}} progress",
+          "range": true,
+          "format": "time_series"
+        }
+      ],
+      "options": {
+        "weathermap": {
+          "version": 14,
+          "id": "wm-opensky-aviation",
+          "nodes": [
+            {
+              "id": "node-ams",
+              "position": [
+                407,
+                36
+              ],
+              "label": "AMS",
+              "showLabel": true,
+              "anchors": {
+                "0": {
+                  "numLinks": 2,
+                  "numFilledLinks": 0
+                },
+                "1": {
+                  "numLinks": 0,
+                  "numFilledLinks": 0
+                },
+                "2": {
+                  "numLinks": 0,
+                  "numFilledLinks": 0
+                },
+                "3": {
+                  "numLinks": 0,
+                  "numFilledLinks": 0
+                },
+                "4": {
+                  "numLinks": 0,
+                  "numFilledLinks": 0
+                }
+              },
+              "useConstantSpacing": false,
+              "compactVerticalLinks": false,
+              "padding": {
+                "vertical": 6,
+                "horizontal": 12
+              },
+              "colors": {
+                "font": "#ffffff",
+                "background": "#22252b",
+                "border": "#5794F2",
+                "statusDown": "#F2495C"
+              },
+              "nodeIcon": null,
+              "isConnection": false
+            },
+            {
+              "id": "node-bru",
+              "position": [
+                356,
+                299
+              ],
+              "label": "BRU",
+              "showLabel": true,
+              "anchors": {
+                "0": {
+                  "numLinks": 2,
+                  "numFilledLinks": 0
+                },
+                "1": {
+                  "numLinks": 0,
+                  "numFilledLinks": 0
+                },
+                "2": {
+                  "numLinks": 0,
+                  "numFilledLinks": 0
+                },
+                "3": {
+                  "numLinks": 0,
+                  "numFilledLinks": 0
+                },
+                "4": {
+                  "numLinks": 0,
+                  "numFilledLinks": 0
+                }
+              },
+              "useConstantSpacing": false,
+              "compactVerticalLinks": false,
+              "padding": {
+                "vertical": 6,
+                "horizontal": 12
+              },
+              "colors": {
+                "font": "#ffffff",
+                "background": "#22252b",
+                "border": "#5794F2",
+                "statusDown": "#F2495C"
+              },
+              "nodeIcon": null,
+              "isConnection": false
+            },
+            {
+              "id": "node-dus",
+              "position": [
+                769,
+                226
+              ],
+              "label": "DUS",
+              "showLabel": true,
+              "anchors": {
+                "0": {
+                  "numLinks": 2,
+                  "numFilledLinks": 0
+                },
+                "1": {
+                  "numLinks": 0,
+                  "numFilledLinks": 0
+                },
+                "2": {
+                  "numLinks": 0,
+                  "numFilledLinks": 0
+                },
+                "3": {
+                  "numLinks": 0,
+                  "numFilledLinks": 0
+                },
+                "4": {
+                  "numLinks": 0,
+                  "numFilledLinks": 0
+                }
+              },
+              "useConstantSpacing": false,
+              "compactVerticalLinks": false,
+              "padding": {
+                "vertical": 6,
+                "horizontal": 12
+              },
+              "colors": {
+                "font": "#ffffff",
+                "background": "#22252b",
+                "border": "#5794F2",
+                "statusDown": "#F2495C"
+              },
+              "nodeIcon": null,
+              "isConnection": false
+            }
+          ],
+          "links": [
+            {
+              "id": "link-AMS-BRU",
+              "nodes": [
+                {
+                  "id": "node-ams",
+                  "position": [
+                    407,
+                    36
+                  ],
+                  "label": "AMS",
+                  "showLabel": true,
+                  "anchors": {
+                    "0": {
+                      "numLinks": 2,
+                      "numFilledLinks": 0
+                    },
+                    "1": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    },
+                    "2": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    },
+                    "3": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    },
+                    "4": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    }
+                  },
+                  "useConstantSpacing": false,
+                  "compactVerticalLinks": false,
+                  "padding": {
+                    "vertical": 6,
+                    "horizontal": 12
+                  },
+                  "colors": {
+                    "font": "#ffffff",
+                    "background": "#22252b",
+                    "border": "#5794F2",
+                    "statusDown": "#F2495C"
+                  },
+                  "nodeIcon": null,
+                  "isConnection": false
+                },
+                {
+                  "id": "node-bru",
+                  "position": [
+                    356,
+                    299
+                  ],
+                  "label": "BRU",
+                  "showLabel": true,
+                  "anchors": {
+                    "0": {
+                      "numLinks": 2,
+                      "numFilledLinks": 0
+                    },
+                    "1": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    },
+                    "2": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    },
+                    "3": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    },
+                    "4": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    }
+                  },
+                  "useConstantSpacing": false,
+                  "compactVerticalLinks": false,
+                  "padding": {
+                    "vertical": 6,
+                    "horizontal": 12
+                  },
+                  "colors": {
+                    "font": "#ffffff",
+                    "background": "#22252b",
+                    "border": "#5794F2",
+                    "statusDown": "#F2495C"
+                  },
+                  "nodeIcon": null,
+                  "isConnection": false
+                }
+              ],
+              "sides": {
+                "A": {
+                  "bandwidth": 40,
+                  "query": "AMS-BRU aircraft",
+                  "labelOffset": 55,
+                  "anchor": 0,
+                  "dashboardLink": "",
+                  "directionLabel": "Aircraft on route"
+                },
+                "Z": {
+                  "bandwidth": 40,
+                  "query": null,
+                  "labelOffset": 55,
+                  "anchor": 0,
+                  "dashboardLink": ""
+                }
+              },
+              "units": "short",
+              "arrows": {
+                "width": 8,
+                "height": 10,
+                "offset": 2
+              },
+              "stroke": 6,
+              "showThroughputPercentage": false,
+              "singleDirection": true
+            },
+            {
+              "id": "link-AMS-DUS",
+              "nodes": [
+                {
+                  "id": "node-ams",
+                  "position": [
+                    407,
+                    36
+                  ],
+                  "label": "AMS",
+                  "showLabel": true,
+                  "anchors": {
+                    "0": {
+                      "numLinks": 2,
+                      "numFilledLinks": 0
+                    },
+                    "1": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    },
+                    "2": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    },
+                    "3": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    },
+                    "4": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    }
+                  },
+                  "useConstantSpacing": false,
+                  "compactVerticalLinks": false,
+                  "padding": {
+                    "vertical": 6,
+                    "horizontal": 12
+                  },
+                  "colors": {
+                    "font": "#ffffff",
+                    "background": "#22252b",
+                    "border": "#5794F2",
+                    "statusDown": "#F2495C"
+                  },
+                  "nodeIcon": null,
+                  "isConnection": false
+                },
+                {
+                  "id": "node-dus",
+                  "position": [
+                    769,
+                    226
+                  ],
+                  "label": "DUS",
+                  "showLabel": true,
+                  "anchors": {
+                    "0": {
+                      "numLinks": 2,
+                      "numFilledLinks": 0
+                    },
+                    "1": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    },
+                    "2": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    },
+                    "3": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    },
+                    "4": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    }
+                  },
+                  "useConstantSpacing": false,
+                  "compactVerticalLinks": false,
+                  "padding": {
+                    "vertical": 6,
+                    "horizontal": 12
+                  },
+                  "colors": {
+                    "font": "#ffffff",
+                    "background": "#22252b",
+                    "border": "#5794F2",
+                    "statusDown": "#F2495C"
+                  },
+                  "nodeIcon": null,
+                  "isConnection": false
+                }
+              ],
+              "sides": {
+                "A": {
+                  "bandwidth": 40,
+                  "query": "AMS-DUS aircraft",
+                  "labelOffset": 55,
+                  "anchor": 0,
+                  "dashboardLink": "",
+                  "directionLabel": "Aircraft on route"
+                },
+                "Z": {
+                  "bandwidth": 40,
+                  "query": null,
+                  "labelOffset": 55,
+                  "anchor": 0,
+                  "dashboardLink": ""
+                }
+              },
+              "units": "short",
+              "arrows": {
+                "width": 8,
+                "height": 10,
+                "offset": 2
+              },
+              "stroke": 6,
+              "showThroughputPercentage": false,
+              "singleDirection": true
+            },
+            {
+              "id": "link-BRU-DUS",
+              "nodes": [
+                {
+                  "id": "node-bru",
+                  "position": [
+                    356,
+                    299
+                  ],
+                  "label": "BRU",
+                  "showLabel": true,
+                  "anchors": {
+                    "0": {
+                      "numLinks": 2,
+                      "numFilledLinks": 0
+                    },
+                    "1": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    },
+                    "2": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    },
+                    "3": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    },
+                    "4": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    }
+                  },
+                  "useConstantSpacing": false,
+                  "compactVerticalLinks": false,
+                  "padding": {
+                    "vertical": 6,
+                    "horizontal": 12
+                  },
+                  "colors": {
+                    "font": "#ffffff",
+                    "background": "#22252b",
+                    "border": "#5794F2",
+                    "statusDown": "#F2495C"
+                  },
+                  "nodeIcon": null,
+                  "isConnection": false
+                },
+                {
+                  "id": "node-dus",
+                  "position": [
+                    769,
+                    226
+                  ],
+                  "label": "DUS",
+                  "showLabel": true,
+                  "anchors": {
+                    "0": {
+                      "numLinks": 2,
+                      "numFilledLinks": 0
+                    },
+                    "1": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    },
+                    "2": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    },
+                    "3": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    },
+                    "4": {
+                      "numLinks": 0,
+                      "numFilledLinks": 0
+                    }
+                  },
+                  "useConstantSpacing": false,
+                  "compactVerticalLinks": false,
+                  "padding": {
+                    "vertical": 6,
+                    "horizontal": 12
+                  },
+                  "colors": {
+                    "font": "#ffffff",
+                    "background": "#22252b",
+                    "border": "#5794F2",
+                    "statusDown": "#F2495C"
+                  },
+                  "nodeIcon": null,
+                  "isConnection": false
+                }
+              ],
+              "sides": {
+                "A": {
+                  "bandwidth": 40,
+                  "query": "BRU-DUS aircraft",
+                  "labelOffset": 55,
+                  "anchor": 0,
+                  "dashboardLink": "",
+                  "directionLabel": "Aircraft on route"
+                },
+                "Z": {
+                  "bandwidth": 40,
+                  "query": null,
+                  "labelOffset": 55,
+                  "anchor": 0,
+                  "dashboardLink": ""
+                }
+              },
+              "units": "short",
+              "arrows": {
+                "width": 8,
+                "height": 10,
+                "offset": 2
+              },
+              "stroke": 6,
+              "showThroughputPercentage": false,
+              "singleDirection": true
+            }
+          ],
+          "entities": [
+            {
+              "id": "entity-AMS-BRU",
+              "label": "AMS-BRU",
+              "linkId": "link-AMS-BRU",
+              "progressQuery": "AMS-BRU progress",
+              "icon": "\u2708",
+              "size": 18,
+              "showLabel": true
+            },
+            {
+              "id": "entity-AMS-DUS",
+              "label": "AMS-DUS",
+              "linkId": "link-AMS-DUS",
+              "progressQuery": "AMS-DUS progress",
+              "icon": "\u2708",
+              "size": 18,
+              "showLabel": true
+            },
+            {
+              "id": "entity-BRU-DUS",
+              "label": "BRU-DUS",
+              "linkId": "link-BRU-DUS",
+              "progressQuery": "BRU-DUS progress",
+              "icon": "\u2708",
+              "size": 18,
+              "showLabel": true
+            }
+          ],
+          "scale": [
+            {
+              "percent": 0,
+              "color": "#73BF69"
+            },
+            {
+              "percent": 40,
+              "color": "#FADE2A"
+            },
+            {
+              "percent": 75,
+              "color": "#F2495C"
+            }
+          ],
+          "settings": {
+            "link": {
+              "spacing": {
+                "horizontal": 10,
+                "vertical": 5
+              },
+              "stroke": {
+                "color": "rgba(204, 204, 220, 0.16)"
+              },
+              "label": {
+                "background": "#181b1f",
+                "border": "rgba(204, 204, 220, 0.25)",
+                "font": "rgb(204, 204, 220)"
+              },
+              "showAllWithPercentage": false,
+              "valueMappingMode": "last",
+              "defaultUnits": "short",
+              "linkDecimals": 0,
+              "dynamicStroke": {
+                "enabled": false,
+                "minWidth": 1,
+                "maxWidth": 10
+              },
+              "flowAnimation": {
+                "enabled": false,
+                "speed": 2
+              },
+              "gradientColor": false
+            },
+            "fontSizing": {
+              "node": 10,
+              "link": 8
+            },
+            "colorScaleMode": "percent",
+            "panel": {
+              "backgroundColor": "#111217",
+              "showTimestamp": true,
+              "panelSize": {
+                "width": 900,
+                "height": 560
+              },
+              "zoomScale": 0,
+              "offset": {
+                "x": 0,
+                "y": 0
+              },
+              "grid": {
+                "enabled": false,
+                "size": 10,
+                "guidesEnabled": false
+              },
+              "backgroundImage": {
+                "url": "http://localhost:9101/benelux.svg",
+                "fit": "contain",
+                "attachToCanvas": true
+              }
+            },
+            "tooltip": {
+              "fontSize": 10,
+              "textColor": "white",
+              "backgroundColor": "black",
+              "inboundColor": "#00cf00",
+              "outboundColor": "#fade2a",
+              "scaleToBandwidth": true
+            },
+            "scale": {
+              "position": {
+                "x": 0,
+                "y": 0
+              },
+              "size": {
+                "width": 60,
+                "height": 220
+              },
+              "title": "Utilization",
+              "fontSizing": {
+                "title": 14,
+                "threshold": 11
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "datasource": "Prometheus",
+      "gridPos": {
+        "h": 15,
+        "w": 8,
+        "x": 16,
+        "y": 2
+      },
+      "id": 5,
+      "title": "Tracked flights",
+      "type": "table",
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "moving_entity_progress_ratio",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "instance": true,
+              "job": true,
+              "mode": true
+            },
+            "renameByName": {
+              "entity_id": "Flight",
+              "route_id": "Route",
+              "Value": "Progress"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "sort": [
+              {
+                "field": "Route"
+              }
+            ]
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 1
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Progress"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "gauge",
+                  "mode": "gradient"
+                }
+              },
+              {
+                "id": "min",
+                "value": 0
+              },
+              {
+                "id": "max",
+                "value": 1
+              }
+            ]
+          }
+        ]
+      },
+      "options": {}
+    }
+  ]
+}

--- a/testing/opensky/Dockerfile
+++ b/testing/opensky/Dockerfile
@@ -1,3 +1,4 @@
 FROM python:3.12-alpine
 COPY opensky_exporter.py /opensky_exporter.py
+COPY assets /assets
 CMD ["python", "/opensky_exporter.py"]

--- a/testing/opensky/assets/benelux.svg
+++ b/testing/opensky/assets/benelux.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 560" width="900" height="560">
+<rect width="900" height="560" fill="#0d141f"/>
+<path d="M0.0,270.7 L72.0,235.2 L126.0,218.4 L189.0,203.5 L216.0,168.0 L261.0,141.9 L279.0,115.7 L288.0,102.7 L324.0,74.7 L369.0,28.0 L396.0,0.0 L900.0,0.0 L900.0,560.0 L0.0,560.0 Z" fill="#161d26" stroke="rgba(120,170,220,0.35)" stroke-width="1.5"/>
+<g stroke="rgba(204,204,220,0.16)" stroke-width="1" fill="none" stroke-dasharray="4,4">
+<path d="M162.0,233.3 L342.0,201.6 L450.0,196.0 L493.2,231.5 L594.0,248.3 L630.0,326.7"/>
+<path d="M0.0,317.3 L126.0,373.3 L297.0,472.3 L423.0,505.9 L534.6,560.0"/>
+<path d="M819.0,0.0 L756.0,74.7 L648.0,112.0 L666.0,186.7 L648.0,242.7 L630.0,326.7"/>
+<path d="M630.0,326.7 L684.0,373.3 L648.0,438.7 L720.0,504.0 L693.0,560.0"/>
+</g>
+<text x="522.0" y="65.3" fill="rgba(204,204,220,0.22)" font-size="15" font-family="sans-serif" letter-spacing="3" text-anchor="middle">NETHERLANDS</text>
+<text x="342.0" y="364.0" fill="rgba(204,204,220,0.22)" font-size="15" font-family="sans-serif" letter-spacing="3" text-anchor="middle">BELGIUM</text>
+<text x="792.0" y="252.0" fill="rgba(204,204,220,0.22)" font-size="15" font-family="sans-serif" letter-spacing="3" text-anchor="middle">GERMANY</text>
+<text x="144.0" y="513.3" fill="rgba(204,204,220,0.22)" font-size="15" font-family="sans-serif" letter-spacing="3" text-anchor="middle">FRANCE</text>
+<text x="126.0" y="65.3" fill="rgba(204,204,220,0.22)" font-size="15" font-family="sans-serif" letter-spacing="3" text-anchor="middle">North Sea</text>
+</svg>

--- a/testing/opensky/opensky_exporter.py
+++ b/testing/opensky/opensky_exporter.py
@@ -258,8 +258,27 @@ def render_metrics():
     return "\n".join(lines) + "\n"
 
 
+ASSETS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets")
+
+
 class Handler(BaseHTTPRequestHandler):
     def do_GET(self):  # noqa: N802 - http.server API
+        if self.path == "/benelux.svg":
+            # Map background for the aviation demo dashboard, drawn in the
+            # same bbox projection the route corridors use.
+            try:
+                with open(os.path.join(ASSETS_DIR, "benelux.svg"), "rb") as f:
+                    body = f.read()
+            except OSError:
+                self.send_response(404)
+                self.end_headers()
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "image/svg+xml")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
         if self.path != "/metrics":
             self.send_response(404)
             self.end_headers()

--- a/testing/scripts/generate-opensky-dashboard.py
+++ b/testing/scripts/generate-opensky-dashboard.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Generate the OpenSky live aviation dashboard (#266, #274).
+
+Clones the panel/settings skeleton from wm-wan-utilization.json and swaps in
+an AMS/BRU/DUS schematic driven by the OpenSky exporter's metrics:
+
+  opensky_route_aircraft{route_id}        -> link values (single direction)
+  moving_entity_progress_ratio{route_id}  -> moving-entity ✈ position (#266)
+
+Run from the repo root:  python3 testing/scripts/generate-opensky-dashboard.py
+"""
+
+import copy
+import json
+import os
+
+ROOT = os.path.join(os.path.dirname(__file__), "..", "grafana", "dashboards")
+BASE = json.load(open(os.path.join(ROOT, "wm-wan-utilization.json")))
+
+base_panel = [p for p in BASE["panels"] if p.get("type") == "tamirsuliman-weathermap-panel"][0]
+settings = copy.deepcopy(base_panel["options"]["weathermap"]["settings"])
+settings["link"]["defaultUnits"] = "short"
+settings["link"]["linkDecimals"] = 0
+settings["panel"]["panelSize"] = {"width": 900, "height": 560}
+settings["panel"]["backgroundImage"] = {
+    "url": "http://localhost:9101/benelux.svg",
+    "fit": "contain",
+    "attachToCanvas": True,
+}
+
+ANCHORS = {str(i): {"numLinks": 0, "numFilledLinks": 0} for i in range(5)}
+
+# Pixel positions from the exporter bbox projection (lon 2.5-7.5E,
+# lat 49.5-52.5N onto the 900x560 canvas), matching benelux.svg — nodes sit
+# at true geographic coordinates on the map background.
+AIRPORTS = {
+    "AMS": [407, 36],
+    "BRU": [356, 299],
+    "DUS": [769, 226],
+}
+ROUTES = [("AMS", "BRU"), ("AMS", "DUS"), ("BRU", "DUS")]
+
+
+def make_node(code):
+    return {
+        "id": f"node-{code.lower()}",
+        "position": AIRPORTS[code],
+        "label": code,
+        "showLabel": True,
+        "anchors": copy.deepcopy(ANCHORS),
+        "useConstantSpacing": False,
+        "compactVerticalLinks": False,
+        "padding": {"vertical": 6, "horizontal": 12},
+        "colors": {
+            "font": "#ffffff",
+            "background": "#22252b",
+            "border": "#5794F2",
+            "statusDown": "#F2495C",
+        },
+        "nodeIcon": None,
+        "isConnection": False,
+    }
+
+
+nodes = {code: make_node(code) for code in AIRPORTS}
+
+links = []
+entities = []
+for a, z in ROUTES:
+    route = f"{a}-{z}"
+    # Both endpoints anchor at center; count both ends like the editor does.
+    nodes[a]["anchors"]["0"]["numLinks"] += 1
+    nodes[z]["anchors"]["0"]["numLinks"] += 1
+    link = {
+        "id": f"link-{route}",
+        "nodes": [nodes[a], nodes[z]],
+        "sides": {
+            "A": {
+                "bandwidth": 40,
+                "query": f"{route} aircraft",
+                "labelOffset": 55,
+                "anchor": 0,
+                "dashboardLink": "",
+                "directionLabel": "Aircraft on route",
+            },
+            "Z": {
+                "bandwidth": 40,
+                "query": None,
+                "labelOffset": 55,
+                "anchor": 0,
+                "dashboardLink": "",
+            },
+        },
+        "units": "short",
+        "arrows": {"width": 8, "height": 10, "offset": 2},
+        "stroke": 6,
+        "showThroughputPercentage": False,
+        # One route-level aircraft count exists, not per-direction traffic.
+        "singleDirection": True,
+    }
+    links.append(link)
+    entities.append(
+        {
+            "id": f"entity-{route}",
+            "label": route,
+            "linkId": link["id"],
+            "progressQuery": f"{route} progress",
+            "icon": "✈",
+            "size": 18,
+            "showLabel": True,
+        }
+    )
+
+weathermap = {
+    "version": base_panel["options"]["weathermap"]["version"],
+    "id": "wm-opensky-aviation",
+    "nodes": list(nodes.values()),
+    "links": links,
+    "entities": entities,
+    "scale": [
+        {"percent": 0, "color": "#73BF69"},
+        {"percent": 40, "color": "#FADE2A"},
+        {"percent": 75, "color": "#F2495C"},
+    ],
+    "settings": settings,
+}
+
+wm_panel = {
+    "datasource": "Prometheus",
+    "gridPos": {"h": 15, "w": 16, "x": 0, "y": 2},
+    "id": 1,
+    "title": "Aviation routes — live OpenSky feed",
+    "type": "tamirsuliman-weathermap-panel",
+    "targets": [
+        {
+            "refId": "A",
+            "expr": "opensky_route_aircraft",
+            "legendFormat": "{{route_id}} aircraft",
+            "range": True,
+            "format": "time_series",
+        },
+        {
+            "refId": "B",
+            "expr": "moving_entity_progress_ratio",
+            "legendFormat": "{{route_id}} progress",
+            "range": True,
+            "format": "time_series",
+        },
+    ],
+    "options": {"weathermap": weathermap},
+}
+
+
+def stat(panel_id, x, title, expr, unit="none"):
+    return {
+        "datasource": "Prometheus",
+        "gridPos": {"h": 2, "w": 8, "x": x, "y": 0},
+        "id": panel_id,
+        "title": title,
+        "type": "stat",
+        "targets": [{"refId": "A", "expr": expr, "range": False, "instant": True}],
+        "fieldConfig": {"defaults": {"unit": unit}, "overrides": []},
+        "options": {"colorMode": "value", "graphMode": "none", "reduceOptions": {"calcs": ["lastNotNull"]}},
+    }
+
+
+flights_table = {
+    "datasource": "Prometheus",
+    "gridPos": {"h": 15, "w": 8, "x": 16, "y": 2},
+    "id": 5,
+    "title": "Tracked flights",
+    "type": "table",
+    "targets": [
+        {"refId": "A", "expr": "moving_entity_progress_ratio", "format": "table", "instant": True},
+    ],
+    "transformations": [
+        {
+            "id": "organize",
+            "options": {
+                "excludeByName": {"Time": True, "__name__": True, "instance": True, "job": True, "mode": True},
+                "renameByName": {
+                    "entity_id": "Flight",
+                    "route_id": "Route",
+                    "Value": "Progress",
+                },
+            },
+        },
+        {"id": "sortBy", "options": {"sort": [{"field": "Route"}]}},
+    ],
+    "fieldConfig": {
+        "defaults": {"unit": "none", "decimals": 1},
+        "overrides": [
+            {
+                "matcher": {"id": "byName", "options": "Progress"},
+                "properties": [
+                    {"id": "unit", "value": "percentunit"},
+                    {"id": "custom.cellOptions", "value": {"type": "gauge", "mode": "gradient"}},
+                    {"id": "min", "value": 0},
+                    {"id": "max", "value": 1},
+                ],
+            }
+        ],
+    },
+    "options": {},
+}
+
+dashboard = {
+    "annotations": {"list": []},
+    "editable": True,
+    "graphTooltip": 0,
+    "links": [],
+    "refresh": "30s",
+    "schemaVersion": 39,
+    "tags": ["weathermap", "demo", "opensky"],
+    "templating": {"list": []},
+    "time": {"from": "now-30m", "to": "now"},
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "Aviation Demo — OpenSky Live",
+    "description": (
+        "Real aircraft from the OpenSky Network moving along schematic AMS/BRU/DUS "
+        "route corridors. Requires the opensky compose profile "
+        "(docker compose --profile opensky up)."
+    ),
+    "uid": "wm-opensky-aviation",
+    "version": 1,
+    "panels": [
+        stat(2, 0, "Aircraft in bounding box", "opensky_aircraft_in_bbox"),
+        stat(3, 8, "OpenSky API credits remaining", "opensky_api_credits_remaining"),
+        stat(4, 16, "Feed up", "opensky_up"),
+        wm_panel,
+        flights_table,
+    ],
+}
+
+out = os.path.join(ROOT, "wm-opensky-aviation.json")
+with open(out, "w") as f:
+    json.dump(dashboard, f, indent=2)
+    f.write("\n")
+print(f"wrote {os.path.normpath(out)}")


### PR DESCRIPTION
Closes #266

**Stacked on #275** (base branch is `feat/274-opensky-exporter`) — the live demo consumes that PR's OpenSky feed. Merge #275 first, then retarget/merge this one. Draft on purpose — **do not merge** until approved.

## What

Schematic-mode MVP of the moving-entity overlay: a marker (any text/emoji glyph — ✈ 🚆 ●) travels along a link, positioned by a **0..1 progress metric** bound by display name exactly like every other query in the panel.

```text
AMS ───── ✈ 61% ───── BRU
```

## Plugin changes (`src/`)

- **Schema**: `MovingEntity` type (`label`, `linkId`, `progressQuery`, `icon`, `size`, `showLabel`); `wm.entities` is **optional**, so `needsMigration` and the migration path are untouched — pre-existing dashboards load byte-identically.
- **Geometry**: `progressToPosition(points, progress)` pure helper in `utils.ts` — cumulative-length interpolation along a polyline (multi-segment ready for VIA paths), clamps out-of-range/non-finite progress, resolves degenerate inputs instead of throwing.
- **Rendering**: one new SVG group after the nodes layer. Progress resolves through the existing display-name `dataFrameMap`, so **timeline scrubbing replays entity movement for free** (#201 machinery). Missing/non-finite progress hides the entity. The layer is `pointerEvents: none`, so node dragging, link hover, tooltips, and click-through cannot regress.
- **Editor**: `EntityForm` section (entity picker, link picker, progress query from `buildQueryOptions`, glyph/size/label) following the LinkForm patterns — `structuredClone` before every write, explicit `inputId`s (#167).

## Live demo (`testing/`)

**Aviation Demo — OpenSky Live** (`wm-opensky-aviation`), driven by real flights from the #275 exporter:

- AMS/BRU/DUS placed at **true geographic positions** over a Benelux map background (`/benelux.svg`, generated in the same bbox projection as the route corridors and served by the opensky container).
- One ✈ entity per route bound to `moving_entity_progress_ratio` (legend `{{route_id}} progress`); links show live per-corridor aircraft counts (single-direction, `{{route_id}} aircraft`).
- Header stats: aircraft in bbox, API credits remaining, feed health. Right side: tracked-flights table with progress gauges (per user feedback: table instead of a chart).
- `testing/scripts/generate-opensky-dashboard.py` regenerates the dashboard from the WAN-demo skeleton.

## Verification

- **Unit**: `progressToPosition` (single/multi-segment, clamping, degenerate inputs); panel tests — entity renders between its nodes at progress 0.5, hides when the series is missing while the rest of the map still renders. Suite: **171 passing**; typecheck / lint / build / verify-dist clean.
- **Live in Grafana 12.4** (headless Chrome): three real flights (e.g. TAY9MS, CXI59PJ) rendered on the map and **visibly moved along their corridors between 35s samples**; flights table shows one gauge row per flight; **zero console errors**.
- Adjacent-behavior check: entity layer added strictly after existing layers, no changes to link/node/tooltip render paths; all existing tests untouched and green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a moving-entity overlay so markers (e.g., ✈) move along links using a 0..1 progress metric. Includes an OpenSky live aviation demo and an editor to configure entities, meeting #266.

- **New Features**
  - Optional `MovingEntity` type on the weathermap (`wm.entities`).
  - SVG render layer: icon and optional label; hides if progress is missing; no pointer events; timeline scrubbing replays movement.
  - `progressToPosition` helper for multi‑segment paths; clamped and degenerate‑safe.
  - `EntityForm` to pick link, progress query, icon, size, and label.
  - OpenSky demo dashboard: AMS/BRU/DUS over a Benelux map, one ✈ per route bound to `moving_entity_progress_ratio`; assets served by the exporter; generator script included.

- **Migration**
  - No changes needed. `wm.entities` is optional; existing dashboards are unchanged.

<sup>Written for commit 14b6d6343434b7ac5a8092addb6df5a8e97805ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

