### PR TITLE
fix(exporter): add toolchain go1.26.5 directive (Codex P2 on #298)

### DIFF
--- a/testing/exporter/go.mod
+++ b/testing/exporter/go.mod
@@ -2,6 +2,8 @@ module github.com/allamiro/wm-prometheus
 
 go 1.25.12
 
+toolchain go1.26.5
+
 require (
 	github.com/aquilax/go-perlin v1.1.0
 	github.com/prometheus/client_golang v1.23.2


### PR DESCRIPTION
Addresses the Codex P2 review comment on #298: with only `go 1.25.12`, a builder whose local Go is 1.26.0–1.26.4 (e.g. a stale cached `golang:1.26-alpine` image) already satisfies the minimum and compiles with its own **unpatched** stdlib, reintroducing GO-2026-5856. Go only auto-switches toolchains when the current one is *older* than the requirement.

## Fix
Add `toolchain go1.26.5` alongside `go 1.25.12`. Under the default `GOTOOLCHAIN=auto`, any builder on an older toolchain now selects go1.26.5+ automatically.

## Why this cannot re-break the Grafana validator
Their runner is Go 1.26.4 with `GOTOOLCHAIN=local` (toolchain switching disabled). In that mode only the `go` directive is enforced; the `toolchain` line is ignored. Verified empirically in a simulated runner environment (forced go1.26.4):

- `go vet ./...` → OK
- `go build ./...` → OK
- `GOTOOLCHAIN=auto` resolves to go1.26.5 as intended
- `govulncheck ./...` on the patched toolchain → **No vulnerabilities found**

No impact on the plugin archive (this is demo tooling under `testing/`, not shipped in the zip). No v1.6.0 re-cut needed — the current submission is already in the reviewable Warning state and this line doesn't change the validator's scan result either way.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `toolchain go1.26.5` to `testing/exporter/go.mod` so `GOTOOLCHAIN=auto` builders on Go 1.26.0–1.26.4 auto-switch to a patched toolchain and avoid GO-2026-5856. Environments with `GOTOOLCHAIN=local` (e.g., the Grafana validator on 1.26.4) ignore the `toolchain` line and continue to build via `go 1.25.12`; no shipped artifacts are affected.

<sup>Written for commit 4f7197e98d7df468a63b95b0b58343ca5bb004d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

