### PR TITLE
fix(testing): make the demo exporter URL configurable

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -100,7 +100,8 @@ Publish the exporter somewhere else and regenerate the dashboards to match:
 #     ports: !override ["8082:8080"]
 
 WM_EXPORTER_URL=http://localhost:8082 node testing/scripts/generate-scenario-dashboards.js
-docker compose --project-directory testing up -d --build grafana
+# Recreate the exporter (it is what binds the new port) as well as Grafana:
+docker compose --project-directory testing up -d --build exporter grafana
 ```
 
 `WM_EXPORTER_URL` defaults to `http://localhost:8080`, so the committed

--- a/testing/README.md
+++ b/testing/README.md
@@ -84,6 +84,29 @@ The exporter (`testing/exporter/main.go`) produces:
 The exporter also serves the demo background images over HTTP (port 8080,
 published by the compose file): `/floorplan.svg`, `/worldmap.svg`, `/rack.svg`, `/rack2.svg`.
 
+### If port 8080 is already taken
+
+Those URLs are absolute (`http://localhost:8080/...`) because the **browser**
+resolves them, not Grafana — a compose service name would not work. 8080 is a
+commonly occupied port, and when it is, the background art simply never loads:
+the rack/floor-plan/world-map maps render their nodes on an empty canvas with
+no error to explain it.
+
+Publish the exporter somewhere else and regenerate the dashboards to match:
+
+```bash
+# docker-compose.override.yml (untracked, local only)
+#   exporter:
+#     ports: !override ["8082:8080"]
+
+WM_EXPORTER_URL=http://localhost:8082 node testing/scripts/generate-scenario-dashboards.js
+docker compose --project-directory testing up -d --build grafana
+```
+
+`WM_EXPORTER_URL` defaults to `http://localhost:8080`, so the committed
+dashboards are unchanged unless you set it — don't commit dashboards
+regenerated with a custom URL.
+
 ## E2E tests
 
 Playwright E2E tests (`tests/panel.spec.ts`, via `@grafana/plugin-e2e`) run in CI

--- a/testing/scripts/generate-scenario-dashboards.js
+++ b/testing/scripts/generate-scenario-dashboards.js
@@ -29,6 +29,26 @@ const path = require('path');
 const OUT_DIR = path.join(__dirname, '..', 'grafana', 'dashboards');
 const VERSION = 14; // CURRENT_VERSION in src/utils.ts
 
+// Background art (rack elevations, floor plan, world map) is served by the
+// exporter container, and the URL is resolved by the VIEWER'S BROWSER — so it
+// has to be an absolute host:port, not a compose service name.
+//
+// 8080 is one of the most commonly occupied ports on a developer machine. When
+// it is taken, docker compose cannot publish it, the demo maps request an
+// origin that answers with something else or nothing at all, and the panels
+// render their nodes floating on an empty canvas with no error — the map looks
+// broken for a reason nothing on screen explains.
+//
+// Override the whole base URL to match a remapped exporter port, then
+// regenerate:  WM_EXPORTER_URL=http://localhost:8082 node testing/scripts/generate-scenario-dashboards.js
+const EXPORTER_URL = (process.env.WM_EXPORTER_URL || 'http://localhost:8080').replace(/\/+$/, '');
+const bgImage = (file, extra = {}) => ({
+  url: `${EXPORTER_URL}/${file}`,
+  fit: 'contain',
+  attachToCanvas: true,
+  ...extra,
+});
+
 // Anchor enum from src/types.ts
 const A = { Center: 0, Top: 1, Bottom: 2, Left: 3, Right: 4 };
 
@@ -745,7 +765,7 @@ const dashboards = [
       ),
       {
         panel: {
-          backgroundImage: { url: 'http://localhost:8080/worldmap.svg', fit: 'contain', attachToCanvas: true },
+          backgroundImage: bgImage('worldmap.svg'),
         },
         scale: { title: 'Backbone Load' },
       }
@@ -775,7 +795,7 @@ const dashboards = [
       ),
       {
         panel: {
-          backgroundImage: { url: 'http://localhost:8080/floorplan.svg', fit: 'contain', attachToCanvas: true },
+          backgroundImage: bgImage('floorplan.svg'),
         },
         scale: { title: 'Link Load' },
       }
@@ -789,7 +809,7 @@ const dashboards = [
       'A switch faceplate drawn as the background with each port as a status-colored node: green = up, red = down (ports 7 and 19 are unpatched; port 13 flaps every ~5 minutes), gray = admin-disabled (23/24). T1/T2 are the 10G uplinks.',
     weathermap: makeWeathermap('wm-rack-ports', buildRackPorts(), {
       panel: {
-        backgroundImage: { url: 'http://localhost:8080/rack.svg', fit: 'contain', attachToCanvas: true },
+        backgroundImage: bgImage('rack.svg'),
       },
       fontSizing: { node: 9, link: 8 },
       scale: { title: 'Load', size: { width: 0, height: 0 } },
@@ -855,7 +875,7 @@ const dashboards = [
       'Rear elevation of one rack: router, firewall, two switches, three servers, and redundant PDU-A/PDU-B strips. Every port/NIC/PSU inlet/outlet is a status-colored node; network cables run through the left channel with live traffic, power cables carry each feed\u2019s live wattage. SW1 port 5 is down, SRV-2 lost its standby NIC, and SRV-3\u2019s A feed sits in PDU-A\u2019s dead outlet 6 \u2014 its full draw shifts to the B feed.',
     weathermap: makeWeathermap('wm-rack-cabling', buildRackCabling(), {
       panel: {
-        backgroundImage: { url: 'http://localhost:8080/rack2.svg', fit: 'contain', attachToCanvas: true },
+        backgroundImage: bgImage('rack2.svg'),
         panelSize: { width: 1000, height: 760 },
       },
       fontSizing: { node: 8, link: 7 },
@@ -871,7 +891,7 @@ const dashboards = [
       'The rack-cabling topology with the dense-map readability features enabled (plugin >= 1.5.12): hover a cable to highlight its whole path and fade the rest; power cables render as true one-way flows into the PSU inlets; value labels de-overlap automatically and hide when zoomed out two steps; a built-in status legend explains the colors; the PSU inlet labels are bold for emphasis.',
     weathermap: makeWeathermap('wm-rack-interactive', buildInteractiveRack(), {
       panel: {
-        backgroundImage: { url: 'http://localhost:8080/rack2.svg', fit: 'contain', attachToCanvas: true },
+        backgroundImage: bgImage('rack2.svg'),
         panelSize: { width: 1000, height: 760 },
       },
       link: { hoverHighlight: true, labelCollision: true, labelHideZoom: 2 },


### PR DESCRIPTION
Testing-environment only — no plugin code changes.

## The problem

Five demo dashboards (`wm-rack-cabling`, `wm-rack-ports`, `wm-rack-interactive`, `wm-floorplan`, `wm-global-backbone`) take their background art from the exporter container at a hardcoded `http://localhost:8080`. It has to be an absolute `host:port` because the **browser** resolves it, not Grafana — a compose service name wouldn't work.

But 8080 is one of the most commonly occupied ports on a developer machine, and when it's taken the failure is silent and very confusing:

```
net::ERR_CONNECTION_REFUSED  http://localhost:8080/rack2.svg
```

compose can't publish the port → the background never loads → the map draws its nodes floating on an empty canvas, with nothing on screen explaining why. `wm-rack-cabling` is the worst case: a rack rear-elevation map whose entire visual frame is the faceplate art, so without it the map reads as completely broken. It isn't — with the art loading it renders exactly as designed (devices, patch panel, PDU-A/B feeds, legend).

## The fix

The generator now builds those URLs from `WM_EXPORTER_URL`, defaulting to `http://localhost:8080`:

```bash
WM_EXPORTER_URL=http://localhost:8082 node testing/scripts/generate-scenario-dashboards.js
```

Verified that regenerating with **no** env var leaves every committed dashboard byte-identical (`git diff` empty), and that the override reaches all five.

`testing/README.md` gains a short section on the port clash — the compose override snippet, the regenerate command, and a warning not to commit dashboards regenerated against a custom URL.

## Not addressed here

This makes the *demo* robust, but the underlying panel behaviour is still that a background image is a URL which can fail silently. Two follow-ups worth considering, tracked separately: surfacing image load failures in edit mode, and letting the panel embed an uploaded image so a dashboard doesn't depend on an external host at all.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the demo background image URLs configurable to avoid localhost:8080 clashes in testing dashboards. The generator now reads WM_EXPORTER_URL (default http://localhost:8080); docs updated to also recreate the `exporter` when remapping the port; no plugin/runtime changes.

- **Migration**
  - If 8080 is busy, remap the exporter and regenerate: WM_EXPORTER_URL=http://localhost:8082 node testing/scripts/generate-scenario-dashboards.js
  - Recreate the exporter and Grafana to bind the new port: docker compose --project-directory testing up -d --build exporter grafana
  - Do not commit dashboards regenerated with a custom URL.

<sup>Written for commit 37ef55f77e7e6fbd2882539be110c8fc5b99d8a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

