### PR TITLE
fix(#277): timeline slider no longer shows a cut-off unix timestamp

### DIFF
--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -274,6 +274,16 @@ test('Shows the timeline slider when enabled', () => {
   expect(timeline).not.toBeNull();
   // Starts in the live state.
   expect(timeline.textContent).toContain('Live');
+
+  // The slider is driven by a small 0..500 position index, so its numeric box
+  // never shows a raw 13-digit epoch timestamp that would be cut off (#277).
+  const sliderInput = timeline.querySelector('input') as HTMLInputElement | null;
+  expect(sliderInput).not.toBeNull();
+  const shown = Number(sliderInput!.value);
+  expect(Number.isNaN(shown)).toBe(false);
+  expect(shown).toBeLessThanOrEqual(500);
+  // Must not be the raw time-range value (2_000_000 in this mock).
+  expect(shown).toBeLessThan(1_000_000);
 });
 
 test('Hides the timeline slider when disabled', () => {

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -1928,7 +1928,13 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
               return null;
             }
             const current = effectiveScrub ?? toMs;
-            const step = Math.max(1, Math.round((toMs - fromMs) / 500));
+            // Drive the slider on a small 0..STEPS position index rather than raw
+            // epoch milliseconds, so Grafana's built-in value box shows a short
+            // number instead of a 13-digit timestamp that gets cut off (#277).
+            // The readable timestamp is shown in the label to the left.
+            const STEPS = 500;
+            const span = toMs - fromMs;
+            const position = Math.round(((current - fromMs) / span) * STEPS);
             return (
               <div
                 data-testid="weathermap-timeline"
@@ -1945,16 +1951,18 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                   border-top: 1px solid ${theme.colors.border.weak};
                 `}
               >
-                <span style={{ fontSize: '12px', whiteSpace: 'nowrap', minWidth: '128px' }}>
+                <span
+                  style={{ fontSize: '12px', whiteSpace: 'nowrap', flexShrink: 0, minWidth: '128px' }}
+                >
                   {useTimeline ? dateTimeFormat(current, { timeZone: getTimeZone() }) : 'Live (latest)'}
                 </span>
                 <div style={{ flex: '1 1 auto' }}>
                   <Slider
-                    min={fromMs}
-                    max={toMs}
-                    step={step}
-                    value={current}
-                    onChange={(v) => setScrubTime(v)}
+                    min={0}
+                    max={STEPS}
+                    step={1}
+                    value={position}
+                    onChange={(v) => setScrubTime(Math.round(fromMs + (v / STEPS) * span))}
                   />
                 </div>
                 <Button variant="secondary" size="sm" disabled={!useTimeline} onClick={() => setScrubTime(null)}>


### PR DESCRIPTION
Closes #277.

## Root cause
Grafana's `Slider` renders a numeric value box beside the track. The timeline slider used **raw epoch-millisecond** bounds (`min=fromMs`, `max=toMs`, `value=ms`), so that box tried to display a 13-digit number like `1783499636416` in a narrow field — visually cut off.

## Fix
Drive the slider on a small **0–500 position index** instead of milliseconds, converting to/from the timestamp in `onChange`. The value box now shows a short number; the readable, timezone-aware timestamp continues to show in the label to the left (made `flex-shrink: 0` so it is never clipped).

Value resolution is unchanged — `setScrubTime` still stores a real millisecond timestamp, which `effectiveScrub` clamps and `dataFrameMap` uses to resolve link values.

## Verification (run locally)
- `npm run typecheck` → pass
- `npm run test:ci` → **167/167 pass** (new assertion: the slider's numeric input shows the small position index, never the raw time-range value)
- `npm run lint` → pass
- `npm run build` → success

Staged for the next release (not released here). Open/dependabot PRs left untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the timeline slider so it no longer shows a cut‑off 13‑digit Unix timestamp. The slider now uses a 0–500 position index and converts to/from milliseconds on change; the left timestamp label is set to not shrink so it never clips.

<sup>Written for commit fa1faa6037d4833aa3b8c9d0aa5d8a23f7819661. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

