### PR TITLE
release: v1.6.7 — automatic legacy query re-binding for knightss27 imports (#331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.6.7](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.6.7) (2026-08-02)
+
+### Fixed
+
+* **automatic query re-binding for dashboards imported from the original `knightss27-weathermap-panel`** ([#331](https://github.com/allamiro/grafana-network-weathermap-ng/issues/331)): imported maps kept their nodes and links but every link's A/Z side, bandwidth, and status query dropdowns appeared empty — the bindings were still in the JSON, stored under display names the original plugin computed differently. The panel now recognizes those legacy names and rewrites them to the current ones automatically on first data load, so old-plugin dashboards bind their queries out of the box. The rewrite is deliberately conservative: it only touches names that currently resolve to nothing, only on an unambiguous match, and only from a complete data snapshot — working bindings, template-variable queries, and ambiguous cases are never altered ([#333](https://github.com/allamiro/grafana-network-weathermap-ng/pull/333))
+* the FAQ now documents the old-plugin import path accurately (JSON `"type"` edit vs. the UI panel-type picker, which resets options)
+
 ## [1.6.6](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.6.6) (2026-07-26)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamirsuliman-weathermap-panel",
-      "version": "1.6.6",
+      "version": "1.6.7",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "postinstall": "patch-package",


### PR DESCRIPTION
Version bump and changelog for **v1.6.7** — the migration release for users coming from the original plugin.

## Included since v1.6.6

- **fix(links): auto-rebind query names saved by the original knightss27 plugin** (#331, #333) — imported dashboards bind their link/status/tooltip queries automatically on first data load; conservative rewrite rules (broken-only, unambiguous-only, complete-data-only) protect working maps. This unblocks migration for old-plugin users, per the report from @snakeu-oss.
- **fix(security): lockfile CVE patches** (already on main, 50cfe5a).

## Pre-submission checks

- `npm audit --audit-level=high`: **0 high/critical**. Four moderate advisories remain in the transitive `react-router` chain under @grafana/ui — the fix requires react-router 7.x (major, incompatible with @grafana/ui's v5-compat layer) and the router is not used or active inside a panel plugin; not a marketplace blocker (osv-scanner gates on high/critical).
- Full suite 230 tests / lint / typecheck / production build clean on the merged fix.
- Local plugin-validator run against the packaged zip before submission (after tagging).

Tagging `v1.6.7` after merge triggers the release workflow (build, sign, provenance attestation, zip + md5).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automatic legacy query re-binding for dashboards imported from `knightss27-weathermap-panel`, so link A/Z, bandwidth, and status queries attach on first data load without manual setup. Also bumps version and updates the changelog for v1.6.7.

- **Bug Fixes**
  - Auto re-binds legacy display-name queries from the old plugin; only fixes broken, unambiguous names on complete data to avoid touching working maps.
  - Includes lockfile CVE patches; remaining moderate advisories are in transitive `react-router` under `@grafana/ui` and are not active in this panel.

<sup>Written for commit c206f87b1d50d1212e81db49d4779ceeacc3b574. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

