### PR TITLE
release: v1.6.5 — patch high-severity CVEs blocking marketplace submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.6.5](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.6.5) (2026-07-21)
+
+### Security
+
+* patched the high-severity advisories that blocked the v1.6.4 marketplace submission ([#323](https://github.com/allamiro/grafana-network-weathermap-ng/issues/323)) — **fast-uri** 3.1.2 → 3.1.4 (CVE-2026-13676, host confusion via failed IDN canonicalization; flagged by the Grafana plugin validator's osv-scanner) and **immutable** 4.3.8 → 4.3.9 / 5.1.5 → 5.1.9 (CVE-2026-59879, CVE-2026-59880, DoS in `List`/`Map`/`Set`; the 5.x copy is pinned exactly by @grafana/ui, remapped with a version-scoped override). `npm audit` reports 0 high/critical findings; no code or runtime behavior change ([#322](https://github.com/allamiro/grafana-network-weathermap-ng/pull/322))
+
 ## [1.6.4](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.6.4) (2026-07-21)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamirsuliman-weathermap-panel",
-      "version": "1.6.4",
+      "version": "1.6.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1247,9 +1247,9 @@
       }
     },
     "node_modules/@grafana/ui/node_modules/immutable": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "license": "MIT"
     },
     "node_modules/@grafana/ui/node_modules/tslib": {
@@ -7829,9 +7829,9 @@
       "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -8864,9 +8864,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
-      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "@grafana/ui": {
       "uuid": "11.1.1"
     },
+    "immutable@5.1.5": "5.1.9",
     "@opentelemetry/core": "^2.8.0",
     "websocket-driver": "0.7.5",
     "protobufjs": "^7.6.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
## Why

The v1.6.4 marketplace submission was blocked by the Grafana plugin validator (tracked in #323):

> ❌ osv-scanner detected a high severity issue in package fast-uri — CVE-2026-13676

The validator scans the lockfile inside the submitted artifact, so the fix must ship as a new release (**v1.6.5**) before resubmission.

## What

- **fast-uri** 3.1.2 → 3.1.4 — fixes CVE-2026-13676 (GHSA-4c8g-83qw-93j6): host confusion via failed IDN canonicalization. Patched in 3.1.3+; in-range lockfile bump.
- **immutable** 4.3.8 → 4.3.9 (transitive via slate/sass) and 5.1.5 → 5.1.9 (pinned exactly by @grafana/ui, remapped with a version-scoped `overrides` entry) — fixes CVE-2026-59879 and CVE-2026-59880 (DoS in `List`/`Map`/`Set`). Not yet flagged by the validator, but would fail the next osv-scanner run.
- Version bump to **1.6.5** + CHANGELOG entry. Tagging `v1.6.5` after merge triggers the release workflow (build, sign, provenance attestation, zip + md5 assets).

## Verification

- `npm audit`: 0 high/critical (4 pre-existing lows in the @grafana/ui chain remain)
- OSV API confirms fast-uri 3.1.4, immutable 4.3.9 and 5.1.9 have no known advisories
- `npm ls immutable`: no invalid/dedupe conflicts; slate packages keep their own 4.x range
- Build compiles cleanly; all 217 tests across 14 suites pass

Closes #323