### PR TITLE
feat(#279): raise the node padding cap so nodes can be larger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Features
 
+* **larger nodes**: the node padding sliders now go up to 200 (previously 50, which also snapped back typed values), so nodes can be sized for faceplate/background layouts ([#279](https://github.com/allamiro/grafana-network-weathermap-ng/issues/279), PR [#289](https://github.com/allamiro/grafana-network-weathermap-ng/pull/289))
 * **node-z-index**: each node now has an optional **Z-Index** field (next to X/Y) to control stacking order — higher values paint on top; blank keeps the default creation order, so existing maps are unchanged ([#280](https://github.com/allamiro/grafana-network-weathermap-ng/issues/280), PR [#287](https://github.com/allamiro/grafana-network-weathermap-ng/pull/287))
 
 ### Bug Fixes

--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -965,3 +965,23 @@ test('VIA remove leaves the rendered options untouched (#238)', () => {
   expect(weathermap.nodes.filter((n) => n.isConnection)).toHaveLength(1);
   expect(weathermap.links).toHaveLength(2);
 });
+
+test('a node with padding far above the old 50 cap renders correctly (#279)', () => {
+  let testProps = { ...mPanelProps };
+  const weathermap = handleVersionedStateUpdates(getData(theme), theme);
+  weathermap.nodes[0].padding = { horizontal: 200, vertical: 200 };
+  testProps.options = { weathermap };
+  testProps.onOptionsChange = () => {};
+
+  const { container } = render(<WeathermapPanel {...testProps} />);
+
+  // Every node and the link still render; the enlarged node's rect grew to
+  // cover its padding, and no SVG geometry became NaN.
+  weathermap.nodes.forEach((n) => expect(screen.queryByText(n.label!)).not.toBeNull());
+  expect(screen.getAllByTestId('link')).toHaveLength(1);
+  const rects = Array.from(container.querySelectorAll('rect'));
+  const widths = rects.map((r) => parseFloat(r.getAttribute('width') || '0'));
+  expect(Math.max(...widths)).toBeGreaterThan(400);
+  const svgNums = (container.querySelector('svg')!.innerHTML.match(/NaN/g) || []).length;
+  expect(svgNums).toBe(0);
+});

--- a/src/forms/NodeForm.test.tsx
+++ b/src/forms/NodeForm.test.tsx
@@ -201,3 +201,24 @@ test('a newly added node gets its own colors object (#281)', () => {
   expect(newNode.colors).toEqual(updated.nodes[0].colors);
   expect(newNode.colors).not.toBe(updated.nodes[0].colors);
 });
+
+test('node padding sliders allow values above the old 50 cap (#279)', async () => {
+  const spy = jest.fn();
+  const initial = getData(theme);
+  render(<Harness initial={initial} onChangeSpy={spy} />);
+
+  // Pick "Node A", then expand the Padding section.
+  const picker = screen.getAllByRole('combobox')[0];
+  fireEvent.keyDown(picker, { key: 'ArrowDown' });
+  fireEvent.click(await screen.findByText('Node A'));
+  fireEvent.click(screen.getByText('Padding'));
+
+  // Both padding sliders advertise the raised bound, so typed values up to
+  // 200 no longer snap back to 50.
+  const sliders = screen
+    .getAllByRole('slider')
+    .filter((el) => el.getAttribute('aria-valuemax') !== null);
+  const maxes = sliders.map((el) => el.getAttribute('aria-valuemax'));
+  expect(maxes).toEqual(expect.arrayContaining(['200']));
+  expect(maxes).not.toContain('50');
+});

--- a/src/forms/NodeForm.tsx
+++ b/src/forms/NodeForm.tsx
@@ -554,7 +554,9 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                     <InlineField grow label={'Horizontal'}>
                       <Slider
                         min={0}
-                        max={50}
+                        // Larger nodes (#279): the old 50 cap also snapped
+                        // back typed values; saved maps render any padding.
+                        max={200}
                         value={node.padding.horizontal}
                         step={1}
                         onChange={(num) => handleNodePaddingChange(num, i, 'horizontal')}
@@ -563,7 +565,7 @@ export const NodeForm = ({ value, onChange, context }: Props) => {
                     <InlineField grow label={'Vertical'}>
                       <Slider
                         min={0}
-                        max={50}
+                        max={200}
                         value={node.padding.vertical}
                         step={1}
                         onChange={(num) => handleNodePaddingChange(num, i, 'vertical')}


### PR DESCRIPTION
Closes #279

## Problem

The node padding sliders capped at 50 in both directions, and the slider's numeric box snapped any typed value above 50 back down — capping how large a node box can grow. As reported, this blocks dashboards that want big nodes (faceplate/background-style layouts, see also #278's workaround note).

## Fix

Saved maps already render **any** padding value — only the editor clamped (hand-edited JSON with padding 80 worked fine today). So the honest fix is the slider bound: raised `max` from 50 to **200** on both node padding sliders in `NodeForm`. Typed values up to 200 now stick.

No render-path, migration, or schema changes; a padding value is passed through `calculateRectangleAutoWidth`/`Height` unchanged, exactly as before.

## Tests

- New NodeForm test pins the raised bound via the sliders' `aria-valuemax` (fails loudly if the cap regresses to 50).
- Full suite: 172 passing; typecheck / lint / build / verify-dist clean.

Changelog entry added to the pending 1.5.15 section (this ships with the v1.5.15 tag).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised node padding slider max from 50 to 200 so nodes can be larger and typed values up to 200 stick (addresses #279). Added a panel-level regression test to ensure nodes with 200 padding render correctly with no NaNs; no render-path or schema changes.

<sup>Written for commit d9eda0dba2284859846f5d468e5ba27b2b99d57a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

