### PR TITLE
fix(links): auto-rebind query names saved by the original knightss27 plugin (#331)

### DIFF
--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -58,6 +58,7 @@ import {
   clampUtilization,
   utilizationToSpeed,
   utilizationToDotCount,
+  rebindLegacyQueryNames,
 } from 'utils';
 import MapNode from './components/MapNode';
 import ColorScale from 'components/ColorScale';
@@ -127,7 +128,7 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
   // Typed as the original `options.weathermap` was: non-null for the type
   // system, guarded by truthiness checks at runtime (it is undefined when the
   // panel has no saved weathermap yet).
-  const wm = useMemo(() => {
+  const savedWm = useMemo(() => {
     const normalized = normalizeWeathermap(options.weathermap);
     if (normalized && needsMigration(normalized)) {
       return handleVersionedStateUpdates(JSON.parse(JSON.stringify(normalized)), theme);
@@ -136,6 +137,26 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options.weathermap, theme]) as Weathermap;
 
+  // Dashboards imported from the original knightss27 plugin carry query
+  // bindings under the display names that plugin computed, which this fork's
+  // naming scheme no longer produces — every link's queries silently show as
+  // unbound (#331). When the current data contains an unambiguous match for a
+  // stored legacy name, render from a rewritten copy immediately and persist
+  // it below; once saved, this returns null on every subsequent data refresh.
+  // The rewrite is destructive once persisted, so it only ever runs against a
+  // COMPLETE data snapshot: while queries are still loading or any errored,
+  // data.series is a partial namespace in which the alias ambiguity guards
+  // can't be trusted (a missing frame's name can make a colliding legacy
+  // alias look safe).
+  const dataComplete =
+    data.state === LoadingState.Done && !data.error && (data.errors === undefined || data.errors.length === 0);
+  const reboundWm = useMemo(
+    () => (savedWm && dataComplete && data.series.length > 0 ? rebindLegacyQueryNames(savedWm, data.series) : null),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [savedWm, dataComplete, data]
+  );
+  const wm = (reboundWm ?? savedWm) as Weathermap;
+
   // Persist the migrated options only after commit: calling onOptionsChange
   // during render is illegal in React (it updates the panel wrapper while this
   // component renders). The render above already uses the migrated copy, so
@@ -143,11 +164,11 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
   // options.weathermap.version === CURRENT_VERSION and this effect goes quiet.
   const needsMigrationPersist = Boolean(options.weathermap && needsMigration(options.weathermap));
   useEffect(() => {
-    if (needsMigrationPersist) {
+    if (needsMigrationPersist || reboundWm) {
       onOptionsChange({ weathermap: wm });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [needsMigrationPersist, wm]);
+  }, [needsMigrationPersist, reboundWm, wm]);
 
   // Check for editing-related feature set
   const isEditMode = locationService.getSearch().has('editPanel');

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -29,6 +29,9 @@ import {
   sampleAtTime,
   sanitizeUrl,
   valueAtTime,
+  buildLegacyNameAliases,
+  getLegacyDataFrameName,
+  rebindLegacyQueryNames,
 } from 'utils';
 
 test('getSolidFromAlphaColor', () => {
@@ -801,5 +804,161 @@ describe('handleVersionedStateUpdates round-trip guarantees', () => {
     expect(migrated.version).toBe(CURRENT_VERSION);
     expect(migrated.nodes.map((n: { id: string }) => n.id)).toEqual(saved.nodes.map((n: { id: string }) => n.id));
     expect(migrated.settings.statusLegend).toBeUndefined();
+  });
+});
+
+describe('legacy knightss27 query-name rebind (#331)', () => {
+  // A table-style frame (Infinity JSON, SQL) where the value is NOT at index 1:
+  // the original plugin stored getFieldDisplayName(fields[1], frame) — here the
+  // string column — while this fork binds by the first numeric field's name.
+  const tableFrame = (refId: string, legacyName: string, currentName: string) =>
+    toDataFrame({
+      refId,
+      fields: [
+        { name: 'Time', values: [1, 2] },
+        { name: 'iface', type: FieldType.string, values: ['a', 'b'], config: { displayNameFromDS: legacyName } },
+        { name: 'bps', values: [100, 200], config: { displayNameFromDS: currentName } },
+      ],
+    });
+
+  const wmWithQueries = (names: { [path: string]: string }): Weathermap => {
+    const wm = JSON.parse(JSON.stringify(getData(theme)));
+    wm.links[0].sides.A.query = names.aQuery;
+    wm.links[0].sides.A.bandwidthQuery = names.aBandwidth;
+    wm.links[0].sides.Z.query = names.zQuery;
+    wm.links[0].statusQuery = names.status;
+    wm.links[0].tooltipMetrics = [{ label: 'm', queryA: names.metricA, queryZ: names.metricZ }];
+    wm.nodes[0].statusQuery = names.nodeStatus;
+    wm.nodes[0].tooltipMetrics = [{ label: 'n', query: names.nodeMetric }];
+    return wm;
+  };
+
+  test('getLegacyDataFrameName reproduces the old fields[1] naming', () => {
+    const frame = tableFrame('A', 'Interface A', 'Throughput A');
+    expect(getLegacyDataFrameName(frame)).toBe('Interface A');
+    expect(getDataFrameName(frame, [frame])).toBe('Throughput A');
+    expect(getLegacyDataFrameName(toDataFrame({ fields: [] }))).toBeUndefined();
+  });
+
+  test('aliases map legacy names to current names, unambiguously only', () => {
+    const frames = [tableFrame('A', 'Interface A', 'Throughput A'), tableFrame('B', 'Interface B', 'Throughput B')];
+    const aliases = buildLegacyNameAliases(frames);
+    expect(aliases.get('Interface A')).toBe('Throughput A');
+    expect(aliases.get('Interface B')).toBe('Throughput B');
+    expect(aliases.size).toBe(2);
+  });
+
+  test('a legacy name shared by two frames produces no alias', () => {
+    const frames = [tableFrame('A', 'SAME', 'Throughput A'), tableFrame('B', 'SAME', 'Throughput B')];
+    expect(buildLegacyNameAliases(frames).size).toBe(0);
+  });
+
+  test('a legacy name that equals a live current name is never redirected', () => {
+    // Frame B's current name IS "Interface A" — redirecting it would break a
+    // working binding, so no alias may exist for it.
+    const frames = [tableFrame('A', 'Interface A', 'Throughput A'), tableFrame('B', 'Interface B', 'Interface A')];
+    const aliases = buildLegacyNameAliases(frames);
+    expect(aliases.has('Interface A')).toBe(false);
+    expect(aliases.get('Interface B')).toBe('Interface A');
+  });
+
+  test('rebind rewrites every query-holding field to the current name', () => {
+    const frames = [tableFrame('A', 'Interface A', 'Throughput A'), tableFrame('B', 'Interface B', 'Throughput B')];
+    const wm = wmWithQueries({
+      aQuery: 'Interface A',
+      aBandwidth: 'Interface B',
+      zQuery: 'Interface B',
+      status: 'Interface A',
+      metricA: 'Interface A',
+      metricZ: 'Interface B',
+      nodeStatus: 'Interface B',
+      nodeMetric: 'Interface A',
+    });
+    const rebound = rebindLegacyQueryNames(wm, frames);
+    expect(rebound).not.toBeNull();
+    expect(rebound!.links[0].sides.A.query).toBe('Throughput A');
+    expect(rebound!.links[0].sides.A.bandwidthQuery).toBe('Throughput B');
+    expect(rebound!.links[0].sides.Z.query).toBe('Throughput B');
+    expect(rebound!.links[0].statusQuery).toBe('Throughput A');
+    expect(rebound!.links[0].tooltipMetrics![0].queryA).toBe('Throughput A');
+    expect(rebound!.links[0].tooltipMetrics![0].queryZ).toBe('Throughput B');
+    expect(rebound!.nodes[0].statusQuery).toBe('Throughput B');
+    expect(rebound!.nodes[0].tooltipMetrics![0].query).toBe('Throughput A');
+    // the input map is never mutated
+    expect(wm.links[0].sides.A.query).toBe('Interface A');
+  });
+
+  test('a map whose names already resolve returns null (steady state)', () => {
+    const frames = [tableFrame('A', 'Interface A', 'Throughput A')];
+    const wm = wmWithQueries({ aQuery: 'Throughput A' });
+    expect(rebindLegacyQueryNames(wm, frames)).toBeNull();
+  });
+
+  test('template-variable and unknown query strings pass through untouched', () => {
+    const frames = [tableFrame('A', 'Interface A', 'Throughput A')];
+    const wm = wmWithQueries({ aQuery: '$myVar', zQuery: 'not-a-known-name', aBandwidth: 'Interface A' });
+    const rebound = rebindLegacyQueryNames(wm, frames);
+    expect(rebound).not.toBeNull();
+    expect(rebound!.links[0].sides.A.query).toBe('$myVar');
+    expect(rebound!.links[0].sides.Z.query).toBe('not-a-known-name');
+    expect(rebound!.links[0].sides.A.bandwidthQuery).toBe('Throughput A');
+  });
+
+  test('no frames or no aliasable frames yields no rewrite', () => {
+    const wm = wmWithQueries({ aQuery: 'Interface A' });
+    expect(rebindLegacyQueryNames(wm, [])).toBeNull();
+    // time-series frames where old and new naming agree produce no aliases
+    const agreeing = toDataFrame({
+      refId: 'A',
+      fields: [
+        { name: 'Time', values: [1, 2] },
+        { name: 'Value', values: [1, 2], config: { displayNameFromDS: 'wan-in' } },
+      ],
+    });
+    expect(rebindLegacyQueryNames(wm, [agreeing])).toBeNull();
+  });
+});
+
+// Codex review hardening (#333): aliases must also be unambiguous on the
+// TARGET side, and the steady state must not clone.
+describe('legacy rebind alias target guards (#331 review)', () => {
+  const tableFrame = (refId: string, legacyName: string, currentName: string) =>
+    toDataFrame({
+      refId,
+      fields: [
+        { name: 'Time', values: [1, 2] },
+        { name: 'iface', type: FieldType.string, values: ['a', 'b'], config: { displayNameFromDS: legacyName } },
+        { name: 'bps', values: [100, 200], config: { displayNameFromDS: currentName } },
+      ],
+    });
+
+  test('aliases whose current target name is duplicated are rejected', () => {
+    // Two frames with distinct legacy names but the SAME current name: the
+    // frame map resolves that name first-match, so redirecting either legacy
+    // name onto it could silently bind the wrong series.
+    const frames = [tableFrame('A', 'Interface A', 'DUP'), tableFrame('B', 'Interface B', 'DUP')];
+    expect(buildLegacyNameAliases(frames).size).toBe(0);
+  });
+
+  test('a duplicated target only disqualifies its own aliases', () => {
+    const frames = [
+      tableFrame('A', 'Interface A', 'DUP'),
+      tableFrame('B', 'Interface B', 'DUP'),
+      tableFrame('C', 'Interface C', 'Throughput C'),
+    ];
+    const aliases = buildLegacyNameAliases(frames);
+    expect(aliases.size).toBe(1);
+    expect(aliases.get('Interface C')).toBe('Throughput C');
+  });
+
+  test('steady state returns null even when aliases exist (no clone path)', () => {
+    // The datasource's legacy/current names permanently differ, so the alias
+    // map is non-empty on every refresh — but nothing stored matches, so the
+    // fast path must return null without rewriting.
+    const frames = [tableFrame('A', 'Interface A', 'Throughput A')];
+    const wm = JSON.parse(JSON.stringify(getData(theme)));
+    wm.links[0].sides.A.query = 'Throughput A';
+    expect(buildLegacyNameAliases(frames).size).toBe(1);
+    expect(rebindLegacyQueryNames(wm, frames)).toBeNull();
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -641,6 +641,132 @@ export const buildQueryOptions = (frames: DataFrame[]): QueryOption[] => {
 };
 
 /**
+ * The display name the ORIGINAL knightss27-weathermap-panel stored for a
+ * frame: getFieldDisplayName of fields[1], computed without allFrames. This
+ * fork changed both parts — the value field is now the first numeric field
+ * (getValueField) and allFrames is passed so Grafana disambiguates duplicate
+ * names with refId/labels — so query bindings saved by the old plugin no
+ * longer match any current name (#331).
+ */
+export function getLegacyDataFrameName(frame: DataFrame): string | undefined {
+  if (frame.fields.length < 2) {
+    return undefined;
+  }
+  return getFieldDisplayName(frame.fields[1], frame);
+}
+
+/**
+ * Map of legacy (old-plugin) display names -> the current name of the same
+ * frame's primary value series (#331). An alias is only produced when it is
+ * unambiguous in BOTH directions: the legacy name resolves to exactly one
+ * current name, does not collide with any name the current scheme produces
+ * (a legacy name that equals a live name must never redirect it), and its
+ * target identifies exactly one live series (dataFrameMap resolves duplicate
+ * names first-match, so redirecting onto a duplicated name would silently
+ * bind a different series than the frame the alias came from).
+ */
+export function buildLegacyNameAliases(frames: DataFrame[]): Map<string, string> {
+  const currentNameCounts = new Map<string, number>();
+  const legacyTargets = new Map<string, Set<string>>();
+
+  for (const frame of frames) {
+    if (frame.fields.length < 2) {
+      continue;
+    }
+    try {
+      for (const { name } of getValueSeries(frame, frames)) {
+        currentNameCounts.set(name, (currentNameCounts.get(name) ?? 0) + 1);
+      }
+      const legacy = getLegacyDataFrameName(frame);
+      if (legacy) {
+        const targets = legacyTargets.get(legacy) ?? new Set<string>();
+        targets.add(getDataFrameName(frame, frames));
+        legacyTargets.set(legacy, targets);
+      }
+    } catch (e) {
+      // Frames without a usable value field can't be bound either way.
+    }
+  }
+
+  const aliases = new Map<string, string>();
+  legacyTargets.forEach((targets, legacy) => {
+    if (targets.size !== 1 || currentNameCounts.has(legacy)) {
+      return;
+    }
+    const target = targets.values().next().value!;
+    if (currentNameCounts.get(target) === 1) {
+      aliases.set(legacy, target);
+    }
+  });
+  return aliases;
+}
+
+/** Every query-binding string stored in a weathermap, in a stable order. */
+function collectQueryBindings(wm: Weathermap): Array<string | undefined> {
+  const bindings: Array<string | undefined> = [];
+  for (const link of wm.links) {
+    for (const side of ['A', 'Z'] as const) {
+      bindings.push(link.sides[side].query, link.sides[side].bandwidthQuery);
+    }
+    bindings.push(link.statusQuery);
+    for (const metric of link.tooltipMetrics ?? []) {
+      bindings.push(metric.queryA, metric.queryZ);
+    }
+  }
+  for (const node of wm.nodes) {
+    bindings.push(node.statusQuery);
+    for (const metric of node.tooltipMetrics ?? []) {
+      bindings.push(metric.query);
+    }
+  }
+  return bindings;
+}
+
+/**
+ * Rewrite query bindings saved by the original knightss27 plugin to the names
+ * this fork computes for the same frames (#331). Returns a rewritten copy when
+ * anything changed, or null when every stored name already resolves (the
+ * steady state, and the fast path on every data refresh). Only names that
+ * currently resolve to nothing and unambiguously match a legacy name are
+ * touched, so template-variable queries and working bindings pass through
+ * untouched. The steady state (nothing to rewrite) is detected on the
+ * original object — no clone or traversal allocation on ordinary refreshes,
+ * even for datasources whose legacy and current names permanently differ.
+ */
+export function rebindLegacyQueryNames(wm: Weathermap, frames: DataFrame[]): Weathermap | null {
+  const aliases = buildLegacyNameAliases(frames);
+  if (aliases.size === 0) {
+    return null;
+  }
+  if (!collectQueryBindings(wm).some((stored) => stored !== undefined && aliases.has(stored))) {
+    return null;
+  }
+
+  const remap = (stored: string | undefined): string | undefined =>
+    stored !== undefined && aliases.has(stored) ? aliases.get(stored) : stored;
+
+  const copy: Weathermap = JSON.parse(JSON.stringify(wm));
+  for (const link of copy.links) {
+    for (const side of ['A', 'Z'] as const) {
+      link.sides[side].query = remap(link.sides[side].query);
+      link.sides[side].bandwidthQuery = remap(link.sides[side].bandwidthQuery);
+    }
+    link.statusQuery = remap(link.statusQuery);
+    for (const metric of link.tooltipMetrics ?? []) {
+      metric.queryA = remap(metric.queryA);
+      metric.queryZ = remap(metric.queryZ);
+    }
+  }
+  for (const node of copy.nodes) {
+    node.statusQuery = remap(node.statusQuery);
+    for (const metric of node.tooltipMetrics ?? []) {
+      metric.query = remap(metric.query);
+    }
+  }
+  return copy;
+}
+
+/**
  * Schemes that are explicitly unsafe for navigation or resource loading.
  * Any absolute URL must use http:// or https:// — everything else is rejected.
  */

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -99,7 +99,8 @@ New to the plugin? See the **[Tutorial → Getting Started](guide/getting-starte
     - Fixed in v1.5.0+ (React 19 compatibility). Upgrade to the latest release.
 
 - **Q: I exported my config from the original `knightss27-weathermap-panel`. Will it import here?**
-    - Yes — the JSON config format is backward-compatible. Use **Export / Import** in the panel editor.
+    - Yes — the JSON config format is backward-compatible. Use **Export / Import** in the panel editor, or change the panel's `"type"` to `tamirsuliman-weathermap-panel` in the dashboard JSON before importing. Don't switch plugins through the panel-type picker in the UI — Grafana resets the panel options on a UI type switch and the whole map is lost.
+    - Link query bindings (A/Z side and bandwidth queries) are stored by their query display name, which this plugin computes slightly differently than the original in some setups (multiple queries returning a same-named column, table-style results). Since v1.6.7 unambiguous old-style names are re-bound automatically as soon as the panel receives data; if a binding stays empty after import (it can be ambiguous — e.g. two queries whose results are indistinguishable by name), re-select it once in the link editor and re-save.
 
 ---
 


### PR DESCRIPTION
## Why

Dashboards imported from the original `knightss27-weathermap-panel` appear to lose every link's query bindings (#331). The bindings are actually still in the JSON — they're stored as query **display names**, and this fork computes those names differently (first numeric field instead of `fields[1]`, and `allFrames` disambiguation), so the stored strings no longer match anything and every dropdown renders blank.

## What

- `getLegacyDataFrameName` reproduces the old plugin's naming (`getFieldDisplayName(fields[1], frame)` without `allFrames`).
- `buildLegacyNameAliases` maps legacy → current names, **unambiguously only**: a legacy name that collides with any live current name, or that two frames share, is never redirected — working bindings and template-variable queries pass through untouched.
- `rebindLegacyQueryNames` rewrites all query-holding fields (link A/Z `query`/`bandwidthQuery`, link/node `statusQuery`, link/node tooltip metrics) and returns `null` in the steady state, which is the fast path on every data refresh.
- `WeathermapPanel` renders from the rebound copy immediately and persists it through the existing render-path migration effect, so the panel self-heals on first data arrival and the rebind goes quiet once saved.
- FAQ corrected: it claimed old-plugin imports were fully compatible; it now documents the JSON `"type"`-edit import path vs. the UI panel-type picker (which resets options and loses the whole map), and the one ambiguity caveat.

## Verification

- 8 new unit tests: legacy-name reproduction, alias ambiguity guards (shared legacy name, legacy-vs-live collision), full-field rebind, steady-state null, template-variable passthrough, input immutability
- All 227 tests across 14 suites pass; lint and typecheck clean

Closes #331

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blank link query bindings after importing dashboards from the original `knightss27-weathermap-panel` by auto-rebinding legacy display-name queries to the current naming. The panel self-heals on the first complete data load and saves the update.

- **Bug Fixes**
  - Added `getLegacyDataFrameName`, `buildLegacyNameAliases`, and `rebindLegacyQueryNames` to map old `fields[1]` names (no `allFrames`) to current names; rewrites only unambiguous matches, rejects aliases that collide with live names or whose target name is duplicated, and leaves working bindings and template vars untouched.
  - Applied the rebind in `WeathermapPanel` only when data is complete (`LoadingState.Done`, no errors), renders from the rewritten copy, and persists via the existing migration effect; covers link A/Z `query` and `bandwidthQuery`, link/node `statusQuery`, and tooltip metrics.
  - Expanded tests for alias rules (including duplicated-target guard), full-field rewrite, steady-state null with no clone, and input immutability; updated FAQ with safe import guidance and the ambiguity caveat.

<sup>Written for commit 50702a557c8d18f27b8602b713e2d90c8e0d6796. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

