### PR TITLE
docs: expand About This Fork into a narrative tour

### DIFF
--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -26,20 +26,33 @@ New here? Start with the step-by-step guide:
 
 ## About This Fork
 
-This plugin is a continuation of the original [knightss27/grafana-network-weathermap](https://github.com/knightss27/grafana-network-weathermap) which was archived in 2023. The goal of this fork is to keep the plugin working with current Grafana releases and to fix outstanding bugs.
+This plugin is a continuation of the original [knightss27/grafana-network-weathermap](https://github.com/knightss27/grafana-network-weathermap), which was archived in 2023. What began as a compatibility rescue — keeping a much-loved panel working on modern Grafana — has since grown into an actively maintained project with new capabilities, a full documentation site, a hardened core, and runnable demos. This page is a short tour of where the fork stands today.
 
-**What changed from the original:**
+### What's new since the fork
 
-| Area | Change |
-|---|---|
-| Plugin ID | `tamirsuliman-weathermap-panel` (was `knightss27-weathermap-panel`) |
-| Grafana SDK | Updated to `@grafana/*` v11 — requires **Grafana 11.0.0+** |
-| React | Upgraded from React 17 → React 18 |
-| Styling | Migrated from deprecated `stylesFactory` → `useStyles2` + `@emotion/css` |
-| Deprecated APIs | Replaced `Vector.get()` with direct array indexing |
-| Datasource compat | Value extraction now finds the first numeric field instead of hardcoding `fields[1]` |
-| Security | All `window.open()` calls use `noopener,noreferrer`; `locationService` replaces `window.location` |
-| CI / CD | Node.js 24, GitHub Actions Pages deployment, Grafana API version matrix |
+The panel does considerably more than the archived original, and every capability below is driven entirely by the metrics you already query — no extra agents, no packet capture.
+
+- **Live traffic animation** — links animate moving dots whose speed and density track real utilization, with a down-link ✕ badge. See the [Traffic Animation guide](guide/animation.md).
+- **BGP neighbor status maps** — turn session state into a live map, with fleet and detail dashboards and an SNMP/gNMI collection kit. See the [BGP guide](guide/bgp.md).
+- **Timeline / incident replay** — scrub back through history and watch link utilization *and* node status replay step by step.
+- **View-mode zoom & pan** — an opt-in setting that lets dashboard viewers zoom and pan without opening the editor.
+- **Faceplate & rack generators** — one-click **Generate Port Grid** (switch faceplates, patch panels, PDU strips, blade chassis) and **Generate Rack Elevation** (devices laid out by rack unit) build whole port boards as editable nodes in a single step.
+- **Richer nodes & labels** — larger node sizing, scalable font color with an optional background box, and per-side port-label positioning to keep labels clear of icons and parallel links.
+- **1064 bundled icons across 12 sets** — networking, cloud, vendors, platforms, databases, country flags and more, all served by the plugin itself (air-gap friendly). Browse the [Icon Reference](icons.md).
+- **Runnable demos** — a Docker demo stack provisions every scenario (WAN utilization, incident replay, rack boards, the world-map backbone) against Prometheus, InfluxDB, Elasticsearch, and Zabbix. Explore them in the [Use Cases guide](guide/use-cases.md).
+- **Dashboard backup/restore utility** — a dependency-free tool to snapshot your existing Grafana dashboards, queries, and data sources before installing or upgrading.
+
+### Documentation
+
+The fork ships this full documentation site — a step-by-step [Getting Started](guide/getting-started.md) tutorial, deep-dive guides for [Nodes](guide/nodes.md), [Links](guide/links.md), [Panel Options](guide/panel-options.md), and [Interactions & Editing](guide/interactions.md), feature guides for [Traffic Animation](guide/animation.md) and [BGP Neighbor Status](guide/bgp.md), a [Data Sources](guide/datasources.md) reference with per-source notes, a gallery of [Use Cases](guide/use-cases.md), the [Icon Reference](icons.md), and an [FAQ](faq.md).
+
+### Reliability & fixes
+
+Reliability is treated as a feature. The panel is tested against hostile input — malformed saved options, links pointing at deleted nodes, empty data frames — so it renders instead of crashing, and the editor state is deep-frozen in tests so accidental mutation fails CI. Playwright end-to-end suites run on real Grafana from the declared minimum through the latest release. Along the way the fork has fixed data-source binding across Prometheus, InfluxDB, Elasticsearch, and Zabbix (wide-frame value binding, Zabbix alignment and trends), corrected link gradient rendering to the arrow tips, and stays on top of dependency security advisories.
+
+### Under the hood
+
+The original was rebuilt for modern Grafana: the plugin ID is now `tamirsuliman-weathermap-panel`, the `@grafana/*` SDK is updated and verified from **Grafana 11 through 13** (requires **11.0.0+**), React moved 17 → 18, styling migrated from the deprecated `stylesFactory` to `useStyles2` + `@emotion/css`, all `@ts-ignore` overrides were removed, and URLs for dashboard links, icons, and background images are sanitized. Releases are built on Node.js 24, signed and attested, with an API-compatibility matrix and packaging checks on every PR.
 
 Contributions and bug reports are welcome at [github.com/allamiro/grafana-network-weathermap-ng](https://github.com/allamiro/grafana-network-weathermap-ng).
 


### PR DESCRIPTION
## What

Rewrites the **About This Fork** section on the documentation home page ([website/docs/index.md](website/docs/index.md)).

The section was a single stale modernization table that no longer reflected the project. It's now a narrative tour — no big table — grouped into:

- **What's new since the fork** — traffic animation, BGP neighbor status maps, timeline/incident replay, view-mode zoom & pan, port grid & rack elevation generators, richer nodes/labels, 1064 bundled icons, the demo stack, and the backup/restore utility (each linked to its guide).
- **Documentation** — links across the full guide set.
- **Reliability & fixes** — hostile-data safety, deep-frozen editor state, Playwright E2E on Grafana 11→13, data-source binding fixes (Prometheus/InfluxDB/Elasticsearch/Zabbix), gradient fix, ongoing security patching.
- **Under the hood** — the modernization facts folded into prose.

## Scope

Docs / GitHub Pages only — no plugin code, no version bump, not part of a release. Merging to `main` triggers the Pages rebuild that publishes it.

All 11 internal links verified to resolve to existing pages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote the About This Fork section on the docs home page as a concise narrative tour, replacing the outdated modernization table. Docs-only update that adds links to feature guides and under-the-hood updates; 11 internal links verified; no plugin or release changes; merging to main rebuilds Pages.

<sup>Written for commit 66d434a378416eeee1949e583baf18f5cc8a7326. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

