### PR TITLE
fix(deps): clear dev-dependency security advisories (websocket-driver, brace-expansion, protobufjs)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4560,9 +4560,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8481,9 +8481,9 @@
       "dev": true
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13383,10 +13383,11 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -16430,10 +16431,11 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",
         "safe-buffer": ">=5.1.0",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,10 @@
     "@grafana/ui": {
       "uuid": "11.1.1"
     },
-    "@opentelemetry/core": "^2.8.0"
+    "@opentelemetry/core": "^2.8.0",
+    "websocket-driver": "0.7.5",
+    "protobufjs": "^7.6.5",
+    "brace-expansion@2": "2.1.2",
+    "brace-expansion@5": "5.0.7"
   }
 }


### PR DESCRIPTION
Clears the open Dependabot alerts. **All are development-only** — none are in the shipped plugin zip (`dist/` is the webpack bundle of `src/` + runtime deps) — but pinned via `overrides` so the Security tab and the **Grafana submission osv-scan** stay clean.

| Package | Was | Now | Advisory | Via |
|---|---|---|---|---|
| websocket-driver | 0.7.4 | **0.7.5** | GHSA-xv26-6w52-cph6 (Critical) | webpack-livereload-plugin |
| brace-expansion | 2.1.1 / 5.0.6 | **2.1.2 / 5.0.7** | CVE-2026-13149 (High) | glob, eslint plugins |
| protobufjs | 7.6.4 | **7.6.5** | (Moderate) | @opentelemetry/otlp-transformer |

`brace-expansion` is pinned per-major (`@2` / `@5`) because Dependabot couldn't auto-fix it without downgrading `@grafana/eslint-config`; `1.x` is unaffected and untouched. Lockfile regenerated, overrides resolve with no peer conflicts. Supersedes Dependabot PRs #308 (websocket-driver) and #313 (protobufjs).

Verified in the regenerated lock: no vulnerable versions remain. CI (`npm ci` + test/build) validates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins dev-only dependencies via `overrides` to clear security advisories without changing the shipped plugin bundle. Keeps the Security tab and Grafana submission osv-scan clean.

- **Dependencies**
  - `websocket-driver` 0.7.4 → 0.7.5 (GHSA-xv26-6w52-cph6; via `webpack-livereload-plugin`)
  - `brace-expansion` pinned at `2.1.2` and `5.0.7` per major (CVE-2026-13149; via `glob` and ESLint plugins; avoids downgrading `@grafana/eslint-config`)
  - `protobufjs` 7.6.4 → 7.6.5 (via `@opentelemetry/otlp-transformer`)

<sup>Written for commit 4ee2b369e8c4da8ec0c9434e374e9dba49254753. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

