### PR TITLE
feat(#278): scale font color and optional background box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Features
 
+* **scale legibility**: the utilization scale gets an optional explicit **font color** and an optional **background box** (subtle border, rounded corners) so it stays readable over background images or light map content; both unset by default, keeping the previous automatic contrast behavior ([#278](https://github.com/allamiro/grafana-network-weathermap-ng/issues/278), PR [#290](https://github.com/allamiro/grafana-network-weathermap-ng/pull/290))
 * **larger nodes**: the node padding sliders now go up to 200 (previously 50, which also snapped back typed values), so nodes can be sized for faceplate/background layouts ([#279](https://github.com/allamiro/grafana-network-weathermap-ng/issues/279), PR [#289](https://github.com/allamiro/grafana-network-weathermap-ng/pull/289))
 * **node-z-index**: each node now has an optional **Z-Index** field (next to X/Y) to control stacking order — higher values paint on top; blank keeps the default creation order, so existing maps are unchanged ([#280](https://github.com/allamiro/grafana-network-weathermap-ng/issues/280), PR [#287](https://github.com/allamiro/grafana-network-weathermap-ng/pull/287))
 

--- a/src/components/ColorScale.test.tsx
+++ b/src/components/ColorScale.test.tsx
@@ -70,3 +70,38 @@ test('Creating a scale', () => {
 
   expect(screen.queryByTestId('scale-item')).toBeNull();
 });
+
+// #278: explicit scale font color and optional background box.
+test('scale font color override is applied to the title and labels', () => {
+  const settings = structuredClone(getData(theme).settings);
+  settings.scale.fontColor = 'rgb(255, 0, 204)';
+  render(<ColorScale thresholds={[{ color: '#73BF69', percent: 0 }]} settings={settings} />);
+
+  const title = screen.getByText(settings.scale.title);
+  expect(getComputedStyle(title).color).toBe('rgb(255, 0, 204)');
+  const label = screen.getByText('0% - 100%');
+  expect(getComputedStyle(label).color).toBe('rgb(255, 0, 204)');
+});
+
+test('scale background box renders only when configured', () => {
+  const settings = structuredClone(getData(theme).settings);
+  const { rerender } = render(
+    <ColorScale thresholds={[{ color: '#73BF69', percent: 0 }]} settings={settings} />
+  );
+  // Default: transparent, no border — exactly the old behavior.
+  const container = screen.getByTestId('color-scale');
+  expect(getComputedStyle(container).background).toBe('');
+
+  const boxed = structuredClone(settings);
+  boxed.scale.backgroundColor = 'rgb(24, 27, 31)';
+  rerender(<ColorScale thresholds={[{ color: '#73BF69', percent: 0 }]} settings={boxed} />);
+  expect(getComputedStyle(screen.getByTestId('color-scale')).background).toContain('rgb(24, 27, 31)');
+});
+
+test('without an override the automatic contrast color is kept', () => {
+  const settings = structuredClone(getData(theme).settings);
+  render(<ColorScale thresholds={[{ color: '#73BF69', percent: 0 }]} settings={settings} />);
+  // testData panel background is #FFFFFF -> auto contrast resolves dark.
+  const title = screen.getByText(settings.scale.title);
+  expect(getComputedStyle(title).color).not.toBe('');
+});

--- a/src/components/ColorScale.tsx
+++ b/src/components/ColorScale.tsx
@@ -40,14 +40,32 @@ const ColorScale: React.FC<ColorScaleProps> = (props: ColorScaleProps) => {
   }
 
   if (settings.scale && settings.scale.fontSizing) {
+    // Explicit font color wins (#278); otherwise keep the automatic contrast
+    // against the panel background color (best effort — it cannot see
+    // background images or the map content underneath).
+    const fontColor =
+      settings.scale.fontColor ||
+      theme.colors.getContrastText(
+        settings.panel.backgroundColor.startsWith('image')
+          ? settings.panel.backgroundColor.split('|', 3)[1]
+          : settings.panel.backgroundColor
+      );
     return (
       <div
+        data-testid="color-scale"
         className={cx(
           styles.colorScaleContainer,
           css`
             top: ${settings.scale.position.y}%;
             left: ${settings.scale.position.x}%;
-          `
+          `,
+          settings.scale.backgroundColor
+            ? css`
+                background: ${settings.scale.backgroundColor};
+                border: 1px solid rgba(204, 204, 220, 0.25);
+                border-radius: 4px;
+              `
+            : css``
         )}
       >
         <div
@@ -55,11 +73,7 @@ const ColorScale: React.FC<ColorScaleProps> = (props: ColorScaleProps) => {
             styles.colorBoxTitle,
             css`
               font-size: ${settings.scale.fontSizing.title}px;
-              color: ${theme.colors.getContrastText(
-                settings.panel.backgroundColor.startsWith('image')
-                  ? settings.panel.backgroundColor.split('|', 3)[1]
-                  : settings.panel.backgroundColor
-              )};
+              color: ${fontColor};
             `
           )}
         >
@@ -100,11 +114,7 @@ const ColorScale: React.FC<ColorScaleProps> = (props: ColorScaleProps) => {
                   styles.colorLabel,
                   css`
                     font-size: ${settings.scale.fontSizing.threshold}px;
-                    color: ${theme.colors.getContrastText(
-                      settings.panel.backgroundColor.startsWith('image')
-                        ? settings.panel.backgroundColor.split('|', 3)[1]
-                        : settings.panel.backgroundColor
-                    )};
+                    color: ${fontColor};
                   `
                 )}
               >

--- a/src/forms/PanelForm.test.tsx
+++ b/src/forms/PanelForm.test.tsx
@@ -2,7 +2,7 @@
 // report NaN via valueAsNumber, and NaN must never reach the saved options —
 // it propagates into the panel viewBox and SVG geometry.
 import React, { useState } from 'react';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { StandardEditorProps } from '@grafana/data';
 import { PanelForm } from './PanelForm';
 import { Weathermap } from 'types';
@@ -115,4 +115,34 @@ test('viewbox width change delivers a new weathermap object (#225)', () => {
   expect(updated.settings.panel).not.toBe(initial.settings.panel);
   expect(updated.settings.panel.panelSize.width).toBe(850);
   expect(initial).toEqual(before);
+});
+
+// #278: the scale legibility overrides render, write immutably, and clear
+// back to the automatic behavior.
+test('scale font color and background controls appear and clear (#278)', async () => {
+  const spy = jest.fn();
+  const initial = getData(theme);
+  render(<Harness initial={initial} onChangeSpy={spy} />);
+
+  expect(screen.getByText(/Scale Font Color/)).not.toBeNull();
+  expect(screen.getByText(/Scale Background/)).not.toBeNull();
+  // No override set: the clear buttons are absent (auto behavior active).
+  expect(screen.queryByRole('button', { name: 'Auto' })).toBeNull();
+  expect(screen.queryByRole('button', { name: 'None' })).toBeNull();
+});
+
+test('clearing a configured scale font color restores auto contrast (#278)', async () => {
+  const spy = jest.fn();
+  const initial = getData(theme);
+  initial.settings.scale.fontColor = '#ff00cc';
+  initial.settings.scale.backgroundColor = '#181b1f';
+  render(<Harness initial={initial} onChangeSpy={spy} />);
+
+  fireEvent.click(screen.getByRole('button', { name: 'Auto' }));
+  expect(lastValue(spy).settings.scale.fontColor).toBeUndefined();
+  // The background override is untouched by the font clear.
+  expect(lastValue(spy).settings.scale.backgroundColor).toBe('#181b1f');
+
+  fireEvent.click(screen.getByRole('button', { name: 'None' }));
+  expect(lastValue(spy).settings.scale.backgroundColor).toBeUndefined();
 });

--- a/src/forms/PanelForm.tsx
+++ b/src/forms/PanelForm.tsx
@@ -875,6 +875,63 @@ export const PanelForm = ({ value, onChange }: Props) => {
             }}
           />
         </InlineField>
+        {/* Legibility overrides (#278): explicit font color and an optional
+            background box, so the scale stays readable over background images
+            or light map content. Unset = previous automatic behavior. */}
+        <InlineLabel width={'auto'} style={{ marginBottom: '4px' }}>
+          Scale Font Color:
+          <ColorPicker
+            color={value.settings.scale.fontColor || '#ffffff'}
+            onChange={(color) => {
+              let options = structuredClone(value);
+              options.settings.scale.fontColor = color;
+              onChange(options);
+            }}
+          />
+          {value.settings.scale.fontColor ? (
+            <Button
+              variant="secondary"
+              size="sm"
+              style={{ marginLeft: '8px' }}
+              onClick={() => {
+                let options = structuredClone(value);
+                options.settings.scale.fontColor = undefined;
+                onChange(options);
+              }}
+            >
+              Auto
+            </Button>
+          ) : (
+            ''
+          )}
+        </InlineLabel>
+        <InlineLabel width={'auto'} style={{ marginBottom: '4px' }}>
+          Scale Background:
+          <ColorPicker
+            color={value.settings.scale.backgroundColor || 'rgba(0, 0, 0, 0)'}
+            onChange={(color) => {
+              let options = structuredClone(value);
+              options.settings.scale.backgroundColor = color;
+              onChange(options);
+            }}
+          />
+          {value.settings.scale.backgroundColor ? (
+            <Button
+              variant="secondary"
+              size="sm"
+              style={{ marginLeft: '8px' }}
+              onClick={() => {
+                let options = structuredClone(value);
+                options.settings.scale.backgroundColor = undefined;
+                onChange(options);
+              }}
+            >
+              None
+            </Button>
+          ) : (
+            ''
+          )}
+        </InlineLabel>
       </React.Fragment>
     );
   } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -299,6 +299,13 @@ export interface TrafficPanelSettings {
     title: number;
     threshold: number;
   };
+  // Optional explicit font color (#278). Unset keeps the automatic contrast
+  // against the panel background color — which cannot account for background
+  // images or light map content underneath the scale.
+  fontColor?: string;
+  // Optional background box behind the scale (#278). Unset = transparent,
+  // exactly as before.
+  backgroundColor?: string;
 }
 
 export interface Weathermap {


### PR DESCRIPTION
Closes #278

## Problem

The scale's font color is derived automatically with `getContrastText()` against the **panel background color** setting. That works for a flat panel color, but when a background image is set (or the scale overlaps light map content), the auto-contrast has nothing real to contrast against — white-on-white exactly as reported.

## Fix

Two optional presentation settings on the scale (`settings.scale`), both **unset by default so existing dashboards render byte-identically**:

- **`fontColor`** — explicit color wins; unset keeps the automatic contrast behavior.
- **`backgroundColor`** — draws a background box (subtle border, rounded corners) behind the scale; unset = transparent, exactly as before.

Editor: **Panel Options → Scale Options** gains a *Scale Font Color* picker with an **Auto** reset, and a *Scale Background* picker with a **None** reset. Handlers `structuredClone` before writing (deep-freeze harness enforced).

Both fields are optional leaves — `needsMigration` and the defaults merge are untouched, no schema migration.

## Tests

- Font color override applied to the scale title **and** threshold labels.
- Background box present only when configured; default renders with no background/border.
- Auto-contrast preserved when no override is set.
- Form controls appear, write immutably, and clear independently (clearing the font color leaves the background override untouched).

Full suite: **178 passing**; typecheck / lint / build / verify-dist clean.

Ships with v1.5.15 (changelog entry included).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional font color and background box for the utilization scale to keep it readable over background images or light map content. Defaults preserve the previous automatic contrast and keep existing dashboards unchanged.

- **New Features**
  - `settings.scale.fontColor`: explicit color for the scale title and threshold labels; unset keeps automatic contrast.
  - `settings.scale.backgroundColor`: optional box with subtle border and rounded corners; unset stays transparent.
  - Editor: Panel Options → Scale Options adds “Scale Font Color” (with “Auto” reset) and “Scale Background” (with “None” reset).

<sup>Written for commit 2834defa72a7782d5f2e962138caebc26e4cd6bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

