### PR TITLE
fix: exporter Go toolchain 1.26.5 — clears govulncheck GO-2026-5856

### DIFF
--- a/testing/exporter/Dockerfile
+++ b/testing/exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine
+FROM golang:1.26-alpine
 
 WORKDIR /app
 

--- a/testing/exporter/go.mod
+++ b/testing/exporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/allamiro/wm-prometheus
 
-go 1.25.0
+go 1.26.5
 
 require (
 	github.com/aquilax/go-perlin v1.1.0


### PR DESCRIPTION
Fixes the ⚠️ finding from the Grafana Labs plugin validation report for the 1.6.0 submission.

## Problem

The validator's govulncheck source scan flagged **GO-2026-5856** (crypto/tls Encrypted Client Hello privacy leak) as reachable. Root cause: `testing/exporter/go.mod` declared `go 1.25.0`, pinning a vulnerable stdlib. Reproduced locally with the declared toolchain:

```
GOTOOLCHAIN=go1.25.0 govulncheck ./...
  GO-2026-5856  crypto/tls — reachable via main.go:341 http.ListenAndServe
  GO-2026-5039  net/textproto — also surfaced
```

## Fix

- `go.mod`: `go 1.25.0` → **`go 1.26.5`** (per the validator's recommendation)
- `Dockerfile`: `golang:1.25-alpine` → **`golang:1.26-alpine`** (floating patch tag, picks up future stdlib fixes on rebuild)

## Verification

- `govulncheck ./...` → **No vulnerabilities found**
- `go build`, `go vet` clean
- Exporter image rebuilt and serving metrics on the demo stack

Note: the exporter is demo tooling under `testing/` — not part of the plugin archive — but the validator scans the whole source repo, so this clears the submission warning. The report's second item (no-provenance-attestation) is a submission-form issue, not a code issue: the attestation exists and `gh attestation verify` passes against the released zip; the validator only reports that message when the submission's source-code URL field doesn't parse as a github.com repo URL.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade the test exporter to Go 1.26.5 and `golang:1.26-alpine` to clear the `govulncheck` GO-2026-5856 finding from the Grafana validator. This only touches `testing/exporter` and removes the 1.6.0 submission warning.

- **Bug Fixes**
  - `testing/exporter/go.mod`: set `go 1.26.5` (was 1.25.0).
  - `testing/exporter/Dockerfile`: switch base to `golang:1.26-alpine`.
  - Verified: `govulncheck ./...` clean; `go build` and `go vet` pass.

<sup>Written for commit 03161106f82d46f2e077d502f6f99e5aee320869. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

