### PR TITLE
fix(links): don't duplicate a port label on VIA-routed links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [Unreleased]
+
+### Fixed
+
+* **duplicate port label on VIA links**: a port label set on a VIA-routed (waypointed) link rendered again at every intermediate bend, because the origin side data is copied onto each downstream segment for value/color propagation. Port labels now render only at their real node endpoint, never at a VIA connection node — value/color propagation is unchanged ([#317](https://github.com/allamiro/grafana-network-weathermap-ng/issues/317))
+
 ## [1.6.3](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.6.3) (2026-07-21)
 
 ### Security

--- a/src/WeathermapPanel.test.tsx
+++ b/src/WeathermapPanel.test.tsx
@@ -807,6 +807,23 @@ describe('timeline and state synchronization (#201)', () => {
     expect(JSON.stringify(testProps.options.weathermap.links)).toBe(optionsBefore);
   });
 
+  test('port label on a VIA link renders once, not on every segment', () => {
+    // withSideData copies the origin A-side (incl. portLabel) onto every
+    // downstream VIA segment so value/color propagate — but the port label
+    // must render only at the real node endpoint, never at a VIA bend.
+    const testProps = { ...mPanelProps };
+    const weathermap = handleVersionedStateUpdates(getConnectedLinkData(theme), theme);
+    weathermap.links[0].sides.A.portLabel = 'GE-9/9/9';
+    testProps.options = { weathermap };
+    testProps.onOptionsChange = () => {};
+
+    render(<WeathermapPanel {...testProps} />);
+
+    // Exactly one label, despite the A-side (with its portLabel) being copied
+    // onto the C0 -> B segment for data propagation.
+    expect(screen.getAllByText('GE-9/9/9')).toHaveLength(1);
+  });
+
   test('multi-VIA chains show the origin data on every downstream segment', () => {
     // A -> C1 -> C2 -> B: three segments through two consecutive connection
     // nodes. Every segment's A-side label must resolve back to the origin

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -1940,7 +1940,12 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
 
                 return (
                   <React.Fragment key={i}>
-                    {d.sides.A.portLabel && (
+                    {/* A port label only renders at a real node. On a VIA link,
+                        withSideData copies the origin A-side (incl. portLabel)
+                        onto every downstream segment for value/color propagation,
+                        so without this guard the port label would re-render at
+                        each VIA bend. */}
+                    {d.sides.A.portLabel && !tempNodes[d.source.index]?.isConnection && (
                       <g transform={`translate(${aPosX},${aPosY}) rotate(${angleDeg})`}>
                         <text
                           x={0}
@@ -1955,7 +1960,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                         </text>
                       </g>
                     )}
-                    {d.sides.Z.portLabel && (
+                    {d.sides.Z.portLabel && !tempNodes[d.target.index]?.isConnection && (
                       <g transform={`translate(${zPosX},${zPosY}) rotate(${angleDeg})`}>
                         <text
                           x={0}


### PR DESCRIPTION
Closes #317.

## The bug

A **port label** set on a VIA-routed (waypointed) link renders **twice** — at the real node endpoint and again at the intermediate VIA bend — even though the data has the label only once. Visible today on the bundled **WAN Demo — Utilization** map: `EDGE-2 ↔ SITE-NYC` shows `GigabitEthernet0/3` at EDGE-2 and again at the bend.

## Root cause

For a VIA link, `resolvedLinks` calls `withSideData(d, 'A', origin.sides.A)` on every downstream segment so the origin link's **value/color propagate** through the chain. That copy also carried the **port label**, so it re-rendered at each connection (VIA) node.

## Fix

Guard the port-label render so a label only draws when its endpoint is a **real node**, never a connection node:

```jsx
{d.sides.A.portLabel && !tempNodes[d.source.index]?.isConnection && ( … )}
{d.sides.Z.portLabel && !tempNodes[d.target.index]?.isConnection && ( … )}
```

Value/color propagation across VIA segments is unchanged — only the redundant label is suppressed.

## Verification

- Live-checked on the testing stack: the `GigabitEthernet0/3` SVG text count drops from **2 → 1** on both the demo map and the base `wm-wan-utilization` map; the surviving label sits at EDGE-2 and the per-segment value labels still propagate.
- New regression test: `port label on a VIA link renders once, not on every segment`.
- Full `WeathermapPanel.test.tsx` suite green (60 tests).

Found while working on #309; this fix is independent of that feature and applies to any existing map that uses VIA links with port labels.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate port labels on VIA-routed links. Port labels now render only at real node endpoints, not at VIA connection nodes; value/color propagation across segments is unchanged.

- **Bug Fixes**
  - Guard prevents drawing a port label when the endpoint is a connection node.
  - Added a regression test to ensure a VIA link renders only one port label.

<sup>Written for commit c5c59de996cd9965302c31295dee841d825aa9c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

