### PR TITLE
fix(#282): keep node label when toggling Use As Connection; harden new-node colors (#281)

### DIFF
--- a/src/forms/NodeForm.test.tsx
+++ b/src/forms/NodeForm.test.tsx
@@ -160,3 +160,44 @@ test('node color change delivers new node and colors references (#225)', async (
   expect(updated.nodes[0].colors).not.toBe(initial.nodes[0].colors);
   expect(initial).toEqual(before);
 });
+
+test('toggling Use As Connection keeps the node label (#282)', async () => {
+  const spy = jest.fn();
+  const initial = getData(theme);
+  render(<Harness initial={initial} onChangeSpy={spy} />);
+
+  // Select Node A and open the Advanced section.
+  const picker = screen.getAllByRole('combobox')[0];
+  fireEvent.keyDown(picker, { key: 'ArrowDown' });
+  fireEvent.click(await screen.findByText('Node A'));
+  fireEvent.click(screen.getByText('Advanced'));
+
+  // Toggle "Use As Connection (BETA)".
+  let el: HTMLElement | null = screen.getByText('Use As Connection (BETA)');
+  while (el && !el.querySelector('input')) {
+    el = el.parentElement;
+  }
+  const toggle = el!.querySelector('input') as HTMLInputElement;
+  fireEvent.click(toggle);
+
+  const updated = spy.mock.calls[spy.mock.calls.length - 1][0];
+  const nodeA = updated.nodes.find((n: { label?: string }) => n.label === 'Node A');
+  // The node keeps its label (not renamed to "C0") and becomes a connection.
+  expect(nodeA).toBeDefined();
+  expect(nodeA.isConnection).toBe(true);
+});
+
+test('a newly added node gets its own colors object (#281)', () => {
+  const spy = jest.fn();
+  const initial = getData(theme);
+  render(<Harness initial={initial} onChangeSpy={spy} />);
+
+  fireEvent.click(screen.getByText('Add Node'));
+
+  const updated = spy.mock.calls[spy.mock.calls.length - 1][0];
+  const newNode = updated.nodes[updated.nodes.length - 1];
+  // Same values as the first node, but a distinct object — so editing one
+  // node's color can never affect another (#281).
+  expect(newNode.colors).toEqual(updated.nodes[0].colors);
+  expect(newNode.colors).not.toBe(updated.nodes[0].colors);
+});

--- a/src/forms/NodeForm.tsx
+++ b/src/forms/NodeForm.tsx
@@ -46,10 +46,6 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
   const theme = useTheme2();
   const [lockAspectRatio, setLockAspectRatio] = useState(false);
 
-  let connectionCounter = 0;
-  for (let node of value.nodes) {
-    connectionCounter += node.isConnection ? 1 : 0;
-  }
 
   const handleChange = (e: React.FormEvent<HTMLInputElement>, i: number) => {
     // Immutable update (#225): clone the touched node so onChange delivers a
@@ -99,7 +95,8 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
   };
 
   const handleConnectionChange = (e: React.FormEvent<HTMLInputElement>, i: number): void => {
-    updateNode(i, { isConnection: e.currentTarget.checked, label: 'C' + connectionCounter });
+    // Toggling "Use As Connection" must not rename the node — keep its label (#282).
+    updateNode(i, { isConnection: e.currentTarget.checked });
   };
 
   const handleStatusQueryChange = (query: string | undefined, i: number) => {
@@ -202,7 +199,9 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
       },
       colors:
         weathermap.nodes.length > 0
-          ? weathermap.nodes[0].colors
+          ? // Clone so the new node doesn't share the first node's colors object
+            // by reference (#281) — otherwise editing one could affect the other.
+            { ...weathermap.nodes[0].colors }
           : {
               font: theme.colors.secondary.contrastText,
               background: theme.colors.secondary.main,


### PR DESCRIPTION
Staged for the next release.

## #282 — Use As Connection renamed the node (present on 1.5.14)
**Root cause:** `handleConnectionChange` always wrote `label: 'C' + connectionCounter` when the toggle changed, overwriting the user's label (→ "C0").
**Fix:** only flip `isConnection`; leave the label alone. Removed the now-unused `connectionCounter`. Connection nodes still hide their label in view mode, so nothing else changes.

## #281 — new node shared the first node's colors (hardening)
The user-facing symptom (changing a node's color changed the first node) was **already fixed** on current — `handleColorChange` is immutable (`{ ...node.colors, [type]: color }`). But `addNewNode` still assigned `colors: nodes[0].colors` by reference (latent). This clones it (`{ ...nodes[0].colors }`) so nodes can never share a colors object.

## Verification (run locally)
- `npm run typecheck` → pass
- `npm run test:ci` → **169/169 pass** (2 new: toggling Use As Connection keeps the label; a new node gets a distinct colors object)
- `npm run lint` → pass
- `npm run build` → success

Not merged — bundling with the other staged fixes for the next release. Open/dependabot PRs left untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the node label when toggling “Use As Connection” and ensures new nodes get their own colors object, preventing accidental renames and color coupling. Addresses Linear #282 and #281.

- **Bug Fixes**
  - #282: `handleConnectionChange` now only flips `isConnection` and no longer overwrites the label; removed the unused connection counter.
  - #281: `addNewNode` clones the first node’s `colors` instead of sharing the object by reference, so nodes don’t share state.

<sup>Written for commit ef7442b26fa0e3d8d422677cddad00a10f361764. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

