### PR TITLE
release: v1.6.1 — opt-in view-mode zoom & pan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [Unreleased]
+## [1.6.1](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.6.1) (2026-07-21)
 
 ### Features
 
-- View-mode zoom & pan ([#306](https://github.com/allamiro/grafana-network-weathermap-ng/issues/306)): an opt-in panel setting that lets dashboard viewers zoom with the mouse wheel and pan by dragging without opening the editor. The viewer's zoom/pan stays local to their browser (never written into the saved panel options) and double-click resets to the saved view. Off by default — existing panels keep the current behavior (Shift+wheel / Shift+drag in view mode).
+* **view-mode zoom & pan** ([#306](https://github.com/allamiro/grafana-network-weathermap-ng/issues/306)): an opt-in panel setting (**Panel Options → Interaction & Labels → View Mode Zoom & Pan**) that lets dashboard viewers zoom with the mouse wheel and pan by dragging without opening the editor. The viewer's zoom/pan stays local to their browser (never written into the saved panel options) and double-click resets to the saved view. Off by default — existing panels keep the current behavior (Shift+wheel / Shift+drag in view mode) ([#307](https://github.com/allamiro/grafana-network-weathermap-ng/pull/307))
 
 ## [1.6.0](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.6.0) (2026-07-09)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamirsuliman-weathermap-panel",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",
@@ -15707,7 +15707,7 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/tinycolor2": {
-      "version": "1.6.0",
+      "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
     },
@@ -16162,7 +16162,7 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.6.0",
+      "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Rolls **v1.6.1** with the single tested feature from this cycle: **opt-in view-mode zoom & pan** (#306 / merged #307).

- `package.json` / `package-lock.json` → **1.6.1**
- CHANGELOG `[1.6.1]` (view-mode zoom & pan only)

Port Label Offset (#309/#310) is intentionally **held out** pending requester clarification, so it's not in this release.

Code is unchanged from the already-merged #307 (which passed full CI — 214 tests, build, all Grafana API checks); this PR only bumps the version and finalizes the changelog. CI here is the authoritative check (local build/test is flaky on this dev host).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.6.1 to ship the opt-in view‑mode zoom & pan feature. Only updates `package.json`, `package-lock.json`, and the CHANGELOG; no code changes, and Port Label Offset is held out.

<sup>Written for commit 7996892e07aae0a6055c179a5fedb1777c2e8040. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

