### PR TITLE
release: v1.6.6 — unit-aware Absolute Value scale labels (#327)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.6.6](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.6.6) (2026-07-26)
+
+### Features
+
+* **unit-aware Absolute Value scale labels** ([#327](https://github.com/allamiro/grafana-network-weathermap-ng/issues/327)): Absolute Value mode gains an optional **Scale Unit** setting (a Grafana unit picker shown only in that mode, e.g. *bits/sec (SI)*). When set, the scale legend labels are formatted through Grafana's `getValueFormat` — the same automatic Kb/s / Mb/s / Gb/s prefixing the link labels already use — so `500000000 – 750000000` renders as `500 Mb/s – 750 Mb/s`, a standby link reads `70 Kb/s`, and a busy one `1.8 Gb/s`. Unset keeps raw numbers, so existing maps are unchanged; ignored in Percentage mode ([#328](https://github.com/allamiro/grafana-network-weathermap-ng/pull/328))
+
+### Dependencies
+
+* **dompurify** 3.4.11 → 3.4.12 (Dependabot, low-severity alert; sanitizer hardening) ([#324](https://github.com/allamiro/grafana-network-weathermap-ng/pull/324))
+
 ## [1.6.5](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.6.5) (2026-07-21)
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamirsuliman-weathermap-panel",
-      "version": "1.6.5",
+      "version": "1.6.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "^11.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Version bump and changelog for **v1.6.6**.

## Included since v1.6.5

- **feat(scale): unit-aware Absolute Value scale labels** (#327, #328) — optional Scale Unit setting formats legend labels via Grafana's `getValueFormat` (e.g. `500 Mb/s – 750 Mb/s` instead of raw `500000000 – 750000000`). Backward compatible: unset = raw numbers; ignored in Percentage mode. Confirmed working by the issue reporter on the PR build.
- **chore(deps): dompurify 3.4.11 → 3.4.12** (#324) — Dependabot low-severity sanitizer hardening.
- Docs-only updates (#325, #326).

## Verification

- All 219 tests across 14 suites pass; production build compiles cleanly
- Tagging `v1.6.6` after merge triggers the release workflow (build, sign, provenance attestation, zip + md5)

Closes #327

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.6.6 adds an optional Scale Unit for Absolute Value scale legends to format labels using Grafana units. Existing maps keep raw numbers if unset and Percentage mode is unaffected; also updates `dompurify` to 3.4.12.

<sup>Written for commit da8641d0fc426c7757e0f6702326f2ae675ade04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

