### PR TITLE
docs(site): click-to-enlarge for screenshots; drop the light theme (#341)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
     "tests/",
     "testing/scripts/",
     "website/scripts/",
+    "website/docs/javascripts/",
     "website/site/",
     "scripts/"
   ]

--- a/website/docs/javascripts/lightbox.js
+++ b/website/docs/javascripts/lightbox.js
@@ -1,0 +1,180 @@
+/* Click-to-enlarge for documentation screenshots.
+ *
+ * Screenshots on these pages are dense — link editors, full maps, per-member
+ * labels — and at body-text width the detail that matters is unreadable. This
+ * opens any content image in an overlay at full scale, with a second click
+ * zooming to 1:1 pixels and dragging to pan.
+ *
+ * Reading flow is the constraint: the overlay never navigates, the page keeps
+ * its exact scroll position, Escape / backdrop / close button all dismiss it,
+ * and focus returns to the image that was opened. Implemented locally rather
+ * than via a plugin so the docs build stays `pip install mkdocs-material`.
+ */
+(function () {
+  'use strict';
+
+  var overlay = null;
+  var img = null;
+  var caption = null;
+  var opener = null;
+  var zoomed = false;
+  var drag = null;
+
+  function build() {
+    overlay = document.createElement('div');
+    overlay.className = 'nwm-lightbox';
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    overlay.setAttribute('aria-label', 'Enlarged image');
+    overlay.innerHTML =
+      '<button class="nwm-lightbox__close" type="button" aria-label="Close image (Escape)">&times;</button>' +
+      '<figure class="nwm-lightbox__figure">' +
+      '<img class="nwm-lightbox__img" alt="">' +
+      '<figcaption class="nwm-lightbox__caption"></figcaption>' +
+      '</figure>';
+    img = overlay.querySelector('.nwm-lightbox__img');
+    caption = overlay.querySelector('.nwm-lightbox__caption');
+
+    overlay.addEventListener('click', function (e) {
+      // Clicking the backdrop (not the image itself) closes.
+      if (e.target === overlay || e.target.classList.contains('nwm-lightbox__figure')) {
+        close();
+      }
+    });
+    overlay.querySelector('.nwm-lightbox__close').addEventListener('click', close);
+    img.addEventListener('click', function (e) {
+      e.stopPropagation();
+      toggleZoom(e);
+    });
+
+    // Drag to pan while zoomed.
+    img.addEventListener('pointerdown', function (e) {
+      if (!zoomed) {
+        return;
+      }
+      drag = { x: e.clientX, y: e.clientY, left: overlay.scrollLeft, top: overlay.scrollTop };
+      img.setPointerCapture(e.pointerId);
+      img.classList.add('is-grabbing');
+    });
+    img.addEventListener('pointermove', function (e) {
+      if (!drag) {
+        return;
+      }
+      overlay.scrollLeft = drag.left - (e.clientX - drag.x);
+      overlay.scrollTop = drag.top - (e.clientY - drag.y);
+    });
+    ['pointerup', 'pointercancel'].forEach(function (t) {
+      img.addEventListener(t, function () {
+        drag = null;
+        img.classList.remove('is-grabbing');
+      });
+    });
+
+    document.body.appendChild(overlay);
+  }
+
+  function toggleZoom(e) {
+    zoomed = !zoomed;
+    overlay.classList.toggle('is-zoomed', zoomed);
+    if (zoomed && e) {
+      // Keep the clicked point roughly under the cursor after zooming.
+      var r = img.getBoundingClientRect();
+      var fx = (e.clientX - r.left) / r.width;
+      var fy = (e.clientY - r.top) / r.height;
+      requestAnimationFrame(function () {
+        overlay.scrollLeft = fx * img.offsetWidth - overlay.clientWidth / 2;
+        overlay.scrollTop = fy * img.offsetHeight - overlay.clientHeight / 2;
+      });
+    }
+  }
+
+  function open(source) {
+    if (!overlay) {
+      build();
+    }
+    opener = source;
+    zoomed = false;
+    overlay.classList.remove('is-zoomed');
+    img.src = source.currentSrc || source.src;
+    img.alt = source.alt || '';
+    var text = source.alt || '';
+    caption.textContent = text;
+    caption.style.display = text ? '' : 'none';
+    // Lock the page WITHOUT losing scroll position, so dismissing the overlay
+    // puts the reader back exactly where they were.
+    var y = window.scrollY;
+    document.body.dataset.nwmScroll = String(y);
+    document.body.classList.add('nwm-lightbox-open');
+    document.body.style.top = '-' + y + 'px';
+    overlay.classList.add('is-open');
+    overlay.querySelector('.nwm-lightbox__close').focus();
+  }
+
+  function close() {
+    if (!overlay || !overlay.classList.contains('is-open')) {
+      return;
+    }
+    overlay.classList.remove('is-open', 'is-zoomed');
+    zoomed = false;
+    var y = parseInt(document.body.dataset.nwmScroll || '0', 10);
+    document.body.classList.remove('nwm-lightbox-open');
+    document.body.style.top = '';
+    window.scrollTo(0, y);
+    if (opener && typeof opener.focus === 'function') {
+      opener.focus();
+    }
+    opener = null;
+  }
+
+  // Delegated so it covers every page and survives re-rendered content.
+  document.addEventListener('click', function (e) {
+    var target = e.target;
+    if (!(target instanceof HTMLImageElement)) {
+      return;
+    }
+    if (!target.closest('.md-content')) {
+      return;
+    }
+    // Leave genuine links (badges, logos wrapped in <a>) alone.
+    if (target.closest('a')) {
+      return;
+    }
+    e.preventDefault();
+    open(target);
+  });
+
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape') {
+      close();
+    }
+  });
+
+  // Make content images look and behave like controls.
+  function markImages() {
+    document.querySelectorAll('.md-content img').forEach(function (el) {
+      if (el.closest('a') || el.dataset.nwmZoomable) {
+        return;
+      }
+      el.dataset.nwmZoomable = '1';
+      el.tabIndex = 0;
+      el.setAttribute('role', 'button');
+      el.setAttribute('title', 'Click to enlarge');
+      el.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          open(el);
+        }
+      });
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', markImages);
+  } else {
+    markImages();
+  }
+  // Material's instant navigation swaps content without a reload.
+  if (window.document$ && typeof window.document$.subscribe === 'function') {
+    window.document$.subscribe(markImages);
+  }
+})();

--- a/website/docs/javascripts/lightbox.js
+++ b/website/docs/javascripts/lightbox.js
@@ -121,7 +121,16 @@
     document.body.style.top = '';
     window.scrollTo(0, y);
     if (opener && typeof opener.focus === 'function') {
-      opener.focus();
+      // preventScroll matters: focus() otherwise scrolls the element into
+      // view and overrides the restore above. On a long page (the icon
+      // reference is ~15,000px) that silently dropped the reader hundreds of
+      // pixels from where they were — the exact thing this overlay exists to
+      // avoid. Older browsers ignore the option and simply focus.
+      try {
+        opener.focus({ preventScroll: true });
+      } catch (e) {
+        opener.focus();
+      }
     }
     opener = null;
   }

--- a/website/docs/stylesheets/lightbox.css
+++ b/website/docs/stylesheets/lightbox.css
@@ -1,0 +1,121 @@
+/* Click-to-enlarge overlay for documentation screenshots (see
+ * javascripts/lightbox.js). Dracula surfaces to match the rest of the site. */
+
+/* Content images advertise that they are clickable. */
+.md-content img[data-nwm-zoomable] {
+  cursor: zoom-in;
+  border-radius: 4px;
+  transition: box-shadow 120ms ease, transform 120ms ease;
+}
+
+.md-content img[data-nwm-zoomable]:hover,
+.md-content img[data-nwm-zoomable]:focus-visible {
+  box-shadow: 0 0 0 2px var(--md-accent-fg-color, #ff79c6);
+  outline: none;
+}
+
+/* The page keeps its scroll position while the overlay is open. */
+body.nwm-lightbox-open {
+  position: fixed;
+  width: 100%;
+  overflow: hidden;
+}
+
+.nwm-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: none;
+  /* Near-opaque on purpose: at lower alpha the page's own header controls read
+     through the backdrop and compete with the overlay's close button. */
+  background: rgba(20, 21, 27, 0.985);
+  backdrop-filter: blur(3px);
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+
+.nwm-lightbox.is-open {
+  display: block;
+}
+
+.nwm-lightbox__figure {
+  margin: 0;
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5rem 1.5rem 1.5rem;
+  box-sizing: border-box;
+}
+
+.nwm-lightbox__img {
+  display: block;
+  max-width: 95vw;
+  max-height: 88vh;
+  width: auto;
+  height: auto;
+  cursor: zoom-in;
+  border-radius: 4px;
+  background: #14151b;
+  box-shadow: 0 12px 48px rgba(0, 0, 0, 0.6);
+}
+
+/* Zoomed: render at natural pixel size and let the overlay scroll/pan. */
+.nwm-lightbox.is-zoomed .nwm-lightbox__figure {
+  display: block;
+  min-height: 0;
+  width: max-content;
+}
+
+.nwm-lightbox.is-zoomed .nwm-lightbox__img {
+  max-width: none;
+  max-height: none;
+  cursor: grab;
+}
+
+.nwm-lightbox.is-zoomed .nwm-lightbox__img.is-grabbing {
+  cursor: grabbing;
+}
+
+.nwm-lightbox__caption {
+  margin-top: 0.9rem;
+  max-width: 60rem;
+  text-align: center;
+  font-size: 0.72rem;
+  line-height: 1.5;
+  color: rgba(248, 248, 242, 0.72);
+}
+
+.nwm-lightbox.is-zoomed .nwm-lightbox__caption {
+  display: none;
+}
+
+.nwm-lightbox__close {
+  position: fixed;
+  top: 0.6rem;
+  right: 0.9rem;
+  z-index: 1;
+  width: 2.1rem;
+  height: 2.1rem;
+  font-size: 1.5rem;
+  line-height: 1;
+  color: rgba(248, 248, 242, 0.85);
+  background: rgba(40, 42, 54, 0.9);
+  border: 1px solid rgba(248, 248, 242, 0.18);
+  border-radius: 50%;
+  cursor: pointer;
+}
+
+.nwm-lightbox__close:hover,
+.nwm-lightbox__close:focus-visible {
+  color: #ff79c6;
+  border-color: #ff79c6;
+  outline: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .md-content img[data-nwm-zoomable] {
+    transition: none;
+  }
+}

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -11,19 +11,17 @@ theme:
     - search.highlight
   logo: assets/logo.svg
   palette:
-    # Dracula (dark) is the default; styled via stylesheets/dracula.css
+    # Dracula (dark) only — styled via stylesheets/dracula.css. The light
+    # scheme was dropped deliberately: every screenshot on this site is a dark
+    # Grafana capture, and they read as bright rectangles punched into a white
+    # page. One scheme also means one set of colors to keep correct.
     - scheme: slate
       primary: black
-      toggle:
-        icon: material/brightness-4
-        name: Switch to light mode
-    - scheme: default
-      primary: black
-      toggle:
-        icon: material/brightness-7
-        name: Switch to dark mode
 extra_css:
   - stylesheets/dracula.css
+  - stylesheets/lightbox.css
+extra_javascript:
+  - javascripts/lightbox.js
 markdown_extensions:
   - admonition
   - pymdownx.details


### PR DESCRIPTION
Closes #341.

Docs-site only (`website/` plus one eslint ignore entry), branched from `main` so it deploys on merge without waiting on anything else.

## Why

Clicking a screenshot on the published site does nothing. That matters more here than on most docs sites, because these captures are dense — full weathermaps carrying per-link value labels and interface names, link-editor panels with a column of small fields. At the width MkDocs gives body content, the exact detail the surrounding prose is pointing at is unreadable, and the reader's only workaround is right-click → open image in new tab, which costs them their place on the page.

## What

- **Click to enlarge.** Any content image opens in an overlay at full width. **Click again to zoom to 1:1 pixels**, with drag-to-pan — that second step is the one the dense captures actually need. Escape, the backdrop, or the close button dismisses it.
- **Reading flow is the constraint.** The page keeps its *exact* scroll position while the overlay is open and after it closes, so enlarging an image never interrupts reading. That is the whole reason for an overlay rather than a link to the raw file.
- **Keyboard and a11y.** Images are focusable and open with Enter/Space; the overlay is a labelled `role="dialog"`; focus returns to the image that was opened. Images already wrapped in links are left alone so no navigation is hijacked.
- **Light scheme dropped.** Every screenshot on this site is a dark Grafana capture; on a white page they read as bright rectangles punched into the text. One scheme also means one set of colours to keep correct.

Implemented as a local JS + CSS pair rather than adding `mkdocs-glightbox`, so the docs build stays a plain `pip install mkdocs-material` and `docs.yml` is untouched.

`website/docs/javascripts/` joins the eslint ignore list next to the other non-plugin JS (`website/scripts/`, `testing/scripts/`, …) — browser-side docs assets aren't part of any tsconfig project, and eslint fails on them otherwise.

## Verification

`mkdocs build --strict` clean, then driven in a real browser against the built site on the **`/guide/bgp/` page from the report**:

```
  PASS  no light/dark toggle on the BGP page
  PASS  BGP page images are zoomable  — 2 images
  PASS  overlay opens
  PASS  enlarged beyond in-page size  — 688px -> 1368px
  PASS  zooms to 1:1 on second click  — 1368px -> 1400px
  PASS  closes on Escape
  PASS  scroll position preserved
  PASS  opens from the keyboard
```

The same checks pass on `/guide/links/` (10 zoomable images, 1368px → 2480px on a full-width capture).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a click-to-enlarge lightbox for docs screenshots with 1:1 zoom and drag-to-pan, preserving scroll and keyboard access. Removes the light theme and fixes a scroll jump on long pages when closing the overlay.

- **New Features**
  - Content images open in an overlay; second click toggles 1:1 with drag-to-pan; Escape/backdrop/close dismiss.
  - Reading flow preserved: exact scroll position kept; focus returns to the opened image; Enter/Space opens; overlay is a labelled dialog.
  - Images wrapped in links are ignored to avoid hijacking navigation.
  - Implemented locally via `website/docs/javascripts/lightbox.js` and `website/docs/stylesheets/lightbox.css`; wired in `website/mkdocs.yml` (no `mkdocs-glightbox` or extra deps).
  - Dropped the light palette; dark-only theme remains; removed palette toggle.
  - Added `website/docs/javascripts/` to `.eslintrc` ignore to avoid linting non-project browser assets.

- **Bug Fixes**
  - Prevented reading-position jumps on very long pages by using `focus({ preventScroll: true })` after restoring scroll (guarded for older browsers).

<sup>Written for commit 2dda2a33b562773f3ddbf56a9d4337f131821476. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

