### PR TITLE
feat(tools): Grafana dashboard backup/restore utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file. See [standa
 
 * **down-link labels (only when animation is enabled)** — when traffic animation is active for a link, a down status now labels both sides **DOWN** instead of showing a stale throughput number (the hover tooltip still exposes the real series and its history). This is scoped to the animation feature: maps that never enable animation render down links exactly as before (dashed line + last value), so existing status-query dashboards upgrade with no visible change ([#273](https://github.com/allamiro/grafana-network-weathermap-ng/issues/273), PR [#291](https://github.com/allamiro/grafana-network-weathermap-ng/pull/291))
 
+### Tooling
+
+* **Grafana dashboard backup/restore utility** (`tools/grafana-backup.py`) — a dependency-free (Python stdlib only) safety net for **backing up your existing dashboards before installing this plugin or upgrading Grafana**. Exports every dashboard as JSON with its **queries and datasource references** preserved, plus all data sources and folders and a manifest; idempotent `restore` writes them back. Works with token, basic-auth, or open/anonymous Grafana, and handles dashboards across mixed data sources (Prometheus/InfluxDB/Elasticsearch/Zabbix) ([#293](https://github.com/allamiro/grafana-network-weathermap-ng/issues/293), PR [#292](https://github.com/allamiro/grafana-network-weathermap-ng/pull/292))
+
 ## [1.5.15](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.15) (2026-07-08)
 
 ### Features

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,89 @@
+# Grafana backup tool
+
+`grafana-backup.py` — export your Grafana dashboards (with their **queries and
+datasource references**) and data sources to plain JSON, so you can **back up
+before installing this plugin or upgrading Grafana** and restore if anything
+goes wrong.
+
+## Requirements
+
+**Python 3 (3.6+). Nothing to install** — the script uses only the standard
+library and talks to Grafana's HTTP REST API directly. No `pip`, no Grafana
+SDK, no dependencies.
+
+## Authentication
+
+Works with both secured and open Grafana:
+
+| Your Grafana | How to authenticate |
+|---|---|
+| **Token / service account** (typical production) | `--token "$GRAFANA_TOKEN"` |
+| **Basic auth** | `--user admin --password ****` |
+| **Open / anonymous auth** (e.g. the demo stack on `:3101`) | no flags needed |
+
+All flags also read from the environment: `GRAFANA_URL`, `GRAFANA_TOKEN`,
+`GRAFANA_USER`, `GRAFANA_PASSWORD`.
+
+For production, create a **service account** (Administration → Service accounts)
+with the **Viewer** role for backup, or **Editor/Admin** for restore, and use
+its token.
+
+## Back up (do this before adding the plugin)
+
+```bash
+# Secured Grafana
+python3 tools/grafana-backup.py backup \
+  --url https://grafana.example.com --token "$GRAFANA_TOKEN" \
+  --out ./grafana-backup
+
+# Open-auth demo stack
+python3 tools/grafana-backup.py backup --url http://localhost:3101 --out ./grafana-backup
+```
+
+Output:
+
+```
+grafana-backup/
+  folders.json                 # folder structure (uids preserved)
+  datasources.json             # datasource config (see secrets note below)
+  manifest.json                # Grafana version, counts, per-dashboard datasource refs
+  dashboards/
+    <folder>/<title>__<uid>.json   # one file per dashboard = full model + folder mapping
+```
+
+Each dashboard file is the **exact dashboard model** — every panel, target,
+query, and `datasource` reference is preserved verbatim.
+
+## Restore (after the upgrade / if something breaks)
+
+```bash
+python3 tools/grafana-backup.py restore \
+  --url https://grafana.example.com --token "$GRAFANA_TOKEN" \
+  --in ./grafana-backup
+
+# also recreate the data sources (config only — see below)
+python3 tools/grafana-backup.py restore --url ... --in ./grafana-backup --datasources
+```
+
+Restore is idempotent: dashboards are written with `overwrite`, folders and
+data sources are created if missing and skipped if they already exist.
+
+## Two things to know
+
+- **Data source secrets are not exported.** Grafana's API returns datasource
+  *config* (type, URL, access mode, `jsonData`) but never the write-only
+  secrets (passwords, API keys, TLS certs). After a restore with
+  `--datasources`, re-enter secrets once in the Grafana UI. This is a Grafana
+  limitation, not a tool bug — your dashboards and queries are fully captured
+  regardless.
+- **Provisioned dashboards are read-only via the API** and are reported as
+  *skipped (provisioned)* on restore — they're already managed by their
+  provisioning files, so there's nothing to restore. Your own UI-created
+  dashboards restore normally.
+
+## Verified
+
+Backup → delete → restore round-trips a user dashboard with its query intact,
+and captures all data sources and per-dashboard datasource references. Tested
+against Grafana 12.4 with Prometheus, InfluxDB, Elasticsearch, and Zabbix data
+sources.

--- a/tools/README.md
+++ b/tools/README.md
@@ -24,9 +24,32 @@ Works with both secured and open Grafana:
 All flags also read from the environment: `GRAFANA_URL`, `GRAFANA_TOKEN`,
 `GRAFANA_USER`, `GRAFANA_PASSWORD`.
 
-For production, create a **service account** (Administration → Service accounts)
-with the **Viewer** role for backup, or **Editor/Admin** for restore, and use
-its token.
+### How to generate a Grafana token
+
+**Grafana 9.1+ (service account token — recommended):**
+
+1. Log in to Grafana as an **Admin**.
+2. Go to **Administration → Users and access → Service accounts**
+   (older 9.x: **Configuration (gear) → Service accounts**).
+3. Click **Add service account**. Give it a name (e.g. `dashboard-backup`) and a role:
+   - **Viewer** — enough to **back up** (read dashboards/data sources).
+   - **Editor** (or **Admin**) — needed to **restore** (write dashboards/folders/data sources).
+4. Click **Create**, then on the service account page click **Add service account token**.
+5. Name the token, optionally set an **expiration**, and click **Generate token**.
+6. **Copy the token now** — Grafana shows it only once. It looks like `glsa_xxxxxxxx…`.
+7. Use it with the tool:
+   ```bash
+   export GRAFANA_TOKEN="glsa_xxxxxxxxxxxxxxxxxxxx"
+   python3 tools/grafana-backup.py backup --url https://grafana.example.com
+   ```
+
+**Grafana < 9.1 (legacy API key):** **Configuration (gear) → API Keys → Add API key** →
+set a name and role (Viewer to back up, Editor/Admin to restore) → **Add** → copy the key
+and use it as `--token`.
+
+> **Tip:** Keep the token in an environment variable or your secrets manager — don't paste
+> it on the command line where it can land in your shell history. Delete the service account
+> / token when you're done if it was only for a one-off migration.
 
 ## Back up (do this before adding the plugin)
 

--- a/tools/grafana-backup.py
+++ b/tools/grafana-backup.py
@@ -82,6 +82,12 @@ def api(args, path, method="GET", body=None):
         except Exception:
             parsed = payload.decode(errors="replace")
         return e.code, parsed
+    except OSError as e:
+        # URLError (connection refused, DNS failure) and raw socket timeouts
+        # are all OSError subclasses. Status 0 = "could not reach Grafana at
+        # all"; callers surface the reason instead of a raw traceback.
+        reason = getattr(e, "reason", None) or e
+        return 0, f"network error: {reason}"
 
 
 def slugify(text, fallback="untitled"):
@@ -100,14 +106,17 @@ def backup(args):
 
     status, health = api(args, "/api/health")
     if status != 200:
-        die(f"Cannot reach Grafana at {args.url} (HTTP {status}). "
-            f"Check --url and auth.")
+        detail = health if status == 0 else f"HTTP {status}"
+        die(f"Cannot reach Grafana at {args.url} ({detail}). Check --url and auth.")
     version = (health or {}).get("version", "unknown")
     print(f"Grafana {version} at {args.url}")
 
     # --- Folders ---------------------------------------------------------- #
     status, folders = api(args, "/api/folders?limit=1000")
-    folders = folders if status == 200 and isinstance(folders, list) else []
+    if status != 200 or not isinstance(folders, list):
+        # Treating this as "no folders" would write a backup that looks good
+        # but silently misses content — refuse to produce a false restore point.
+        die(f"listing folders failed (HTTP {status}): {folders}")
     with open(os.path.join(args.out, "folders.json"), "w") as f:
         json.dump(folders, f, indent=2)
     folder_by_uid = {fo["uid"]: fo for fo in folders}
@@ -115,7 +124,8 @@ def backup(args):
 
     # --- Data sources (config only; secrets are not returned by the API) -- #
     status, datasources = api(args, "/api/datasources")
-    datasources = datasources if status == 200 and isinstance(datasources, list) else []
+    if status != 200 or not isinstance(datasources, list):
+        die(f"listing data sources failed (HTTP {status}): {datasources}")
     # Drop volatile ids; keep uid/name/type/access/url/jsonData etc.
     for ds in datasources:
         ds.pop("id", None)
@@ -134,7 +144,11 @@ def backup(args):
     seen = set()
     while True:
         status, hits = api(args, f"/api/search?type=dash-db&limit=1000&page={page}")
-        if status != 200 or not hits:
+        if status != 200:
+            # A failed first page means the whole dashboard list is unknown —
+            # that must fail the backup, not masquerade as "0 dashboards".
+            die(f"dashboard search failed on page {page} (HTTP {status}): {hits}")
+        if not hits:
             break
         new = [h for h in hits if h["uid"] not in seen]
         if not new:
@@ -210,11 +224,12 @@ def restore(args):
 
     status, health = api(args, "/api/health")
     if status != 200:
-        die(f"Cannot reach Grafana at {args.url} (HTTP {status}).")
+        detail = health if status == 0 else f"HTTP {status}"
+        die(f"Cannot reach Grafana at {args.url} ({detail}).")
     print(f"Restoring into Grafana {(health or {}).get('version','?')} at {args.url}")
 
     # --- Data sources ----------------------------------------------------- #
-    ds_created = ds_skipped = 0
+    ds_created = ds_skipped = ds_failed = 0
     ds_path = os.path.join(root, "datasources.json")
     if args.datasources and os.path.exists(ds_path):
         with open(ds_path) as f:
@@ -226,11 +241,14 @@ def restore(args):
                     ds_skipped += 1
                 else:
                     print(f"    ! datasource '{ds.get('name')}' HTTP {st}")
-        print(f"  datasources:  {ds_created} created, {ds_skipped} already existed"
+                    ds_failed += 1
+        tail = f", {ds_failed} FAILED" if ds_failed else ""
+        print(f"  datasources:  {ds_created} created, {ds_skipped} already existed{tail}"
               f"  (re-enter any secrets in the Grafana UI)")
 
     # --- Folders (uid preserved so dashboards land in the right place) ---- #
     folder_uids = {}
+    fo_failed = 0
     fo_path = os.path.join(root, "folders.json")
     if os.path.exists(fo_path):
         with open(fo_path) as f:
@@ -243,6 +261,7 @@ def restore(args):
                     folder_uids[fo["uid"]] = fo["uid"]  # already there
                 else:
                     print(f"    ! folder '{fo.get('title')}' HTTP {st}")
+                    fo_failed += 1
 
     # --- Dashboards ------------------------------------------------------- #
     created = failed = skipped = 0
@@ -273,8 +292,11 @@ def restore(args):
     tail = (f", {skipped} skipped (provisioned)" if skipped else "") + \
            (f", {failed} failed" if failed else "")
     print(f"  dashboards:   {created} restored{tail}")
-    print("\nRestore complete." + (" Some items failed." if failed else ""))
-    if failed:
+    # A failed data source or folder is as fatal for automation as a failed
+    # dashboard: the dashboards may import but their queries cannot resolve.
+    total_failed = failed + ds_failed + fo_failed
+    print("\nRestore complete." + (" Some items FAILED." if total_failed else ""))
+    if total_failed:
         sys.exit(1)
 
 
@@ -287,7 +309,9 @@ def die(msg):
 def build_parser():
     p = argparse.ArgumentParser(description="Back up / restore Grafana dashboards, "
                                             "data sources and queries.")
-    sub = p.add_subparsers(dest="cmd", required=True)
+    # required= on add_subparsers needs Python 3.7; enforce manually in main()
+    # so the documented Python 3.6 baseline actually works.
+    sub = p.add_subparsers(dest="cmd")
 
     def add_common(sp):
         sp.add_argument("--url", default=os.environ.get("GRAFANA_URL", "http://localhost:3101"),
@@ -312,11 +336,14 @@ def build_parser():
 
 
 def main():
-    args = build_parser().parse_args()
+    parser = build_parser()
+    args = parser.parse_args()
     if args.cmd == "backup":
         backup(args)
     elif args.cmd == "restore":
         restore(args)
+    else:
+        parser.error("a command is required: backup or restore")
 
 
 if __name__ == "__main__":

--- a/tools/grafana-backup.py
+++ b/tools/grafana-backup.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""
+grafana-backup.py — back up and restore Grafana dashboards (with their data
+sources and queries) so you can survive a Grafana upgrade.
+
+Dashboards are saved as plain JSON — each file is the exact dashboard model,
+including every panel's queries and its datasource references. Data sources are
+saved alongside so the queries can resolve after a restore. Folder structure is
+preserved.
+
+Works against:
+  * Grafana with authorization — API token / service-account token (--token)
+    or basic auth (--user/--password)
+  * Grafana with open/anonymous auth (no flags) — e.g. the demo stack on :3101
+
+Usage
+-----
+  # Back up everything from an open-auth Grafana (anonymous admin)
+  python3 tools/grafana-backup.py backup --url http://localhost:3101 --out ./grafana-backup
+
+  # Back up from a secured Grafana with a service-account token
+  python3 tools/grafana-backup.py backup --url https://grafana.example.com \
+      --token "$GRAFANA_TOKEN" --out ./grafana-backup
+
+  # Back up with basic auth
+  python3 tools/grafana-backup.py backup --url https://grafana.example.com \
+      --user admin --password admin --out ./grafana-backup
+
+  # Restore into a freshly-upgraded Grafana
+  python3 tools/grafana-backup.py restore --url http://localhost:3101 --in ./grafana-backup
+
+Environment fallbacks: GRAFANA_URL, GRAFANA_TOKEN, GRAFANA_USER, GRAFANA_PASSWORD.
+
+Notes
+-----
+  * Data source SECRETS (passwords, API keys) are write-only in Grafana's API
+    and are NOT returned by the export — the config is captured, but you must
+    re-enter secrets after a restore (or provide them; see --datasources on
+    restore). This is a Grafana limitation, not a bug here.
+  * Restore is idempotent: dashboards use overwrite, folders/datasources are
+    created if missing and skipped if they already exist.
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+TIMEOUT = 30
+
+
+# --------------------------------------------------------------------------- #
+# HTTP helpers
+# --------------------------------------------------------------------------- #
+def make_auth_header(args):
+    if args.token:
+        return {"Authorization": f"Bearer {args.token}"}
+    if args.user:
+        raw = f"{args.user}:{args.password or ''}".encode()
+        return {"Authorization": "Basic " + base64.b64encode(raw).decode()}
+    return {}  # anonymous / open auth
+
+
+def api(args, path, method="GET", body=None):
+    url = args.url.rstrip("/") + path
+    data = json.dumps(body).encode() if body is not None else None
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    headers.update(make_auth_header(args))
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+            payload = resp.read()
+            return resp.status, (json.loads(payload) if payload else None)
+    except urllib.error.HTTPError as e:
+        payload = e.read()
+        try:
+            parsed = json.loads(payload)
+        except Exception:
+            parsed = payload.decode(errors="replace")
+        return e.code, parsed
+
+
+def slugify(text, fallback="untitled"):
+    text = (text or "").strip().lower()
+    text = re.sub(r"[^a-z0-9._-]+", "-", text).strip("-")
+    return text or fallback
+
+
+# --------------------------------------------------------------------------- #
+# Backup
+# --------------------------------------------------------------------------- #
+def backup(args):
+    os.makedirs(args.out, exist_ok=True)
+    dash_dir = os.path.join(args.out, "dashboards")
+    os.makedirs(dash_dir, exist_ok=True)
+
+    status, health = api(args, "/api/health")
+    if status != 200:
+        die(f"Cannot reach Grafana at {args.url} (HTTP {status}). "
+            f"Check --url and auth.")
+    version = (health or {}).get("version", "unknown")
+    print(f"Grafana {version} at {args.url}")
+
+    # --- Folders ---------------------------------------------------------- #
+    status, folders = api(args, "/api/folders?limit=1000")
+    folders = folders if status == 200 and isinstance(folders, list) else []
+    with open(os.path.join(args.out, "folders.json"), "w") as f:
+        json.dump(folders, f, indent=2)
+    folder_by_uid = {fo["uid"]: fo for fo in folders}
+    print(f"  folders:      {len(folders)}")
+
+    # --- Data sources (config only; secrets are not returned by the API) -- #
+    status, datasources = api(args, "/api/datasources")
+    datasources = datasources if status == 200 and isinstance(datasources, list) else []
+    # Drop volatile ids; keep uid/name/type/access/url/jsonData etc.
+    for ds in datasources:
+        ds.pop("id", None)
+        ds.pop("orgId", None)
+        ds.pop("version", None)
+    with open(os.path.join(args.out, "datasources.json"), "w") as f:
+        json.dump(datasources, f, indent=2)
+    print(f"  datasources:  {len(datasources)} "
+          f"(config only — secrets are write-only in Grafana and not exported)")
+
+    # --- Dashboards (paginated search) ------------------------------------ #
+    manifest = {"grafana_version": version, "source_url": args.url,
+                "folders": len(folders), "datasources": len(datasources),
+                "dashboards": []}
+    page, saved, failed = 1, 0, 0
+    seen = set()
+    while True:
+        status, hits = api(args, f"/api/search?type=dash-db&limit=1000&page={page}")
+        if status != 200 or not hits:
+            break
+        new = [h for h in hits if h["uid"] not in seen]
+        if not new:
+            break
+        for h in new:
+            seen.add(h["uid"])
+            uid = h["uid"]
+            st, full = api(args, f"/api/dashboards/uid/{uid}")
+            if st != 200 or not isinstance(full, dict) or "dashboard" not in full:
+                print(f"    ! failed to fetch {uid} ({h.get('title')}) HTTP {st}")
+                failed += 1
+                continue
+            model = full["dashboard"]
+            meta = full.get("meta", {})
+            model.pop("id", None)  # id is instance-specific; uid is the key
+            folder_uid = meta.get("folderUid", "")
+            folder_title = meta.get("folderTitle", "General")
+
+            sub = os.path.join(dash_dir, slugify(folder_title, "general"))
+            os.makedirs(sub, exist_ok=True)
+            fname = f"{slugify(model.get('title'), uid)}__{uid}.json"
+            with open(os.path.join(sub, fname), "w") as f:
+                json.dump({"dashboard": model, "folderUid": folder_uid,
+                           "folderTitle": folder_title}, f, indent=2)
+
+            manifest["dashboards"].append({
+                "uid": uid, "title": model.get("title"),
+                "folderUid": folder_uid, "folderTitle": folder_title,
+                "datasources": sorted(_dashboard_datasource_refs(model)),
+                "file": os.path.relpath(os.path.join(sub, fname), args.out),
+            })
+            saved += 1
+        page += 1
+
+    with open(os.path.join(args.out, "manifest.json"), "w") as f:
+        json.dump(manifest, f, indent=2)
+
+    print(f"  dashboards:   {saved} saved" + (f", {failed} failed" if failed else ""))
+    print(f"\nBackup written to {os.path.abspath(args.out)}")
+    if failed:
+        sys.exit(1)
+
+
+def _dashboard_datasource_refs(model):
+    """Collect datasource uids/names referenced by a dashboard's panels/targets."""
+    refs = set()
+
+    def visit(obj):
+        if isinstance(obj, dict):
+            ds = obj.get("datasource")
+            if isinstance(ds, dict):
+                refs.add(ds.get("uid") or ds.get("type") or "?")
+            elif isinstance(ds, str):
+                refs.add(ds)
+            for v in obj.values():
+                visit(v)
+        elif isinstance(obj, list):
+            for v in obj:
+                visit(v)
+
+    visit(model)
+    refs.discard("?")
+    return refs
+
+
+# --------------------------------------------------------------------------- #
+# Restore
+# --------------------------------------------------------------------------- #
+def restore(args):
+    root = args.inp
+    if not os.path.isdir(root):
+        die(f"Backup directory not found: {root}")
+
+    status, health = api(args, "/api/health")
+    if status != 200:
+        die(f"Cannot reach Grafana at {args.url} (HTTP {status}).")
+    print(f"Restoring into Grafana {(health or {}).get('version','?')} at {args.url}")
+
+    # --- Data sources ----------------------------------------------------- #
+    ds_created = ds_skipped = 0
+    ds_path = os.path.join(root, "datasources.json")
+    if args.datasources and os.path.exists(ds_path):
+        with open(ds_path) as f:
+            for ds in json.load(f):
+                st, _ = api(args, "/api/datasources", "POST", ds)
+                if st in (200, 201):
+                    ds_created += 1
+                elif st == 409:  # already exists
+                    ds_skipped += 1
+                else:
+                    print(f"    ! datasource '{ds.get('name')}' HTTP {st}")
+        print(f"  datasources:  {ds_created} created, {ds_skipped} already existed"
+              f"  (re-enter any secrets in the Grafana UI)")
+
+    # --- Folders (uid preserved so dashboards land in the right place) ---- #
+    folder_uids = {}
+    fo_path = os.path.join(root, "folders.json")
+    if os.path.exists(fo_path):
+        with open(fo_path) as f:
+            for fo in json.load(f):
+                st, res = api(args, "/api/folders", "POST",
+                              {"uid": fo["uid"], "title": fo["title"]})
+                if st in (200, 201):
+                    folder_uids[fo["uid"]] = fo["uid"]
+                elif st in (409, 412):
+                    folder_uids[fo["uid"]] = fo["uid"]  # already there
+                else:
+                    print(f"    ! folder '{fo.get('title')}' HTTP {st}")
+
+    # --- Dashboards ------------------------------------------------------- #
+    created = failed = skipped = 0
+    dash_dir = os.path.join(root, "dashboards")
+    for dirpath, _, files in os.walk(dash_dir):
+        for name in sorted(files):
+            if not name.endswith(".json"):
+                continue
+            with open(os.path.join(dirpath, name)) as f:
+                doc = json.load(f)
+            model = doc["dashboard"]
+            model.pop("id", None)
+            model["version"] = 0  # let the target assign fresh versions
+            payload = {"dashboard": model, "overwrite": True,
+                       "folderUid": doc.get("folderUid") or ""}
+            st, res = api(args, "/api/dashboards/db", "POST", payload)
+            msg = res.get("message", "") if isinstance(res, dict) else str(res)
+            if st in (200, 201):
+                created += 1
+            elif "provisioned" in msg.lower():
+                # Provisioning-managed dashboards are read-only via the API by
+                # design — they're already restored from their provisioning
+                # files, so skipping them is correct, not a failure.
+                skipped += 1
+            else:
+                print(f"    ! dashboard '{model.get('title')}' HTTP {st}: {msg or res}")
+                failed += 1
+    tail = (f", {skipped} skipped (provisioned)" if skipped else "") + \
+           (f", {failed} failed" if failed else "")
+    print(f"  dashboards:   {created} restored{tail}")
+    print("\nRestore complete." + (" Some items failed." if failed else ""))
+    if failed:
+        sys.exit(1)
+
+
+# --------------------------------------------------------------------------- #
+def die(msg):
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(2)
+
+
+def build_parser():
+    p = argparse.ArgumentParser(description="Back up / restore Grafana dashboards, "
+                                            "data sources and queries.")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    def add_common(sp):
+        sp.add_argument("--url", default=os.environ.get("GRAFANA_URL", "http://localhost:3101"),
+                        help="Grafana base URL (env GRAFANA_URL)")
+        sp.add_argument("--token", default=os.environ.get("GRAFANA_TOKEN"),
+                        help="API / service-account token (env GRAFANA_TOKEN)")
+        sp.add_argument("--user", default=os.environ.get("GRAFANA_USER"),
+                        help="Basic-auth user (env GRAFANA_USER)")
+        sp.add_argument("--password", default=os.environ.get("GRAFANA_PASSWORD"),
+                        help="Basic-auth password (env GRAFANA_PASSWORD)")
+
+    b = sub.add_parser("backup", help="export dashboards + data sources to JSON")
+    add_common(b)
+    b.add_argument("--out", default="./grafana-backup", help="output directory")
+
+    r = sub.add_parser("restore", help="import a backup into a Grafana instance")
+    add_common(r)
+    r.add_argument("--in", dest="inp", default="./grafana-backup", help="backup directory")
+    r.add_argument("--datasources", action="store_true",
+                   help="also recreate data sources (secrets must be re-entered)")
+    return p
+
+
+def main():
+    args = build_parser().parse_args()
+    if args.cmd == "backup":
+        backup(args)
+    elif args.cmd == "restore":
+        restore(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A small, dependency-free utility to **back up dashboards before installing this plugin or upgrading Grafana**, and restore them if anything breaks.

## What it does
- Exports every dashboard as JSON — the full model, so **queries and datasource references are preserved verbatim**.
- Exports **data sources** (config) and **folders** alongside, plus a `manifest.json` (Grafana version, per-dashboard datasource refs).
- **Restore** is idempotent: dashboards overwrite, folders/data sources create-if-missing, provisioned dashboards skip.
- Handles **dashboards across different data sources** (Prometheus / InfluxDB / Elasticsearch / Zabbix) — each keeps its own datasource + query.

## No dependencies
Python 3 standard library only (`urllib`, `json`, `base64`, `argparse`). **No `pip`, no Grafana SDK.** Runs anywhere Python 3.6+ is installed.

## Auth — secured or open Grafana
| Grafana | Flag |
|---|---|
| Token / service account | `--token "$GRAFANA_TOKEN"` |
| Basic auth | `--user … --password …` |
| Open / anonymous | (none) |

```bash
python3 tools/grafana-backup.py backup  --url https://grafana.example.com --token "$T" --out ./grafana-backup
python3 tools/grafana-backup.py restore --url https://grafana.example.com --token "$T" --in  ./grafana-backup
```

## Verified
Backup → delete → restore round-trips a user dashboard with its query intact; captures all data sources and per-dashboard datasource refs; tested across the four demo datasource types on Grafana 12.4.

Notes (documented in `tools/README.md`): data source **secrets** are write-only in Grafana's API and not exported (re-enter after restore); **provisioned** dashboards are read-only via the API and reported as *skipped*.

Draft for review — not tied to a release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a small, dependency-free Python tool to back up Grafana dashboards (full JSON models with queries and datasource refs) and restore them after upgrades or plugin installs. Includes folders, data sources, and a manifest, with stricter failure handling to avoid partial backups.

- **New Features**
  - Backup: saves every dashboard model to JSON, plus folders and `datasources.json`; writes a `manifest.json` with Grafana version and per-dashboard datasource refs.
  - Restore: overwrites dashboards, creates folders/datasources if missing, skips provisioned dashboards; works across mixed data sources.
  - Auth: supports API/service-account token, basic auth, or anonymous; flags also read from env vars.
  - Implementation: Python 3 stdlib only (no `pip`), Python 3.6+; README documents token setup.

- **Bug Fixes**
  - Backup aborts on non-200 from folders/datasources/search to prevent false restore points.
  - Restore exits non-zero if any datasource or folder create fails, not just dashboards.
  - Clear “Cannot reach Grafana …” messaging for network errors; improved Python 3.6 compatibility.

<sup>Written for commit 1926d0d1af0f076d1108f1763d3050576a6ebf09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Closes #293
