### PR TITLE
feat(scale): unit-aware Absolute Value scale labels (#327)

### DIFF
--- a/src/components/ColorScale.test.tsx
+++ b/src/components/ColorScale.test.tsx
@@ -105,3 +105,39 @@ test('without an override the automatic contrast color is kept', () => {
   const title = screen.getByText(settings.scale.title);
   expect(getComputedStyle(title).color).not.toBe('');
 });
+
+// #327: Absolute Value legend labels can be formatted with a unit.
+test('value mode without a scale unit renders raw numbers (pre-#327 behavior)', () => {
+  const settings = structuredClone(getData(theme).settings);
+  settings.colorScaleMode = 'value';
+  delete settings.scale.scaleUnit;
+  render(
+    <ColorScale
+      thresholds={[
+        { color: '#73BF69', percent: 500000000 },
+        { color: '#FF9830', percent: 750000000 },
+      ]}
+      settings={settings}
+    />
+  );
+  expect(screen.getByText('500000000 – 750000000')).not.toBeNull();
+  expect(screen.getByText('750000000+')).not.toBeNull();
+});
+
+test('value mode with a bps scale unit formats labels with automatic prefixes', () => {
+  const settings = structuredClone(getData(theme).settings);
+  settings.colorScaleMode = 'value';
+  settings.scale.scaleUnit = 'bps';
+  render(
+    <ColorScale
+      thresholds={[
+        { color: '#73BF69', percent: 500000000 },
+        { color: '#FF9830', percent: 750000000 },
+      ]}
+      settings={settings}
+    />
+  );
+  // 500000000 bps -> "500 Mb/s", 750000000 bps -> "750 Mb/s".
+  expect(screen.getByText('500 Mb/s – 750 Mb/s')).not.toBeNull();
+  expect(screen.getByText('750 Mb/s+')).not.toBeNull();
+});

--- a/src/components/ColorScale.tsx
+++ b/src/components/ColorScale.tsx
@@ -1,7 +1,20 @@
 import { useStyles2, useTheme2 } from '@grafana/ui';
+import { getValueFormat } from '@grafana/data';
 import { css, cx } from '@emotion/css';
 import React from 'react';
 import { Threshold, WeathermapSettings } from 'types';
+
+// Format an absolute threshold value for the legend. With a scale unit set,
+// route the raw number through Grafana's getValueFormat so it inherits the same
+// automatic prefixing (Kb/s, Mb/s, Gb/s…) the link labels use (#327). Without a
+// unit, keep the raw number — the pre-#327 behavior.
+const formatScaleValue = (value: number, unit?: string): string => {
+  if (!unit) {
+    return String(value);
+  }
+  const formatted = getValueFormat(unit)(value);
+  return `${formatted.text}${formatted.suffix ?? ''}`;
+};
 
 interface ColorScaleProps {
   thresholds: Threshold[];
@@ -83,10 +96,12 @@ const ColorScale: React.FC<ColorScaleProps> = (props: ColorScaleProps) => {
           const isValueMode = settings.colorScaleMode === 'value';
           let label: string;
           if (isValueMode) {
+            const unit = settings.scale.scaleUnit;
+            const current = formatScaleValue(threshold.percent, unit);
             label =
               thresholds[i + 1] === undefined
-                ? String(threshold.percent) + '+'
-                : threshold.percent + ' – ' + thresholds[i + 1].percent;
+                ? current + '+'
+                : current + ' – ' + formatScaleValue(thresholds[i + 1].percent, unit);
           } else {
             label =
               threshold.percent +

--- a/src/forms/ColorForm.tsx
+++ b/src/forms/ColorForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { css } from '@emotion/css';
-import { Button, Input, ColorPicker, Icon, useStyles2, RadioButtonGroup } from '@grafana/ui';
+import { Button, Input, ColorPicker, Icon, useStyles2, RadioButtonGroup, UnitPicker } from '@grafana/ui';
 import { GrafanaTheme2, SelectableValue, StandardEditorProps } from '@grafana/data';
 import { finiteOrFallback } from 'utils';
 import { Weathermap } from 'types';
@@ -82,6 +82,15 @@ export const ColorForm = (props: Props) => {
     onChange({ ...value, settings: { ...value.settings, colorScaleMode: mode } });
   };
 
+  const handleScaleUnitChange = (unit: string | undefined) => {
+    // Immutable update so the editor re-renders (#162); scaleUnit lives on the
+    // scale settings block alongside title/position/colors.
+    onChange({
+      ...value,
+      settings: { ...value.settings, scale: { ...value.settings.scale, scaleUnit: unit } },
+    });
+  };
+
   const thresholdLabel = currentMode === 'value' ? 'Value' : '%';
 
   return (
@@ -107,6 +116,15 @@ export const ColorForm = (props: Props) => {
           size="sm"
         />
       </div>
+      {/* Absolute Value legend labels can inherit the same automatic unit
+          prefixing (Kb/s, Mb/s, Gb/s…) as link labels (#327). Only meaningful
+          in value mode — percentages never carry a unit. */}
+      {currentMode === 'value' && (
+        <div className={styles.modeRow}>
+          <span className={styles.modeLabel}>Scale Unit</span>
+          <UnitPicker value={value.settings.scale.scaleUnit} onChange={handleScaleUnitChange} />
+        </div>
+      )}
       {editedPercents.map((threshold, i) => (
         <Input
           // Explicit id: without one, Grafana 13's options-pane Field context

--- a/src/types.ts
+++ b/src/types.ts
@@ -343,6 +343,11 @@ export interface TrafficPanelSettings {
   // Optional background box behind the scale (#278). Unset = transparent,
   // exactly as before.
   backgroundColor?: string;
+  // Optional Grafana unit id (e.g. 'bps', 'binbps', 'Bps') used to format the
+  // Absolute Value scale legend labels through getValueFormat, so a threshold
+  // of 500000000 renders as "500 Mb/s" instead of a raw number (#327). Unset =
+  // raw numbers, exactly as before. Ignored in Percentage mode.
+  scaleUnit?: string;
 }
 
 export interface Weathermap {


### PR DESCRIPTION
Closes #327.

## Problem

Absolute Value scale mode colored links correctly, but the legend printed thresholds as raw numbers — a scale like `500000000 – 750000000` is unreadable. There was no way to make the legend leverage the automatic unit conversion (Kb/s, Mb/s, Gb/s, Tb/s) that link labels already use.

## Change

Add an optional **Scale Unit** to the color scale. When set (to any Grafana unit id, e.g. `bps` — bits/sec SI), the Absolute Value legend labels are formatted through Grafana's `getValueFormat`, the same automatic prefixing used for link labels:

```
500000000 – 750000000    ->    500 Mb/s – 750 Mb/s
```

Low-traffic and high-traffic links get sensible prefixes automatically (70 Kb/s, 1.8 Gb/s), which the "force queries to fixed Mb/s" workaround could not.

## Details

- `types`: optional `TrafficPanelSettings.scaleUnit`. Unset = raw numbers, fully backward compatible; ignored in Percentage mode — no migration needed.
- `ColorScale`: value-mode labels run through `getValueFormat` when a unit is set.
- `ColorForm`: a `UnitPicker` (already used for per-link units) shown **only** in Absolute Value mode.

## Tests

Added two `ColorScale` tests: raw-number fallback (pre-change behavior) and `bps` → `500 Mb/s – 750 Mb/s`.

- `tsc --noEmit` passes.
- Note: the jest suite must be run under Node 22/24 (as CI does); it can't run on Node 20 due to the SWC/OpenSSL md4 toolchain requirement.

## Status

Draft — holding for the next release bundle.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Absolute Value scale legends unit-aware by adding an optional scale unit that formats thresholds with automatic prefixes (Kb/s, Mb/s, Gb/s) for readability. Closes #327.

- **New Features**
  - Optional `scale.scaleUnit` (Grafana unit id like `bps`); when set, legend thresholds use `@grafana/data` `getValueFormat`. Unset keeps raw numbers; ignored in Percentage mode.
  - Added `@grafana/ui` `UnitPicker` in the color scale settings, shown only in Absolute Value mode.
  - Tests cover raw-number fallback and `bps` formatting (e.g., "500 Mb/s – 750 Mb/s").

<sup>Written for commit 587511650b13281da149a9fc2c4e2bce849911a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

