### PR TITLE
release: v1.6.2 — dev-dependency security patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.6.2](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.6.2) (2026-07-21)
+
+### Security
+
+* cleared development-dependency advisories via `overrides` — **websocket-driver** 0.7.4 → 0.7.5 (Critical, GHSA-xv26-6w52-cph6), **brace-expansion** 2.1.1 → 2.1.2 and 5.0.6 → 5.0.7 (High, CVE-2026-13149), **protobufjs** 7.6.4 → 7.6.5 (Moderate). All are build/lint/test tooling — **not shipped in the plugin** — but pinned so the dependency scan stays clean; no code or runtime behavior change ([#314](https://github.com/allamiro/grafana-network-weathermap-ng/pull/314))
+
 ## [1.6.1](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.6.1) (2026-07-21)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamirsuliman-weathermap-panel",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",
@@ -15708,7 +15708,7 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/tinycolor2": {
-      "version": "1.6.1",
+      "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
     },
@@ -16163,7 +16163,7 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.6.1",
+      "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Patch release rolling the dependency-advisory fixes from #314.

- `package.json` / `package-lock.json` → **1.6.2**
- CHANGELOG `[1.6.2]` (Security): websocket-driver 0.7.5, brace-expansion 2.1.2/5.0.7, protobufjs 7.6.5

**No code / behavior change** — dev-only tooling pinned via `overrides` so the submission osv-scan is clean. Cut so we can submit a scan-clean version to the Grafana catalog. CI validates (`npm ci` installs the patched tree + test/build).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patch release v1.6.2 pins vulnerable dev dependencies via `overrides` to clear security advisories and keep scans clean. No code or runtime behavior changes.

- **Dependencies**
  - Patched dev-only tooling: `websocket-driver` → 0.7.5, `brace-expansion` → 2.1.2 and 5.0.7, `protobufjs` → 7.6.5.

<sup>Written for commit f871240680e4b17024b829b7399d60f3dde6f5c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

