### PR TITLE
fix: harden node positions against malformed saved options (#339)

### DIFF
--- a/src/WeathermapPanel.hostile.test.tsx
+++ b/src/WeathermapPanel.hostile.test.tsx
@@ -168,10 +168,13 @@ describe('malformed links and geometry (#198)', () => {
     });
 
     test('still renders with gradient coloring and grid guides on', () => {
-      // Both read node positions by separate paths from the link geometry.
+      // These read node positions by paths separate from the link geometry —
+      // and the grid-guide rect specifically reads nodes[0], so the malformed
+      // value has to go there as well or that path is never actually stressed.
       expect(() =>
         renderPanel([goodFrame('A QUERY')], (wm) => {
           withPosition(wm);
+          (wm.nodes[0] as unknown as { position: unknown }).position = position;
           wm.settings.link.gradientColor = true;
           wm.settings.panel.grid.guidesEnabled = true;
         })

--- a/src/WeathermapPanel.hostile.test.tsx
+++ b/src/WeathermapPanel.hostile.test.tsx
@@ -8,7 +8,11 @@ import { WeathermapPanel } from 'WeathermapPanel';
 import { SimpleOptions, Weathermap } from 'types';
 import { getData, theme } from 'testData';
 
-const renderPanel = (series: unknown[], mutate?: (wm: Weathermap) => void) => {
+const renderPanel = (
+  series: unknown[],
+  mutate?: (wm: Weathermap) => void,
+  onOptionsChange: (o: unknown) => void = () => {}
+) => {
   const wm = getData(theme);
   wm.links[0].sides.A.query = 'A QUERY';
   wm.links[0].sides.Z.query = 'Z QUERY';
@@ -29,7 +33,7 @@ const renderPanel = (series: unknown[], mutate?: (wm: Weathermap) => void) => {
     renderCounter: 1,
     title: 'T',
     eventBus: {},
-    onOptionsChange: () => {},
+    onOptionsChange,
   } as unknown as PanelProps<SimpleOptions>;
   render(<WeathermapPanel {...props} />);
 };
@@ -138,5 +142,59 @@ describe('malformed links and geometry (#198)', () => {
     });
     expect(screen.getAllByTestId('link').length).toBeGreaterThan(0);
     expect(document.body.innerHTML).not.toContain('NaN');
+  });
+
+  // #339: every one of these came from a real failure mode. `null` and a
+  // missing key threw and took down the WHOLE panel; the rest rendered NaN
+  // into link points, arrow polygons and gradient axes with no error shown.
+  describe.each([
+    ['a NaN coordinate', [NaN, 300]],
+    ['an Infinity coordinate', [Infinity, 300]],
+    ['a short array', [200]],
+    ['an empty array', []],
+    ['a null position', null],
+    ['a missing position', undefined],
+    ['a non-array position', {}],
+    ['numeric strings', ['200', '300']],
+  ])('node with %s (#339)', (_name, position) => {
+    const withPosition = (wm: Weathermap) => {
+      (wm.nodes[1] as unknown as { position: unknown }).position = position;
+    };
+
+    test('renders without throwing, and emits no NaN geometry', () => {
+      expect(() => renderPanel([goodFrame('A QUERY')], withPosition)).not.toThrow();
+      expect(screen.getAllByTestId('link').length).toBeGreaterThan(0);
+      expect(document.body.innerHTML).not.toContain('NaN');
+    });
+
+    test('still renders with gradient coloring and grid guides on', () => {
+      // Both read node positions by separate paths from the link geometry.
+      expect(() =>
+        renderPanel([goodFrame('A QUERY')], (wm) => {
+          withPosition(wm);
+          wm.settings.link.gradientColor = true;
+          wm.settings.panel.grid.guidesEnabled = true;
+        })
+      ).not.toThrow();
+      expect(document.body.innerHTML).not.toContain('NaN');
+    });
+  });
+
+  test('a malformed position is never repaired in the saved options', () => {
+    // The coercion is render-only: options.weathermap is user data, and a bad
+    // coordinate must not be silently overwritten with a guess. This fixture
+    // is pre-migration, so the version migration does persist once — what
+    // matters is that the position it writes is still the user's original.
+    const onOptionsChange = jest.fn();
+    renderPanel(
+      [goodFrame('A QUERY')],
+      (wm) => {
+        (wm.nodes[1] as unknown as { position: unknown }).position = null;
+      },
+      onOptionsChange
+    );
+    for (const [saved] of onOptionsChange.mock.calls) {
+      expect((saved as { weathermap: Weathermap }).weathermap.nodes[1].position).toBeNull();
+    }
   });
 });

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -39,6 +39,7 @@ import {
 import { getTemplateSrv, locationService } from '@grafana/runtime';
 import {
   measureText,
+  finitePosition,
   getSolidFromAlphaColor,
   nearestMultiple,
   calculateRectangleAutoWidth,
@@ -67,8 +68,14 @@ import ColorScale from 'components/ColorScale';
 function generateDrawnNode(d: Node, i: number, wm: Weathermap): DrawnNode {
   let toReturn: DrawnNode = { ...d } as DrawnNode;
   toReturn.index = i;
-  toReturn.x = toReturn.position[0];
-  toReturn.y = toReturn.position[1];
+  // Saved positions are hostile input (#339): a missing or null position used
+  // to throw here and take down the whole panel, and a non-finite one seeded
+  // NaN into every coordinate derived from it. Normalize both the drawn x/y
+  // and the DrawnNode's own position so downstream editing math agrees.
+  const [posX, posY] = finitePosition(toReturn.position);
+  toReturn.position = [posX, posY];
+  toReturn.x = posX;
+  toReturn.y = posY;
 
   // Resolve Grafana template variables ($var) at draw time
   const tmplSrv = getTemplateSrv();
@@ -1616,13 +1623,13 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                 <rect
                   x={
                     wm.nodes.length > 0
-                      ? wm.nodes[0].position[0] -
+                      ? finitePosition(wm.nodes[0].position)[0] -
                         wm.settings.panel.panelSize.width * Math.pow(1.2, renderedZoomScale) * 2
                       : 0
                   }
                   y={
                     wm.nodes.length > 0
-                      ? wm.nodes[0].position[1] -
+                      ? finitePosition(wm.nodes[0].position)[1] -
                         wm.settings.panel.panelSize.height * Math.pow(1.2, renderedZoomScale) * 2
                       : 0
                   }
@@ -2168,15 +2175,15 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                         prevState.map((val, index) => {
                           if (index === d.index || selectedNodes.find((n) => n.id === nodes[index].id)) {
                             const scaledPos = getScaledMousePos({ x: position.deltaX, y: position.deltaY });
+                            // Saved position is read back here, so an unreadable
+                            // one would otherwise write NaN into the options the
+                            // moment a broken node is dragged (#339).
+                            const [savedX, savedY] = finitePosition(wm.nodes[index].position);
                             val.x = Math.round(
-                              wm.settings.panel.grid.enabled
-                                ? wm.nodes[index].position[0] + (val.x + scaledPos.x - wm.nodes[index].position[0])
-                                : val.x + scaledPos.x
+                              wm.settings.panel.grid.enabled ? savedX + (val.x + scaledPos.x - savedX) : val.x + scaledPos.x
                             );
                             val.y = Math.round(
-                              wm.settings.panel.grid.enabled
-                                ? wm.nodes[index].position[1] + (val.y + scaledPos.y - wm.nodes[index].position[1])
-                                : val.y + scaledPos.y
+                              wm.settings.panel.grid.enabled ? savedY + (val.y + scaledPos.y - savedY) : val.y + scaledPos.y
                             );
                           }
                           return val;

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1009,6 +1009,12 @@ describe('finitePosition (#339)', () => {
     expect(finitePosition([200, NaN], 50)).toEqual([200, 50]);
   });
 
+  test('a non-finite fallback cannot reintroduce what this helper removes', () => {
+    expect(finitePosition([NaN, 0], NaN)).toEqual([0, 0]);
+    expect(finitePosition(null, Infinity)).toEqual([0, 0]);
+    expect(finitePosition([undefined, undefined], -Infinity)).toEqual([0, 0]);
+  });
+
   test('never mutates or aliases its input', () => {
     const input: [number, number] = [10, 20];
     const out = finitePosition(input);

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -17,6 +17,7 @@ import {
   calculateRectangleAutoWidth,
   CURRENT_VERSION,
   finiteOrFallback,
+  finitePosition,
   getSolidFromAlphaColor,
   handleVersionedStateUpdates,
   isSafeUrl,
@@ -960,5 +961,58 @@ describe('legacy rebind alias target guards (#331 review)', () => {
     wm.links[0].sides.A.query = 'Throughput A';
     expect(buildLegacyNameAliases(frames).size).toBe(1);
     expect(rebindLegacyQueryNames(wm, frames)).toBeNull();
+  });
+});
+
+// Node positions are hostile input (#339): saved options are hand-editable and
+// can arrive truncated. Reading position[0] directly threw on a missing value
+// and seeded NaN through every derived coordinate.
+describe('finitePosition (#339)', () => {
+  test('passes through a well-formed position', () => {
+    expect(finitePosition([200, 300])).toEqual([200, 300]);
+    expect(finitePosition([0, 0])).toEqual([0, 0]);
+    expect(finitePosition([-40, -12.5])).toEqual([-40, -12.5]);
+  });
+
+  test('accepts numeric strings, which already rendered correctly', () => {
+    // Every consumer coerced these through arithmetic, so maps using them work
+    // today — rejecting them now would be a regression.
+    expect(finitePosition(['200', '300'])).toEqual([200, 300]);
+  });
+
+  test.each([
+    ['NaN coordinate', [NaN, 300]],
+    ['Infinity coordinate', [Infinity, 300]],
+    ['-Infinity coordinate', [300, -Infinity]],
+    ['short array', [200]],
+    ['empty array', []],
+    ['null', null],
+    ['undefined', undefined],
+    ['plain object', {}],
+    ['string', 'nope'],
+    ['number', 42],
+    ['array of objects', [{}, {}]],
+    ['nested arrays', [[1], [2]]],
+  ])('coerces %s to the fallback instead of throwing', (_name, input) => {
+    const [x, y] = finitePosition(input);
+    expect(Number.isFinite(x)).toBe(true);
+    expect(Number.isFinite(y)).toBe(true);
+  });
+
+  test('a partially valid position keeps the readable coordinate', () => {
+    expect(finitePosition([200, NaN])).toEqual([200, 0]);
+    expect(finitePosition([NaN, 300])).toEqual([0, 300]);
+  });
+
+  test('honours an explicit fallback', () => {
+    expect(finitePosition(null, 50)).toEqual([50, 50]);
+    expect(finitePosition([200, NaN], 50)).toEqual([200, 50]);
+  });
+
+  test('never mutates or aliases its input', () => {
+    const input: [number, number] = [10, 20];
+    const out = finitePosition(input);
+    expect(out).not.toBe(input);
+    expect(input).toEqual([10, 20]);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -304,7 +304,11 @@ export function finiteOrFallback(value: number, fallback: number): number {
  */
 export function finitePosition(pos: unknown, fallback = 0): [number, number] {
   const arr = Array.isArray(pos) ? pos : [];
-  return [finiteOrFallback(Number(arr[0]), fallback), finiteOrFallback(Number(arr[1]), fallback)];
+  // The fallback is normalized too. A caller passing a non-finite fallback
+  // would otherwise reintroduce exactly what this helper exists to remove —
+  // finitePosition([NaN, 0], NaN) would hand back [NaN, 0].
+  const safeFallback = Number.isFinite(fallback) ? fallback : 0;
+  return [finiteOrFallback(Number(arr[0]), safeFallback), finiteOrFallback(Number(arr[1]), safeFallback)];
 }
 
 /** Optional numeric fields: blank or unparsable input becomes undefined. */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -282,6 +282,31 @@ export function finiteOrFallback(value: number, fallback: number): number {
   return Number.isFinite(value) ? value : fallback;
 }
 
+/**
+ * A node's `[x, y]` as finite numbers (#339).
+ *
+ * `position` comes straight out of saved `options.weathermap`, which is
+ * hand-editable, copy-pasteable between dashboards, and can arrive truncated
+ * from a partial import. Reading `position[0]` directly meant a missing or
+ * `null` position threw and took down the WHOLE panel, while `[NaN, 300]`,
+ * `[Infinity, 300]`, a short array, `[]` or `{}` rendered `NaN` into every
+ * coordinate derived from it — link endpoints, polyline points, arrow
+ * polygons, gradient axes, label placement.
+ *
+ * This coerces at the RENDER boundary and never rewrites the saved value: a
+ * bad coordinate must not be silently persisted over (`options.weathermap` is
+ * user data). A node whose position cannot be read draws at `fallback`, so it
+ * stays visible and fixable instead of vanishing or killing the panel.
+ *
+ * Numeric strings are accepted because they already worked — every consumer
+ * put them through arithmetic that coerced them, so rejecting them now would
+ * break maps that render fine today.
+ */
+export function finitePosition(pos: unknown, fallback = 0): [number, number] {
+  const arr = Array.isArray(pos) ? pos : [];
+  return [finiteOrFallback(Number(arr[0]), fallback), finiteOrFallback(Number(arr[1]), fallback)];
+}
+
 /** Optional numeric fields: blank or unparsable input becomes undefined. */
 export function parseOptionalFiniteNumber(raw: string): number | undefined {
   if (raw.trim() === '') {


### PR DESCRIPTION
Closes #339.

## The bug

`generateDrawnNode` read `position[0]` / `position[1]` straight off saved options with no validation, and every coordinate derived from a node — link endpoints via `getMultiLinkPosition`, polyline points, arrow polygons, gradient axes, label placement — inherited whatever came back.

Verified against `main` at 745a5bf:

| `position` value | Before |
|---|---|
| `null` | **panel throws** — `Cannot read properties of null (reading '0')` |
| key absent | **panel throws** — `Cannot read properties of undefined (reading '0')` |
| `[NaN, 300]` | renders, 21 `NaN` in the emitted SVG |
| `[Infinity, 300]` | renders, 9 `NaN` |
| `[200]` (short) | renders, 19 `NaN` |
| `[]` | renders, 23 `NaN` |
| `{}` | renders, 23 `NaN` |

The throwing cases are the worse ones: **one bad node kills the entire panel**, not just itself, and nothing indicates which node is responsible. Hand-editing dashboard JSON, a partial copy-paste between dashboards, or a truncated import all reach this. The NaN cases are quieter but harder to diagnose — the map comes out blank or half-drawn with no error at all.

## The fix

Adds `finitePosition(pos, fallback = 0)` to `utils.ts`, built on the existing `finiteOrFallback`, returning a finite `[x, y]` for any input shape. Used at all three places that read a saved position:

- **`generateDrawnNode`** — the choke point; also normalizes the `DrawnNode`'s own `position` so downstream editing math agrees with the drawn coordinates;
- **the grid-guide rect origin** — reads `wm.nodes[0].position` directly;
- **the node-drag commit** — so a broken node cannot write `NaN` back into the saved options the moment someone drags it.

Two deliberate choices:

**Coercion happens at the render boundary and never rewrites the saved value.** `options.weathermap` is user data; a coordinate we cannot read must not be silently persisted over with a guess. A node with an unreadable position now draws at the origin — visible, obviously wrong, and fixable by the user — rather than vanishing or being fatal. A test pins that rendering never repairs the stored value.

**Numeric strings stay valid.** `["200", "300"]` already rendered correctly, because every consumer put those values through arithmetic that coerced them. Rejecting them now would break maps that work today.

## Tests

Unit tests for `finitePosition` across every malformed shape — non-finite, short, empty, `null`, `undefined`, non-array, arrays of objects, nested arrays — plus partially valid positions (`[200, NaN]` keeps the readable coordinate), an explicit fallback, and no input mutation.

Panel-level, the hostile suite gains the full table above: each case must render without throwing and emit no `NaN`, **and** must do both again with gradient coloring and grid guides enabled, since those read node positions by paths separate from the link geometry.

`npm run lint` · `npm run typecheck` · `CI=true npx jest` (264 passed, 14 suites) · `npm run build` — all green.

Found while hardening the polyline gradient work in #336. The gradient stops there are guarded separately; this hole is underneath them and predates that branch, so it lands on its own against `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened node position handling to prevent panel crashes and NaN geometry when saved options are malformed. Invalid positions now render at a safe fallback instead of breaking the panel. Closes #339.

- **Bug Fixes**
  - Added `finitePosition(pos, fallback)` and used it in `generateDrawnNode`, grid-guide origin, and drag commit to coerce positions to finite `[x, y]`; the fallback is sanitized so non-finite inputs cannot reintroduce `NaN`.
  - Normalizes `DrawnNode.position`; never overwrites saved options; numeric string coordinates remain valid.
  - Expanded hostile tests to cover malformed shapes, assert no `NaN` with gradient coloring and grid guides, fix the grid-guide path to target `nodes[0]`, and pin that rendering never “repairs” the stored position.

<sup>Written for commit 5dd921ed8d96ca318c36eadb728720e65aab19e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

