### PR TITLE
fix(#283): gradient color now reaches link arrow tips

### DIFF
--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -287,6 +287,38 @@ test('Hides the timeline slider when disabled', () => {
   expect(screen.queryByTestId('weathermap-timeline')).toBeNull();
 });
 
+test('Gradient color applies to link arrow tips (issue #283)', () => {
+  let testProps = { ...mPanelProps };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  weathermap.settings.link.gradientColor = true;
+  testProps.options = { weathermap };
+  testProps.onOptionsChange = (o: SimpleOptions) => {
+    testProps.options = o;
+  };
+
+  const { container } = render(<WeathermapPanel {...testProps} />);
+  const arrows = Array.from(container.querySelectorAll('polygon'));
+  expect(arrows.length).toBeGreaterThan(0);
+  // Arrow heads must be painted with the gradient, not a solid color, so the
+  // gradient continues smoothly to the tips.
+  expect(arrows.every((p) => (p.getAttribute('fill') || '').startsWith('url(#grad'))).toBe(true);
+});
+
+test('Arrow tips use a solid color when gradient is off', () => {
+  let testProps = { ...mPanelProps };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  weathermap.settings.link.gradientColor = false;
+  testProps.options = { weathermap };
+  testProps.onOptionsChange = (o: SimpleOptions) => {
+    testProps.options = o;
+  };
+
+  const { container } = render(<WeathermapPanel {...testProps} />);
+  const arrows = Array.from(container.querySelectorAll('polygon'));
+  expect(arrows.length).toBeGreaterThan(0);
+  expect(arrows.some((p) => (p.getAttribute('fill') || '').startsWith('url(#grad'))).toBe(false);
+});
+
 // Tests plays badly with new deps
 // test('Editing a weathermap', () => {
 //   let testProps = { ...mPanelProps };

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -1366,12 +1366,18 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
             {wm.settings.link.gradientColor &&
               resolvedLinks.map((d) => (
                 <React.Fragment key={d.id}>
+                  {/*
+                    Both gradients span the full link (A node -> Z node) with the
+                    same A->Z stops so every element that samples them — the A and
+                    Z line halves and both arrow heads — sits on one continuous
+                    gradient. This removes the color break at the arrow tips (#283).
+                  */}
                   <linearGradient
                     id={`grad-a-${d.id}`}
                     x1={d.lineStartA.x}
                     y1={d.lineStartA.y}
-                    x2={d.lineEndA.x}
-                    y2={d.lineEndA.y}
+                    x2={d.lineStartZ.x}
+                    y2={d.lineStartZ.y}
                     gradientUnits="userSpaceOnUse"
                   >
                     <stop offset="0%" stopColor={getScaleColor(d.sides.A.currentValue, d.sides.A.bandwidth)} />
@@ -1379,14 +1385,14 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                   </linearGradient>
                   <linearGradient
                     id={`grad-z-${d.id}`}
-                    x1={d.lineStartZ.x}
-                    y1={d.lineStartZ.y}
-                    x2={d.lineEndZ.x}
-                    y2={d.lineEndZ.y}
+                    x1={d.lineStartA.x}
+                    y1={d.lineStartA.y}
+                    x2={d.lineStartZ.x}
+                    y2={d.lineStartZ.y}
                     gradientUnits="userSpaceOnUse"
                   >
-                    <stop offset="0%" stopColor={getScaleColor(d.sides.Z.currentValue, d.sides.Z.bandwidth)} />
-                    <stop offset="100%" stopColor={getScaleColor(d.sides.A.currentValue, d.sides.A.bandwidth)} />
+                    <stop offset="0%" stopColor={getScaleColor(d.sides.A.currentValue, d.sides.A.bandwidth)} />
+                    <stop offset="100%" stopColor={getScaleColor(d.sides.Z.currentValue, d.sides.Z.bandwidth)} />
                   </linearGradient>
                 </React.Fragment>
               ))}
@@ -1544,7 +1550,13 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                                         ${d.arrowPolygonA.p2.x}
                                         ${d.arrowPolygonA.p2.y}
                                     `}
-                          fill={d.isDown ? (d.statusDownColor || '#d32f2f') : getScaleColor(d.sides.A.currentValue, d.sides.A.bandwidth)}
+                          fill={
+                            d.isDown
+                              ? (d.statusDownColor || '#d32f2f')
+                              : wm.settings.link.gradientColor
+                              ? `url(#grad-a-${d.id})`
+                              : getScaleColor(d.sides.A.currentValue, d.sides.A.bandwidth)
+                          }
                           onMouseMove={(e) => {
                             handleLinkHover(d, 'A', e);
                           }}
@@ -1602,7 +1614,13 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                                         ${d.arrowPolygonZ.p2.x}
                                         ${d.arrowPolygonZ.p2.y}
                                     `}
-                          fill={d.isDown ? (d.statusDownColor || '#d32f2f') : getScaleColor(d.sides.Z.currentValue, d.sides.Z.bandwidth)}
+                          fill={
+                            d.isDown
+                              ? (d.statusDownColor || '#d32f2f')
+                              : wm.settings.link.gradientColor
+                              ? `url(#grad-z-${d.id})`
+                              : getScaleColor(d.sides.Z.currentValue, d.sides.Z.bandwidth)
+                          }
                           onMouseMove={(e) => {
                             handleLinkHover(d, 'Z', e);
                           }}


### PR DESCRIPTION
Closes #283.

## Root cause (verified)
With **Gradient Color** enabled, the link *lines* are stroked with the per-link gradient (`url(#grad-a/z-…)`), but both **arrow polygons** were filled with a *solid* `getScaleColor(side)` color. So the arrow head color jumps away from the gradient's end — the "jarring break at the tips" in the report. The two gradients were also defined per-half (mirrored A→lineEndA / Z→lineEndZ), not one smooth span.

## Fix
1. Define **both** gradients across the **full link** (A node → Z node) with the same A→Z stops, so the A line, Z line, and both arrow heads all sample **one continuous gradient**.
2. Fill the A and Z **arrow polygons** with the gradient (`url(#grad-a/z-…)`) when Gradient Color is on.

Result: one smooth gradient from node to node, including the tips.

## Regression safety
- Only the **gradient-enabled** path changes. When Gradient Color is **off**, links keep their solid `getScaleColor` fill (unchanged). The **down** state (dashed + `statusDownColor`) is checked first and is untouched. Flow-animation, connection-node joins, and single-direction links are not modified.
- `npm run typecheck` passes.
- New tests: arrow polygons use a gradient fill when Gradient Color is on, and a solid fill when it is off.

> Note: local test execution was temporarily blocked by a broken permission-approval channel in my environment (`npm ci` and typecheck ran fine; the jest runner could not get approval). **Please let CI validate the full suite here** — I have not merged to `main` and won't until these checks are green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes issue #283 by extending the gradient to link arrow tips, removing the color break at the ends. The link now uses one continuous A→Z gradient across both line halves and arrow heads.

- **Bug Fixes**
  - Gradients span the full link with shared A→Z stops; arrow polygons fill with `url(#grad-a-*)` / `url(#grad-z-*)` when Gradient Color is on.
  - Solid-color and "down" states are unchanged; when Gradient Color is off, tips stay solid. Tests cover both cases.

<sup>Written for commit 67f68be61ed56cbc208b68c6d70021d3f6df7fd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

