### PR TITLE
release: v1.5.15 (timeline timestamp, connection label, node colors, node z-index, gradient tips)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.5.15](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.15) (2026-07-08)
+
+### Features
+
+* **node-z-index**: each node now has an optional **Z-Index** field (next to X/Y) to control stacking order — higher values paint on top; blank keeps the default creation order, so existing maps are unchanged ([#280](https://github.com/allamiro/grafana-network-weathermap-ng/issues/280), PR [#287](https://github.com/allamiro/grafana-network-weathermap-ng/pull/287))
+
+### Bug Fixes
+
+* **timeline-timestamp**: the timeline slider no longer shows a cut-off unix timestamp — the slider is driven by a small position index and the readable, timezone-aware timestamp is shown in the label ([#277](https://github.com/allamiro/grafana-network-weathermap-ng/issues/277), PR [#285](https://github.com/allamiro/grafana-network-weathermap-ng/pull/285))
+* **connection-label**: toggling **Use As Connection (BETA)** no longer overwrites the node's label with `C<n>` — the label is preserved ([#282](https://github.com/allamiro/grafana-network-weathermap-ng/issues/282), PR [#286](https://github.com/allamiro/grafana-network-weathermap-ng/pull/286))
+* **node-colors**: a newly added node now gets its own colors object instead of sharing the first node's by reference, hardening against cross-node color edits ([#281](https://github.com/allamiro/grafana-network-weathermap-ng/issues/281), PR [#286](https://github.com/allamiro/grafana-network-weathermap-ng/pull/286))
+* **gradient-arrow-tips**: link gradient coloring now spans the full A→Z path and paints the arrow heads, removing the color break at the tips ([#283](https://github.com/allamiro/grafana-network-weathermap-ng/issues/283), PR [#284](https://github.com/allamiro/grafana-network-weathermap-ng/pull/284))
+
 ## [1.5.14](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.14) (2026-07-04)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.14",
+  "version": "1.5.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamirsuliman-weathermap-panel",
-      "version": "1.5.14",
+      "version": "1.5.15",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.5.14",
+  "version": "1.5.15",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -319,6 +319,40 @@ test('Arrow tips use a solid color when gradient is off', () => {
   expect(arrows.some((p) => (p.getAttribute('fill') || '').startsWith('url(#grad'))).toBe(false);
 });
 
+// DOCUMENT_POSITION_FOLLOWING = 4 (avoids colliding with the imported `Node` type).
+const FOLLOWS = 4;
+
+test('Nodes paint in creation order by default (#280)', () => {
+  let testProps = { ...mPanelProps };
+  testProps.options = { weathermap: handleVersionedStateUpdates(getData(theme), theme) };
+  testProps.onOptionsChange = (o: SimpleOptions) => {
+    testProps.options = o;
+  };
+
+  render(<WeathermapPanel {...testProps} />);
+  const aGroup = screen.getByText('Node A').closest('g')!;
+  const bGroup = screen.getByText('Node B').closest('g')!;
+  // Node B (created second) renders after Node A, so it sits on top.
+  expect(aGroup.compareDocumentPosition(bGroup) & FOLLOWS).toBeTruthy();
+});
+
+test('A higher z-index node paints on top (#280)', () => {
+  let testProps = { ...mPanelProps };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  // Give the first node (Node A) a high z-index so it should render last.
+  weathermap.nodes.find((n) => n.label === 'Node A')!.zIndex = 10;
+  testProps.options = { weathermap };
+  testProps.onOptionsChange = (o: SimpleOptions) => {
+    testProps.options = o;
+  };
+
+  render(<WeathermapPanel {...testProps} />);
+  const aGroup = screen.getByText('Node A').closest('g')!;
+  const bGroup = screen.getByText('Node B').closest('g')!;
+  // Now Node A must render AFTER Node B (i.e. B is followed by A) → A on top.
+  expect(bGroup.compareDocumentPosition(aGroup) & FOLLOWS).toBeTruthy();
+});
+
 // Tests plays badly with new deps
 // test('Editing a weathermap', () => {
 //   let testProps = { ...mPanelProps };

--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -274,6 +274,16 @@ test('Shows the timeline slider when enabled', () => {
   expect(timeline).not.toBeNull();
   // Starts in the live state.
   expect(timeline.textContent).toContain('Live');
+
+  // The slider is driven by a small 0..500 position index, so its numeric box
+  // never shows a raw 13-digit epoch timestamp that would be cut off (#277).
+  const sliderInput = timeline.querySelector('input') as HTMLInputElement | null;
+  expect(sliderInput).not.toBeNull();
+  const shown = Number(sliderInput!.value);
+  expect(Number.isNaN(shown)).toBe(false);
+  expect(shown).toBeLessThanOrEqual(500);
+  // Must not be the raw time-range value (2_000_000 in this mock).
+  expect(shown).toBeLessThan(1_000_000);
 });
 
 test('Hides the timeline slider when disabled', () => {

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -1816,7 +1816,16 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
               })}
             </g>
             <g>
-              {nodes.map((d, i) => (
+              {/*
+                Paint nodes in z-index order (#280): higher zIndex renders later,
+                so it sits on top. Equal zIndex keeps creation order (by node
+                index), so the default (all 0) matches the previous behavior. A
+                sorted copy is used — `nodes` itself stays in index order because
+                the callbacks below address nodes by their stable `d.index`.
+              */}
+              {[...nodes]
+                .sort((a, b) => (a.zIndex ?? 0) - (b.zIndex ?? 0) || a.index - b.index)
+                .map((d) => (
                 <MapNode
                   key={d.id}
                   {...{
@@ -1835,7 +1844,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                       setDraggedNode(d);
                       setNodes((prevState) =>
                         prevState.map((val, index) => {
-                          if (index === i || selectedNodes.find((n) => n.id === nodes[index].id)) {
+                          if (index === d.index || selectedNodes.find((n) => n.id === nodes[index].id)) {
                             const scaledPos = getScaledMousePos({ x: position.deltaX, y: position.deltaY });
                             val.x = Math.round(
                               wm.settings.panel.grid.enabled
@@ -1859,7 +1868,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                       setDraggedNode(null as unknown as DrawnNode);
                       // Build the persisted positions immutably: writing into
                       // wm.nodes[..] hands Grafana the same references (#225).
-                      const movedIndexes = new Set<number>([i, ...selectedNodes.map((n) => n.index)]);
+                      const movedIndexes = new Set<number>([d.index, ...selectedNodes.map((n) => n.index)]);
                       const snappedPosition = (index: number): [number, number] => [
                         wm.settings.panel.grid.enabled
                           ? nearestMultiple(nodes[index].x, wm.settings.panel.grid.size)
@@ -1881,15 +1890,16 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                       });
                     },
                     onClick: (e) => {
+                      const clicked = tempNodes[d.index];
                       if ((e.ctrlKey || e.metaKey) && isEditMode) {
                         setSelectedNodes((v) => {
                           // Return a NEW array: mutating and returning the same
                           // reference makes React skip selection re-renders (#225).
-                          const cIndex = v.findIndex((n) => n.id === tempNodes[i].id);
-                          return cIndex > -1 ? v.filter((_, vi) => vi !== cIndex) : [...v, tempNodes[i]];
+                          const cIndex = v.findIndex((n) => n.id === clicked.id);
+                          return cIndex > -1 ? v.filter((_, vi) => vi !== cIndex) : [...v, clicked];
                         });
-                      } else if (!isEditMode && tempNodes[i].dashboardLink) {
-                        openDashboardLink(tempNodes[i].dashboardLink, tempNodes[i].openInSameTab);
+                      } else if (!isEditMode && clicked.dashboardLink) {
+                        openDashboardLink(clicked.dashboardLink, clicked.openInSameTab);
                       }
                       // Force an update
                       onOptionsChange(options);

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -1928,7 +1928,13 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
               return null;
             }
             const current = effectiveScrub ?? toMs;
-            const step = Math.max(1, Math.round((toMs - fromMs) / 500));
+            // Drive the slider on a small 0..STEPS position index rather than raw
+            // epoch milliseconds, so Grafana's built-in value box shows a short
+            // number instead of a 13-digit timestamp that gets cut off (#277).
+            // The readable timestamp is shown in the label to the left.
+            const STEPS = 500;
+            const span = toMs - fromMs;
+            const position = Math.round(((current - fromMs) / span) * STEPS);
             return (
               <div
                 data-testid="weathermap-timeline"
@@ -1945,16 +1951,18 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                   border-top: 1px solid ${theme.colors.border.weak};
                 `}
               >
-                <span style={{ fontSize: '12px', whiteSpace: 'nowrap', minWidth: '128px' }}>
+                <span
+                  style={{ fontSize: '12px', whiteSpace: 'nowrap', flexShrink: 0, minWidth: '128px' }}
+                >
                   {useTimeline ? dateTimeFormat(current, { timeZone: getTimeZone() }) : 'Live (latest)'}
                 </span>
                 <div style={{ flex: '1 1 auto' }}>
                   <Slider
-                    min={fromMs}
-                    max={toMs}
-                    step={step}
-                    value={current}
-                    onChange={(v) => setScrubTime(v)}
+                    min={0}
+                    max={STEPS}
+                    step={1}
+                    value={position}
+                    onChange={(v) => setScrubTime(Math.round(fromMs + (v / STEPS) * span))}
                   />
                 </div>
                 <Button variant="secondary" size="sm" disabled={!useTimeline} onClick={() => setScrubTime(null)}>

--- a/src/forms/NodeForm.test.tsx
+++ b/src/forms/NodeForm.test.tsx
@@ -160,3 +160,44 @@ test('node color change delivers new node and colors references (#225)', async (
   expect(updated.nodes[0].colors).not.toBe(initial.nodes[0].colors);
   expect(initial).toEqual(before);
 });
+
+test('toggling Use As Connection keeps the node label (#282)', async () => {
+  const spy = jest.fn();
+  const initial = getData(theme);
+  render(<Harness initial={initial} onChangeSpy={spy} />);
+
+  // Select Node A and open the Advanced section.
+  const picker = screen.getAllByRole('combobox')[0];
+  fireEvent.keyDown(picker, { key: 'ArrowDown' });
+  fireEvent.click(await screen.findByText('Node A'));
+  fireEvent.click(screen.getByText('Advanced'));
+
+  // Toggle "Use As Connection (BETA)".
+  let el: HTMLElement | null = screen.getByText('Use As Connection (BETA)');
+  while (el && !el.querySelector('input')) {
+    el = el.parentElement;
+  }
+  const toggle = el!.querySelector('input') as HTMLInputElement;
+  fireEvent.click(toggle);
+
+  const updated = spy.mock.calls[spy.mock.calls.length - 1][0];
+  const nodeA = updated.nodes.find((n: { label?: string }) => n.label === 'Node A');
+  // The node keeps its label (not renamed to "C0") and becomes a connection.
+  expect(nodeA).toBeDefined();
+  expect(nodeA.isConnection).toBe(true);
+});
+
+test('a newly added node gets its own colors object (#281)', () => {
+  const spy = jest.fn();
+  const initial = getData(theme);
+  render(<Harness initial={initial} onChangeSpy={spy} />);
+
+  fireEvent.click(screen.getByText('Add Node'));
+
+  const updated = spy.mock.calls[spy.mock.calls.length - 1][0];
+  const newNode = updated.nodes[updated.nodes.length - 1];
+  // Same values as the first node, but a distinct object — so editing one
+  // node's color can never affect another (#281).
+  expect(newNode.colors).toEqual(updated.nodes[0].colors);
+  expect(newNode.colors).not.toBe(updated.nodes[0].colors);
+});

--- a/src/forms/NodeForm.tsx
+++ b/src/forms/NodeForm.tsx
@@ -46,10 +46,6 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
   const theme = useTheme2();
   const [lockAspectRatio, setLockAspectRatio] = useState(false);
 
-  let connectionCounter = 0;
-  for (let node of value.nodes) {
-    connectionCounter += node.isConnection ? 1 : 0;
-  }
 
   const handleChange = (e: React.FormEvent<HTMLInputElement>, i: number) => {
     // Immutable update (#225): clone the touched node so onChange delivers a
@@ -99,7 +95,8 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
   };
 
   const handleConnectionChange = (e: React.FormEvent<HTMLInputElement>, i: number): void => {
-    updateNode(i, { isConnection: e.currentTarget.checked, label: 'C' + connectionCounter });
+    // Toggling "Use As Connection" must not rename the node — keep its label (#282).
+    updateNode(i, { isConnection: e.currentTarget.checked });
   };
 
   const handleStatusQueryChange = (query: string | undefined, i: number) => {
@@ -202,7 +199,9 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
       },
       colors:
         weathermap.nodes.length > 0
-          ? weathermap.nodes[0].colors
+          ? // Clone so the new node doesn't share the first node's colors object
+            // by reference (#281) — otherwise editing one could affect the other.
+            { ...weathermap.nodes[0].colors }
           : {
               font: theme.colors.secondary.contrastText,
               background: theme.colors.secondary.main,

--- a/src/forms/NodeForm.tsx
+++ b/src/forms/NodeForm.tsx
@@ -61,6 +61,9 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
       node.position[1] = finiteOrFallback(e.currentTarget.valueAsNumber, node.position[1]);
     } else if (e.currentTarget.name === 'label') {
       node.label = e.currentTarget.value;
+    } else if (e.currentTarget.name === 'zIndex') {
+      // Blank clears the z-index (back to default order); otherwise store the number.
+      node.zIndex = e.currentTarget.value === '' ? undefined : finiteOrFallback(e.currentTarget.valueAsNumber, 0);
     }
     onChange({ ...value, nodes: value.nodes.map((n, ni) => (ni === i ? node : n)) });
   };
@@ -369,6 +372,16 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                     type={'number'}
                     className={styles.nodeLabel}
                     name={'Y'}
+                  />
+                </InlineField>
+                <InlineField grow label={'Z-Index'} tooltip={'Paint order — higher values sit on top of lower ones. Leave blank for the default (creation) order.'}>
+                  <Input
+                    value={node.zIndex ?? ''}
+                    onChange={(e) => handleChange(e, i)}
+                    placeholder={'0'}
+                    type={'number'}
+                    className={styles.nodeLabel}
+                    name={'zIndex'}
                   />
                 </InlineField>
                 <InlineField grow label={'Label'}>

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,9 @@ export interface Node {
   dashboardLink?: string;
   openInSameTab?: boolean;
   tooltipMetrics?: NodeTooltipMetric[];
+  // Paint order: higher values render on top. Defaults to 0 when unset, in which
+  // case nodes keep their creation order (later nodes on top), as before.
+  zIndex?: number;
   anchors: {
     [Anchor.Center]: NodeAnchor;
     [Anchor.Top]: NodeAnchor;


### PR DESCRIPTION
Bundles the staged fixes/feature into **v1.5.15**:

- **#285** — timeline slider no longer shows a cut-off unix timestamp (#277)
- **#286** — Use As Connection keeps the node label (#282) + new-node color hardening (#281)
- **#287** — per-node Z-Index for stacking order (#280)
- **#284** — gradient reaches the link arrow tips (#283, already on main since v1.5.14)

Integrated on a release branch; all three feature branches merged cleanly (no conflicts). Bumps version + changelog.

## Combined verification (local)
- `npm run typecheck` → pass
- `npm run test:ci` → **171/171 pass**
- `npm run lint` → pass
- `npm run build` → success

Merging with a merge commit so #285/#286/#287 auto-close (and issues #277/#282/#280).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.5.15 adds per-node z-index to control node stacking and extends link gradients to arrow tips. It also fixes the timeline slider value, preserves labels when using “Use As Connection”, and isolates new-node colors.

- **New Features**
  - Per-node z-index input next to X/Y; higher renders on top. Defaults keep creation order (issue #280).
  - Link gradient now covers arrow heads across the full A→Z path (issue #283).

- **Bug Fixes**
  - Timeline slider shows a small 0..500 position index; timestamp stays in the label, avoiding cut-off (issue #277).
  - Toggling “Use As Connection (BETA)” no longer renames the node; label is preserved (issue #282).
  - New nodes get a cloned colors object to prevent shared references across nodes (issue #281).

<sup>Written for commit 719db5ca68b62cfc4f3a0901b93a59399e1ab8ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

