### PR TITLE
chore(testing): allow UI edits+save on the demo dashboards

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -23,7 +23,21 @@ docker compose build
 docker compose up
 ```
 
-Grafana will be available at `http://localhost:3101`. Five dashboards are provisioned, connected to the Prometheus data source.
+Grafana will be available at `http://localhost:3101`. Every dashboard below is provisioned automatically and connected to the Prometheus data source.
+
+### The demos are editable
+
+The provider sets `allowUiUpdates: true`, so you can open a demo, change panel
+options, and **Save** — the edit persists to Grafana's database instead of being
+rejected as a read-only provisioned file. That is the point of the stack: try
+Layers, View Mode Zoom & Pan, or Port Label Offset on a real map without
+hand-editing JSON first.
+
+The trade-off is that a dashboard you have saved from the UI stops tracking its
+file. Re-running a generator updates the JSON on disk, but Grafana keeps your
+saved copy until the file's `version` is higher than the stored one. To get the
+pristine demo back, either delete the dashboard in the UI (provisioning restores
+it within `updateIntervalSeconds`) or bump `version` in the file.
 
 To test against a specific Grafana version:
 

--- a/testing/grafana/provisioning/dashboards/all.yml
+++ b/testing/grafana/provisioning/dashboards/all.yml
@@ -5,5 +5,10 @@ providers:
     org_id: 1
     folder: ''
     type: 'file'
+    # Let the demo dashboards be edited and saved from the UI (persisted to the
+    # Grafana DB) instead of being locked read-only as provisioned files — so
+    # you can toggle panel options like View Mode Zoom & Pan or Port Label
+    # Offset and save them to try the features.
+    allowUiUpdates: true
     options:
       path: '/var/lib/grafana/dashboards'


### PR DESCRIPTION
The demo stack provisions ~24 dashboards from files, which Grafana locks read-only. That makes the stack awkward for the thing it exists for: you cannot open a demo, flip **Layers** or **View Mode Zoom & Pan** or **Port Label Offset**, and save to see what it does — Grafana rejects the save as provisioned.

Setting `allowUiUpdates: true` on the provider lets those saves land in Grafana's database.

## Verified, not assumed

Against the local stack, before/after the flag:

```
provisioned: False | canSave: True | canEdit: True
```

and a full round trip — edit a panel title via the API (the same path the UI save uses), read it back, confirm it persisted, then revert:

```
save status: success  version 2
persisted title: WAN Demo — Utilization [ui-save-probe]
restored title:  WAN Demo — Utilization
```

Without the flag that POST fails with *"Dashboard cannot be saved because it is provisioned."*

## The trade-off, now documented

A dashboard saved from the UI stops tracking its file: re-running a generator rewrites the JSON on disk, but Grafana keeps the stored copy until the file's `version` outranks it. `testing/README.md` now says so, and gives the two ways back to a pristine demo — delete it in the UI (provisioning restores it) or bump `version` in the file.

Also fixes a stale line claiming "Five dashboards are provisioned"; there are 24.

## Scope

`testing/` only — the dev stack. No plugin source, no build, no release artifact is touched.