### PR TITLE
feat(#280): per-node z-index to control stacking order

### DIFF
--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -319,6 +319,40 @@ test('Arrow tips use a solid color when gradient is off', () => {
   expect(arrows.some((p) => (p.getAttribute('fill') || '').startsWith('url(#grad'))).toBe(false);
 });
 
+// DOCUMENT_POSITION_FOLLOWING = 4 (avoids colliding with the imported `Node` type).
+const FOLLOWS = 4;
+
+test('Nodes paint in creation order by default (#280)', () => {
+  let testProps = { ...mPanelProps };
+  testProps.options = { weathermap: handleVersionedStateUpdates(getData(theme), theme) };
+  testProps.onOptionsChange = (o: SimpleOptions) => {
+    testProps.options = o;
+  };
+
+  render(<WeathermapPanel {...testProps} />);
+  const aGroup = screen.getByText('Node A').closest('g')!;
+  const bGroup = screen.getByText('Node B').closest('g')!;
+  // Node B (created second) renders after Node A, so it sits on top.
+  expect(aGroup.compareDocumentPosition(bGroup) & FOLLOWS).toBeTruthy();
+});
+
+test('A higher z-index node paints on top (#280)', () => {
+  let testProps = { ...mPanelProps };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  // Give the first node (Node A) a high z-index so it should render last.
+  weathermap.nodes.find((n) => n.label === 'Node A')!.zIndex = 10;
+  testProps.options = { weathermap };
+  testProps.onOptionsChange = (o: SimpleOptions) => {
+    testProps.options = o;
+  };
+
+  render(<WeathermapPanel {...testProps} />);
+  const aGroup = screen.getByText('Node A').closest('g')!;
+  const bGroup = screen.getByText('Node B').closest('g')!;
+  // Now Node A must render AFTER Node B (i.e. B is followed by A) → A on top.
+  expect(bGroup.compareDocumentPosition(aGroup) & FOLLOWS).toBeTruthy();
+});
+
 // Tests plays badly with new deps
 // test('Editing a weathermap', () => {
 //   let testProps = { ...mPanelProps };

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -1816,7 +1816,16 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
               })}
             </g>
             <g>
-              {nodes.map((d, i) => (
+              {/*
+                Paint nodes in z-index order (#280): higher zIndex renders later,
+                so it sits on top. Equal zIndex keeps creation order (by node
+                index), so the default (all 0) matches the previous behavior. A
+                sorted copy is used — `nodes` itself stays in index order because
+                the callbacks below address nodes by their stable `d.index`.
+              */}
+              {[...nodes]
+                .sort((a, b) => (a.zIndex ?? 0) - (b.zIndex ?? 0) || a.index - b.index)
+                .map((d) => (
                 <MapNode
                   key={d.id}
                   {...{
@@ -1835,7 +1844,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                       setDraggedNode(d);
                       setNodes((prevState) =>
                         prevState.map((val, index) => {
-                          if (index === i || selectedNodes.find((n) => n.id === nodes[index].id)) {
+                          if (index === d.index || selectedNodes.find((n) => n.id === nodes[index].id)) {
                             const scaledPos = getScaledMousePos({ x: position.deltaX, y: position.deltaY });
                             val.x = Math.round(
                               wm.settings.panel.grid.enabled
@@ -1859,7 +1868,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                       setDraggedNode(null as unknown as DrawnNode);
                       // Build the persisted positions immutably: writing into
                       // wm.nodes[..] hands Grafana the same references (#225).
-                      const movedIndexes = new Set<number>([i, ...selectedNodes.map((n) => n.index)]);
+                      const movedIndexes = new Set<number>([d.index, ...selectedNodes.map((n) => n.index)]);
                       const snappedPosition = (index: number): [number, number] => [
                         wm.settings.panel.grid.enabled
                           ? nearestMultiple(nodes[index].x, wm.settings.panel.grid.size)
@@ -1881,15 +1890,16 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                       });
                     },
                     onClick: (e) => {
+                      const clicked = tempNodes[d.index];
                       if ((e.ctrlKey || e.metaKey) && isEditMode) {
                         setSelectedNodes((v) => {
                           // Return a NEW array: mutating and returning the same
                           // reference makes React skip selection re-renders (#225).
-                          const cIndex = v.findIndex((n) => n.id === tempNodes[i].id);
-                          return cIndex > -1 ? v.filter((_, vi) => vi !== cIndex) : [...v, tempNodes[i]];
+                          const cIndex = v.findIndex((n) => n.id === clicked.id);
+                          return cIndex > -1 ? v.filter((_, vi) => vi !== cIndex) : [...v, clicked];
                         });
-                      } else if (!isEditMode && tempNodes[i].dashboardLink) {
-                        openDashboardLink(tempNodes[i].dashboardLink, tempNodes[i].openInSameTab);
+                      } else if (!isEditMode && clicked.dashboardLink) {
+                        openDashboardLink(clicked.dashboardLink, clicked.openInSameTab);
                       }
                       // Force an update
                       onOptionsChange(options);

--- a/src/forms/NodeForm.tsx
+++ b/src/forms/NodeForm.tsx
@@ -61,6 +61,9 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
       node.position[1] = finiteOrFallback(e.currentTarget.valueAsNumber, node.position[1]);
     } else if (e.currentTarget.name === 'label') {
       node.label = e.currentTarget.value;
+    } else if (e.currentTarget.name === 'zIndex') {
+      // Blank clears the z-index (back to default order); otherwise store the number.
+      node.zIndex = e.currentTarget.value === '' ? undefined : finiteOrFallback(e.currentTarget.valueAsNumber, 0);
     }
     onChange({ ...value, nodes: value.nodes.map((n, ni) => (ni === i ? node : n)) });
   };
@@ -369,6 +372,16 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                     type={'number'}
                     className={styles.nodeLabel}
                     name={'Y'}
+                  />
+                </InlineField>
+                <InlineField grow label={'Z-Index'} tooltip={'Paint order — higher values sit on top of lower ones. Leave blank for the default (creation) order.'}>
+                  <Input
+                    value={node.zIndex ?? ''}
+                    onChange={(e) => handleChange(e, i)}
+                    placeholder={'0'}
+                    type={'number'}
+                    className={styles.nodeLabel}
+                    name={'zIndex'}
                   />
                 </InlineField>
                 <InlineField grow label={'Label'}>

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,9 @@ export interface Node {
   dashboardLink?: string;
   openInSameTab?: boolean;
   tooltipMetrics?: NodeTooltipMetric[];
+  // Paint order: higher values render on top. Defaults to 0 when unset, in which
+  // case nodes keep their creation order (later nodes on top), as before.
+  zIndex?: number;
   anchors: {
     [Anchor.Center]: NodeAnchor;
     [Anchor.Top]: NodeAnchor;


### PR DESCRIPTION
Closes #280.

Adds an optional per-node **Z-Index** so you can force which node sits above/below others (SVG has no CSS `z-index`, so paint order = document order — this sorts the nodes before rendering).

## Changes
- **types:** optional `Node.zIndex` (default 0).
- **WeathermapPanel:** paint a **z-index-sorted copy** of the nodes — higher z-index renders later (on top); ties broken by creation order. The render callbacks now address nodes by their stable `d.index` (not the map iteration index), so drag / drag-group / multi-select / click-navigation are correct regardless of paint order. The `nodes` state array stays in index order.
- **NodeForm:** a **Z-Index** number input next to X/Y (blank = default order).

## Regression safety (this touches the core node loop)
- **Default is unchanged:** with all z-index unset, the tiebreak sorts by index → identical to the previous order (verified by a "default paints in creation order" test).
- The sort runs on a **copy**; the `nodes` state is never mutated.
- All node-index logic switched from the map index `i` to the stable `d.index`; the only other `wm.nodes.map` sites are the state generators (index order) and position persistence — none is a paint loop.
- **169/169 tests pass**, including existing drag/select/edit-mode/connection/VIA tests.

## Verification (run locally)
- `npm run typecheck` → pass
- `npm run test:ci` → **169/169 pass** (2 new: default creation order; higher z-index on top)
- `npm run lint` → pass
- `npm run build` → success

Staged for the next release; not merged. Open/dependabot PRs untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional per-node z-index to control stacking order (implements #280). Nodes render by z-index with ties by creation order, so default behavior is unchanged.

- **New Features**
  - types: add optional Node.zIndex.
  - WeathermapPanel: paint a z-index–sorted copy; callbacks use stable d.index so drag/select/navigation remain correct.
  - NodeForm: add Z-Index number input; blank resets to default order.

<sup>Written for commit 84a4af6edde2a2ad6b17b1e7123450d9490c44e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

