### PR TITLE
docs: restore the modernization table under About This Fork

### DIFF
--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -52,7 +52,20 @@ Reliability is treated as a feature. The panel is tested against hostile input �
 
 ### Under the hood
 
-The original was rebuilt for modern Grafana: the plugin ID is now `tamirsuliman-weathermap-panel`, the `@grafana/*` SDK is updated and verified from **Grafana 11 through 13** (requires **11.0.0+**), React moved 17 → 18, styling migrated from the deprecated `stylesFactory` to `useStyles2` + `@emotion/css`, all `@ts-ignore` overrides were removed, and URLs for dashboard links, icons, and background images are sanitized. Releases are built on Node.js 24, signed and attested, with an API-compatibility matrix and packaging checks on every PR.
+The original was rebuilt for modern Grafana. What changed from the archived plugin:
+
+| Area | Change |
+|---|---|
+| Plugin ID | `tamirsuliman-weathermap-panel` (was `knightss27-weathermap-panel`) |
+| Grafana SDK | `@grafana/data` / `runtime` / `ui` updated and verified from **Grafana 11 → 13** (requires **11.0.0+**) |
+| React | Upgraded 17 → 18 (React 19 `findDOMNode` crash fixed) |
+| TypeScript | On 5.4+ — all `@ts-ignore` overrides removed |
+| Styling | Deprecated `stylesFactory` → `useStyles2` + `@emotion/css` |
+| Deprecated APIs | `Vector.get()` replaced with direct array indexing |
+| Datasource compat | Value extraction finds the first numeric field instead of hardcoding `fields[1]`; wide-frame binding across Prometheus / InfluxDB / Elasticsearch / Zabbix |
+| Security | URL sanitization for dashboard links, icons, and background images; `window.open()` uses `noopener,noreferrer`; `locationService` replaces `window.location` |
+| Testing | Playwright E2E (`@grafana/plugin-e2e`) on real Grafana, declared minimum through latest |
+| CI / CD | Node.js 24, signed + attested releases, Grafana API-compatibility matrix, packaging checks, GitHub Pages docs deploy |
 
 Contributions and bug reports are welcome at [github.com/allamiro/grafana-network-weathermap-ng](https://github.com/allamiro/grafana-network-weathermap-ng).
 


### PR DESCRIPTION
Brings back the *what changed from the original* table (expanded — Grafana 11→13, TypeScript, testing, CI/CD) under **Under the hood**, keeping the narrative tour above it. Docs / GitHub Pages only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored the modernization table under “Under the hood” in docs to clearly compare this fork with the archived plugin. Docs-only: adds at-a-glance updates for plugin ID, Grafana 11–13 support, `@grafana/data`/`runtime`/`ui`, React 18, TypeScript, styling, deprecated APIs, datasource compatibility, security, testing, and CI/CD.

<sup>Written for commit 5bca8e64e9d1ea50bd7a490af4790910977f1ef6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

