### PR TITLE
release: v1.6.3 — complete brace-expansion advisory fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.6.3](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.6.3) (2026-07-21)
+
+### Security
+
+* completed the **brace-expansion** advisory fix — pinned the remaining **1.x** line (1.1.15 → 1.1.16, CVE-2026-13149) that the 1.6.2 override missed; `npm audit` now reports **0 vulnerabilities**. Dev-only tooling, not shipped in the plugin; no code or runtime behavior change
+
 ## [1.6.2](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.6.2) (2026-07-21)
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamirsuliman-weathermap-panel",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",
@@ -5441,9 +5441,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8548,7 +8548,7 @@
       "dev": true
     },
     "node_modules/harmony-reflect": {
-      "version": "1.6.2",
+      "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
       "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
       "dev": true
@@ -15708,7 +15708,7 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/tinycolor2": {
-      "version": "1.6.2",
+      "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
     },
@@ -16163,7 +16163,7 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.6.2",
+      "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
@@ -105,6 +105,7 @@
     "websocket-driver": "0.7.5",
     "protobufjs": "^7.6.5",
     "brace-expansion@2": "2.1.2",
-    "brace-expansion@5": "5.0.7"
+    "brace-expansion@5": "5.0.7",
+    "brace-expansion@1": "1.1.16"
   }
 }


### PR DESCRIPTION
Completes the dependency-advisory cleanup. v1.6.2 pinned brace-expansion **2.x/5.x** but missed the **1.x** line (`1.1.15 < 1.1.16`, CVE-2026-13149, still High), so one alert (#102) stayed open.

- Adds `brace-expansion@1` → **1.1.16** override
- All three lines now patched: **1.1.16 / 2.1.2 / 5.0.7** — `npm audit` = **0 vulnerabilities**
- Version → **1.6.3**, CHANGELOG `[1.6.3]` (Security)

Dev-only tooling, **not shipped in the plugin**, no code/behavior change. Submit this for a fully scan-clean version. CI validates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `brace-expansion@1` to 1.1.16 to finish the security advisory fix and clear the last audit alert. Releases v1.6.3; dev-only tooling, no plugin code or behavior change.

- **Dependencies**
  - Add override `brace-expansion@1: 1.1.16` (completes advisory fix). All lines now pinned: 1.1.16 / 2.1.2 / 5.0.7 → `npm audit` shows 0 vulnerabilities.
  - Bump package to `1.6.3` and update CHANGELOG.

<sup>Written for commit f611c9cac2ddd7eb7a1ed2dae3fbdd49de507eda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

