### PR TITLE
fix: pin exporter Go directive to 1.25.12 so the Grafana validator's runner can scan it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this project will be documented in this file. See [standa
 
 * **Grafana dashboard backup/restore utility** (`tools/grafana-backup.py`) — a dependency-free (Python stdlib only) safety net for **backing up your existing dashboards before installing this plugin or upgrading Grafana**. Exports every dashboard as JSON with its **queries and datasource references** preserved, plus all data sources and folders and a manifest; idempotent `restore` writes them back. Works with token, basic-auth, or open/anonymous Grafana, and handles dashboards across mixed data sources (Prometheus/InfluxDB/Elasticsearch/Zabbix) ([#293](https://github.com/allamiro/grafana-network-weathermap-ng/issues/293), PR [#292](https://github.com/allamiro/grafana-network-weathermap-ng/pull/292))
 
+### Chores (not part of the plugin archive)
+
+* **plugin-catalog validation** — the demo exporter's Go directive is pinned to `go 1.25.12` (patched `crypto/tls` line for GO-2026-5856) so the Grafana plugin validator's Go 1.26.4 / `GOTOOLCHAIN=local` scanner can load and scan the module; the Docker build uses `golang:1.26-alpine` (≥1.26.5, also patched). Note: the validator may still warn about GO-2026-5856 because its own scan toolchain (1.26.4) predates the 1.26-line fix (1.26.5) — that finding clears when Grafana updates their runner ([#297](https://github.com/allamiro/grafana-network-weathermap-ng/pull/297), [#298](https://github.com/allamiro/grafana-network-weathermap-ng/pull/298))
+
 ## [1.5.15](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.5.15) (2026-07-08)
 
 ### Features

--- a/testing/exporter/go.mod
+++ b/testing/exporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/allamiro/wm-prometheus
 
-go 1.26.5
+go 1.25.12
 
 require (
 	github.com/aquilax/go-perlin v1.1.0


### PR DESCRIPTION
Fixes the ❌ blocking finding from the catalog validator's re-scan of the 1.6.0 submission.

## What happened

Round 1 (⚠️): validator flagged GO-2026-5856 (crypto/tls, reachable via the demo exporter's HTTP server) and recommended "update Go toolchain to 1.26.5 or later". We set `go 1.26.5` (#297).

Round 2 (❌): the validator's own runner is **Go 1.26.4 with `GOTOOLCHAIN=local`** — it cannot load a `go 1.26.5` module: `go.mod requires go >= 1.26.5 (running go 1.26.4)`. Their recommendation is unsatisfiable on their own scanner.

## Fix

`go 1.25.12` — verified against the [advisory](https://pkg.go.dev/vuln/GO-2026-5856): the fix ships in **1.25.12** (1.25 line) and **1.26.5** (1.26 line). This directive is both patched *and* loadable by their 1.26.4 runner.

Verified in their exact environment (`GOTOOLCHAIN=go1.26.4`): module loads, builds, and vets. On our actual build toolchain (1.26.5 / `golang:1.26-alpine`): `govulncheck ./...` → No vulnerabilities found.

## Expectation for the next validator run

Empirical finding: govulncheck evaluates the **stdlib of the toolchain running the scan**, not the go directive. So while Grafana's runner stays on 1.26.4, it may still *warn* about GO-2026-5856 — that's a finding against their scan toolchain (any module importing `net/http` triggers it) and is non-blocking (Warning = "can be reviewed", unlike this Failed state). It clears automatically when they update their runner to ≥1.26.5.

Changelog updated (1.6.0 chores). Will re-cut v1.6.0 after merge so the tag's source carries the loadable directive.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned the demo exporter's `go` directive to 1.25.12 so the Grafana validator (Go 1.26.4 runner) can load and scan the module. This keeps the fix for `GO-2026-5856` in `crypto/tls` while restoring validator compatibility.

- **Bug Fixes**
  - Changed `testing/exporter/go.mod` from `go 1.26.5` to `go 1.25.12` (advisory is fixed in 1.25.12 and 1.26.5).
  - Validator may still warn due to its own 1.26.4 stdlib; this is non-blocking and resolves when they upgrade.
  - Updated changelog; builds still use `golang:1.26-alpine` (≥1.26.5), `govulncheck` is clean.

<sup>Written for commit d58167fae66e2456fe99f499c5bd59a2d028a216. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

