### PR TITLE
feat(panel): embed an uploaded background image; report load failures (#344)

### DIFF
--- a/src/WeathermapPanel.background.test.tsx
+++ b/src/WeathermapPanel.background.test.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { getDefaultRelativeTimeRange, getTimeZone, LoadingState, PanelProps } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { WeathermapPanel } from 'WeathermapPanel';
 import { SimpleOptions, Weathermap } from 'types';
 import { getData, theme } from 'testData';
@@ -95,23 +95,49 @@ describe('background image failure notice (#344)', () => {
     expect(screen.getByTestId('weathermap-data-notice').textContent).toMatch(/rejected/i);
   });
 
+  // Absence is asserted after the effects have actually been flushed, not
+  // after an arbitrary sleep: a fixed delay neither proves the effect ran nor
+  // catches a notice that appears later, and goes flaky on a slow machine.
+  const settle = async () => {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  };
+
   test('the same bad source is silent in VIEW mode', async () => {
     renderPanel(withBackground('data:text/html;base64,PHNjcmlwdD4=', true));
-    await new Promise((r) => setTimeout(r, 50));
+    await settle();
     expect(screen.queryByTestId('weathermap-data-notice')).toBeNull();
   });
 
   test('a valid source produces no notice', async () => {
     enterEditMode();
     renderPanel(withBackground(SVG_URI, true));
-    await new Promise((r) => setTimeout(r, 50));
+    await settle();
     expect(screen.queryByTestId('weathermap-data-notice')).toBeNull();
   });
 
   test('no background configured produces no notice', async () => {
     enterEditMode();
     renderPanel();
-    await new Promise((r) => setTimeout(r, 50));
+    await settle();
+    expect(screen.queryByTestId('weathermap-data-notice')).toBeNull();
+  });
+
+  test('a failure found in edit mode does not leak into view mode', async () => {
+    // The probe state survives a mode switch until its effect re-runs, so the
+    // notice is gated on isEditMode at render too.
+    enterEditMode();
+    const bad = 'data:text/html;base64,PHNjcmlwdD4=';
+    const first = renderPanel(withBackground(bad, true));
+    await waitFor(() => expect(screen.getByTestId('weathermap-data-notice')).toBeTruthy());
+    // Unmount before re-rendering: RTL keeps every render in the document, so
+    // without this the assertion below would find the FIRST render's banner.
+    first.unmount();
+    spy?.mockRestore();
+    spy = undefined;
+    renderPanel(withBackground(bad, true));
+    await settle();
     expect(screen.queryByTestId('weathermap-data-notice')).toBeNull();
   });
 });

--- a/src/WeathermapPanel.background.test.tsx
+++ b/src/WeathermapPanel.background.test.tsx
@@ -30,7 +30,10 @@ const renderPanel = (mutate?: (wm: Weathermap) => void) => {
     eventBus: {},
     onOptionsChange: jest.fn(),
   } as unknown as PanelProps<SimpleOptions>;
-  return render(<WeathermapPanel {...props} />);
+  // `props` is handed back so a test can re-render the SAME instance with a
+  // FRESH element — passing the identical element object back to rerender()
+  // lets React bail out, and nothing re-reads the edit-mode flag.
+  return { ...render(<WeathermapPanel {...props} />), props };
 };
 
 const withBackground = (url: string, attachToCanvas: boolean) => (wm: Weathermap) => {
@@ -129,15 +132,21 @@ describe('background image failure notice (#344)', () => {
     // notice is gated on isEditMode at render too.
     enterEditMode();
     const bad = 'data:text/html;base64,PHNjcmlwdD4=';
-    const first = renderPanel(withBackground(bad, true));
+    const { rerender, props } = renderPanel(withBackground(bad, true));
     await waitFor(() => expect(screen.getByTestId('weathermap-data-notice')).toBeTruthy());
-    // Unmount before re-rendering: RTL keeps every render in the document, so
-    // without this the assertion below would find the FIRST render's banner.
-    first.unmount();
+    // Re-render the SAME instance with the mode flipped, so the carried-over
+    // failure state is what the view-mode render has to deal with.
+    //
+    // Honest limitation: this pins the OUTCOME (no banner in view mode), not
+    // the render-time gate specifically. RTL wraps rerender in act(), which
+    // flushes the effect that resets the status in the same tick, so the
+    // intermediate render is not observable here — the test passes with the
+    // `isEditMode &&` guards removed. The guards still matter in a real
+    // browser, where React commits and paints a frame before effects run, and
+    // that frame would otherwise show the stale banner over a dashboard.
     spy?.mockRestore();
     spy = undefined;
-    renderPanel(withBackground(bad, true));
-    await settle();
+    rerender(<WeathermapPanel {...props} />);
     expect(screen.queryByTestId('weathermap-data-notice')).toBeNull();
   });
 });

--- a/src/WeathermapPanel.background.test.tsx
+++ b/src/WeathermapPanel.background.test.tsx
@@ -1,0 +1,117 @@
+// Background image sources (#344): linked URLs, embedded data: URIs, the
+// edit-mode failure notice, and the hostile-input boundary.
+import React from 'react';
+import { getDefaultRelativeTimeRange, getTimeZone, LoadingState, PanelProps } from '@grafana/data';
+import { locationService } from '@grafana/runtime';
+import { render, screen, waitFor } from '@testing-library/react';
+import { WeathermapPanel } from 'WeathermapPanel';
+import { SimpleOptions, Weathermap } from 'types';
+import { getData, theme } from 'testData';
+import { handleVersionedStateUpdates } from 'utils';
+
+const PNG = 'data:image/png;base64,iVBORw0KGgo=';
+const SVG_URI = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciLz4=';
+
+const renderPanel = (mutate?: (wm: Weathermap) => void) => {
+  const wm = handleVersionedStateUpdates(getData(theme), theme);
+  mutate?.(wm);
+  const props = {
+    id: 1,
+    data: { state: LoadingState.Done, series: [], timeRange: getDefaultRelativeTimeRange() },
+    timeRange: getDefaultRelativeTimeRange(),
+    timeZone: getTimeZone(),
+    options: { weathermap: wm },
+    transparent: false,
+    width: 600,
+    height: 400,
+    fieldConfig: {},
+    renderCounter: 1,
+    title: 'T',
+    eventBus: {},
+    onOptionsChange: jest.fn(),
+  } as unknown as PanelProps<SimpleOptions>;
+  return render(<WeathermapPanel {...props} />);
+};
+
+const withBackground = (url: string, attachToCanvas: boolean) => (wm: Weathermap) => {
+  wm.settings.panel.backgroundImage = { url, fit: 'contain', attachToCanvas };
+};
+
+describe('background image sources (#344)', () => {
+  test('an embedded data URI renders on the canvas path', () => {
+    const { container } = renderPanel(withBackground(SVG_URI, true));
+    const image = container.querySelector('svg image');
+    expect(image).not.toBeNull();
+    expect(image!.getAttribute('href')).toBe(SVG_URI);
+  });
+
+  test('an embedded data URI renders on the CSS (fixed) path', () => {
+    const { container } = renderPanel(withBackground(PNG, false));
+    expect(container.innerHTML).toContain(`url(${PNG})`);
+  });
+
+  test('a linked URL still works on both paths, unchanged', () => {
+    const url = 'https://example.com/rack.svg';
+    const canvas = renderPanel(withBackground(url, true));
+    expect(canvas.container.querySelector('svg image')!.getAttribute('href')).toBe(url);
+    const fixed = renderPanel(withBackground(url, false));
+    expect(fixed.container.innerHTML).toContain(`url(${url})`);
+  });
+
+  test.each([
+    ['a script data URI', 'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg=='],
+    ['a javascript: URL', 'javascript:alert(1)'],
+    ['a non-base64 svg payload', 'data:image/svg+xml,<svg onload=alert(1)>'],
+    ['an unsupported image type', 'data:image/tiff;base64,AAAA'],
+  ])('%s is refused at render time, not just in the editor', (_name, hostile) => {
+    // Defense in depth: a hand-edited dashboard never reaches the DOM with it.
+    const canvas = renderPanel(withBackground(hostile, true));
+    expect(canvas.container.querySelector('svg image')).toBeNull();
+    const fixed = renderPanel(withBackground(hostile, false));
+    expect(fixed.container.innerHTML).not.toContain('alert(1)');
+    expect(fixed.container.innerHTML).not.toContain('data:text/html');
+  });
+
+  test('no background configured renders no image element', () => {
+    const { container } = renderPanel();
+    expect(container.querySelector('svg image')).toBeNull();
+  });
+});
+
+describe('background image failure notice (#344)', () => {
+  let spy: jest.SpyInstance | undefined;
+  afterEach(() => {
+    spy?.mockRestore();
+    spy = undefined;
+  });
+  const enterEditMode = () => {
+    spy = jest.spyOn(locationService, 'getSearch').mockReturnValue(new URLSearchParams('editPanel=1'));
+  };
+
+  test('a source the sanitizer refuses is reported in edit mode', async () => {
+    enterEditMode();
+    renderPanel(withBackground('data:text/html;base64,PHNjcmlwdD4=', true));
+    await waitFor(() => expect(screen.getByTestId('weathermap-data-notice')).toBeTruthy());
+    expect(screen.getByTestId('weathermap-data-notice').textContent).toMatch(/rejected/i);
+  });
+
+  test('the same bad source is silent in VIEW mode', async () => {
+    renderPanel(withBackground('data:text/html;base64,PHNjcmlwdD4=', true));
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.queryByTestId('weathermap-data-notice')).toBeNull();
+  });
+
+  test('a valid source produces no notice', async () => {
+    enterEditMode();
+    renderPanel(withBackground(SVG_URI, true));
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.queryByTestId('weathermap-data-notice')).toBeNull();
+  });
+
+  test('no background configured produces no notice', async () => {
+    enterEditMode();
+    renderPanel();
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.queryByTestId('weathermap-data-notice')).toBeNull();
+  });
+});

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -200,7 +200,11 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
   // elevation, a floor plan). Probe it and report in EDIT MODE only, so a
   // transient failure never puts a banner on a wall display.
   const bgConfiguredSrc = wm?.settings?.panel?.backgroundImage?.url ?? '';
-  const bgSafeSrc = sanitizeImageSource(bgConfiguredSrc);
+  // Memoized because an embedded background can be megabytes: sanitizing strips
+  // whitespace and regex-matches the whole string, and this renders on every
+  // live data refresh. Keyed on the raw source, so it runs once per change
+  // rather than once (previously five times) per render.
+  const bgSafeSrc = useMemo(() => sanitizeImageSource(bgConfiguredSrc), [bgConfiguredSrc]);
   const [bgImageStatus, setBgImageStatus] = useState<'ok' | 'failed' | 'rejected'>('ok');
   useEffect(() => {
     if (!isEditMode || !bgConfiguredSrc) {
@@ -213,6 +217,10 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
       setBgImageStatus('rejected');
       return;
     }
+    // Clear any previous verdict before probing: otherwise the render between
+    // "source changed" and "new probe answered" reports the OLD failure against
+    // the NEW source, which is worst for a valid-but-slow image.
+    setBgImageStatus('ok');
     let cancelled = false;
     const probe = new Image();
     probe.onload = () => {
@@ -1056,15 +1064,17 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
     }
     // A broken background (#344) is edit-mode only and ranks below a query
     // error, but above the no-data hint: it is a configuration mistake the
-    // editor can see and fix immediately.
-    if (bgImageStatus === 'rejected') {
+    // editor can see and fix immediately. Gated on isEditMode HERE as well as
+    // in the probe effect — the effect's reset runs after the render that
+    // switched modes, so without this the banner can flash once in view mode.
+    if (isEditMode && bgImageStatus === 'rejected') {
       return {
         level: 'error',
         message:
           'Background image source was rejected. Use an http(s) or relative URL, or upload a PNG, JPEG, GIF, WebP, or SVG file.',
       };
     }
-    if (bgImageStatus === 'failed') {
+    if (isEditMode && bgImageStatus === 'failed') {
       return {
         level: 'error',
         message: `Background image failed to load: ${bgSafeSrc.startsWith('data:') ? 'embedded image is not valid' : bgSafeSrc}`,
@@ -1512,8 +1522,8 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
             backgroundImage:
               wm.settings.panel.backgroundImage &&
               !wm.settings.panel.backgroundImage.attachToCanvas &&
-              sanitizeImageSource(wm.settings.panel.backgroundImage.url)
-                ? `url(${sanitizeImageSource(wm.settings.panel.backgroundImage.url)})`
+              bgSafeSrc
+                ? `url(${bgSafeSrc})`
                 : 'none',
             backgroundSize: wm.settings.panel.backgroundImage?.fit,
             backgroundPosition: 'center',
@@ -1655,9 +1665,9 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
           >
             {wm.settings.panel.backgroundImage &&
             wm.settings.panel.backgroundImage.attachToCanvas &&
-            sanitizeImageSource(wm.settings.panel.backgroundImage.url) ? (
+            bgSafeSrc ? (
               <image
-                href={sanitizeImageSource(wm.settings.panel.backgroundImage.url)}
+                href={bgSafeSrc}
                 x={0}
                 y={0}
                 width={wm.settings.panel.panelSize.width}

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -51,6 +51,7 @@ import {
   spreadLabels,
   LabelPlacement,
   sanitizeUrl,
+  sanitizeImageSource,
   aggregateFieldValues,
   getTimeField,
   valueAtTime,
@@ -191,6 +192,44 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
 
   const [draggedNode, setDraggedNode] = useState(null as unknown as DrawnNode);
   const [selectedNodes, setSelectedNodes] = useState([] as DrawnNode[]);
+
+  // Background image health (#344). A background that 404s, is refused, or is
+  // rejected by the sanitizer renders as nothing at all — the map draws its
+  // nodes on an empty canvas with no hint that the art is missing, which is a
+  // genuinely baffling failure when the background IS the frame (a rack
+  // elevation, a floor plan). Probe it and report in EDIT MODE only, so a
+  // transient failure never puts a banner on a wall display.
+  const bgConfiguredSrc = wm?.settings?.panel?.backgroundImage?.url ?? '';
+  const bgSafeSrc = sanitizeImageSource(bgConfiguredSrc);
+  const [bgImageStatus, setBgImageStatus] = useState<'ok' | 'failed' | 'rejected'>('ok');
+  useEffect(() => {
+    if (!isEditMode || !bgConfiguredSrc) {
+      setBgImageStatus('ok');
+      return;
+    }
+    if (!bgSafeSrc) {
+      // Non-empty source that the sanitizer refused (bad scheme, or a data URI
+      // of a type we do not accept) — never even attempted.
+      setBgImageStatus('rejected');
+      return;
+    }
+    let cancelled = false;
+    const probe = new Image();
+    probe.onload = () => {
+      if (!cancelled) {
+        setBgImageStatus('ok');
+      }
+    };
+    probe.onerror = () => {
+      if (!cancelled) {
+        setBgImageStatus('failed');
+      }
+    };
+    probe.src = bgSafeSrc;
+    return () => {
+      cancelled = true;
+    };
+  }, [isEditMode, bgConfiguredSrc, bgSafeSrc]);
 
   // Timeline slider (#158): when scrubbing, holds the selected timestamp (ms).
   // null means "live" — resolve values with the normal value-mapping mode.
@@ -1015,6 +1054,22 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
       const message = data.error?.message || data.errors?.[0]?.message || 'A query returned an error.';
       return { level: 'error', message: `Query error: ${message}` };
     }
+    // A broken background (#344) is edit-mode only and ranks below a query
+    // error, but above the no-data hint: it is a configuration mistake the
+    // editor can see and fix immediately.
+    if (bgImageStatus === 'rejected') {
+      return {
+        level: 'error',
+        message:
+          'Background image source was rejected. Use an http(s) or relative URL, or upload a PNG, JPEG, GIF, WebP, or SVG file.',
+      };
+    }
+    if (bgImageStatus === 'failed') {
+      return {
+        level: 'error',
+        message: `Background image failed to load: ${bgSafeSrc.startsWith('data:') ? 'embedded image is not valid' : bgSafeSrc}`,
+      };
+    }
     // Only warn about missing data when the map actually expects some — i.e. at
     // least one node or link has a query configured. A topology-only map is fine.
     const expectsData = Boolean(
@@ -1457,8 +1512,8 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
             backgroundImage:
               wm.settings.panel.backgroundImage &&
               !wm.settings.panel.backgroundImage.attachToCanvas &&
-              sanitizeUrl(wm.settings.panel.backgroundImage.url)
-                ? `url(${sanitizeUrl(wm.settings.panel.backgroundImage.url)})`
+              sanitizeImageSource(wm.settings.panel.backgroundImage.url)
+                ? `url(${sanitizeImageSource(wm.settings.panel.backgroundImage.url)})`
                 : 'none',
             backgroundSize: wm.settings.panel.backgroundImage?.fit,
             backgroundPosition: 'center',
@@ -1600,9 +1655,9 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
           >
             {wm.settings.panel.backgroundImage &&
             wm.settings.panel.backgroundImage.attachToCanvas &&
-            sanitizeUrl(wm.settings.panel.backgroundImage.url) ? (
+            sanitizeImageSource(wm.settings.panel.backgroundImage.url) ? (
               <image
-                href={sanitizeUrl(wm.settings.panel.backgroundImage.url)}
+                href={sanitizeImageSource(wm.settings.panel.backgroundImage.url)}
                 x={0}
                 y={0}
                 width={wm.settings.panel.panelSize.width}

--- a/src/forms/PanelForm.test.tsx
+++ b/src/forms/PanelForm.test.tsx
@@ -233,15 +233,23 @@ describe('background image upload (#344)', () => {
     expect(field.readOnly).toBe(true);
   });
 
+  // Restored in afterEach, not inline: an inline restore is skipped when an
+  // assertion throws, leaking a confirm() that always returns true into every
+  // later test that branches on it.
+  let confirmSpy: jest.SpyInstance | undefined;
+  afterEach(() => {
+    confirmSpy?.mockRestore();
+    confirmSpy = undefined;
+  });
+
   test('removing the background clears a previous upload note', async () => {
     const spy = jest.fn();
-    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+    confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
     render(<Harness initial={withBackground()} onChangeSpy={spy} />);
     fireEvent.change(screen.getByTestId('bg-image-upload'), { target: { files: [svgFile()] } });
     await screen.findByTestId('bg-image-upload-note');
     fireEvent.click(screen.getByTestId('bg-image-remove'));
     expect(screen.queryByTestId('bg-image-upload-note')).toBeNull();
-    confirmSpy.mockRestore();
   });
 
   test('a linked URL stays editable and is shown verbatim', () => {

--- a/src/forms/PanelForm.test.tsx
+++ b/src/forms/PanelForm.test.tsx
@@ -222,6 +222,28 @@ describe('background image upload (#344)', () => {
     expect(field.readOnly).toBe(true);
   });
 
+  test('an embedded source with stray whitespace is still shown as a summary', () => {
+    // Imported dashboards can carry wrapped base64; classify the sanitized
+    // form so they read the same as a freshly uploaded image.
+    const initial = withBackground();
+    initial.settings.panel.backgroundImage!.url = 'data:image/svg+xml;base64,PHN2\n Zy8+';
+    render(<Harness initial={initial} onChangeSpy={jest.fn()} />);
+    const field = document.querySelector('input[name="bgImageURL"]') as HTMLInputElement;
+    expect(field.value).toMatch(/^Embedded image \(SVG, /);
+    expect(field.readOnly).toBe(true);
+  });
+
+  test('removing the background clears a previous upload note', async () => {
+    const spy = jest.fn();
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+    render(<Harness initial={withBackground()} onChangeSpy={spy} />);
+    fireEvent.change(screen.getByTestId('bg-image-upload'), { target: { files: [svgFile()] } });
+    await screen.findByTestId('bg-image-upload-note');
+    fireEvent.click(screen.getByTestId('bg-image-remove'));
+    expect(screen.queryByTestId('bg-image-upload-note')).toBeNull();
+    confirmSpy.mockRestore();
+  });
+
   test('a linked URL stays editable and is shown verbatim', () => {
     const initial = withBackground();
     initial.settings.panel.backgroundImage!.url = 'https://example.com/bg.png';

--- a/src/forms/PanelForm.test.tsx
+++ b/src/forms/PanelForm.test.tsx
@@ -158,3 +158,76 @@ test('clearing a configured scale font color restores auto contrast (#278)', asy
   fireEvent.click(screen.getByRole('button', { name: 'None' }));
   expect(lastValue(spy).settings.scale.backgroundColor).toBeUndefined();
 });
+
+// Background image upload (#344). jsdom has a real FileReader, so the whole
+// read -> sanitize -> store path runs for real here.
+describe('background image upload (#344)', () => {
+  const withBackground = () => {
+    const initial = getData(theme);
+    initial.settings.panel.backgroundImage = { url: '', fit: 'contain' };
+    return initial;
+  };
+  const svgFile = (name = 'rack.svg', bytes = 512) =>
+    new File([new Uint8Array(bytes).fill(60)], name, { type: 'image/svg+xml' });
+
+  test('uploading embeds the file as a data URI in the existing url field', async () => {
+    const spy = jest.fn();
+    render(<Harness initial={withBackground()} onChangeSpy={spy} />);
+    const input = screen.getByTestId('bg-image-upload') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [svgFile()] } });
+    await screen.findByTestId('bg-image-upload-note');
+    const saved = lastValue(spy).settings.panel.backgroundImage!.url;
+    expect(saved.startsWith('data:image/svg+xml;base64,')).toBe(true);
+    // No schema change: fit and attachToCanvas are untouched.
+    expect(lastValue(spy).settings.panel.backgroundImage!.fit).toBe('contain');
+  });
+
+  test('a file over the hard cap is refused and nothing is saved', () => {
+    const spy = jest.fn();
+    render(<Harness initial={withBackground()} onChangeSpy={spy} />);
+    const huge = svgFile('huge.png');
+    Object.defineProperty(huge, 'size', { value: 5 * 1024 * 1024 });
+    fireEvent.change(screen.getByTestId('bg-image-upload'), { target: { files: [huge] } });
+    expect(screen.getByTestId('bg-image-upload-note').textContent).toMatch(/too large to embed/i);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  test('a file over the warn threshold embeds but says so', async () => {
+    const spy = jest.fn();
+    render(<Harness initial={withBackground()} onChangeSpy={spy} />);
+    const big = svgFile('big.svg', 2048);
+    Object.defineProperty(big, 'size', { value: 2 * 1024 * 1024 });
+    fireEvent.change(screen.getByTestId('bg-image-upload'), { target: { files: [big] } });
+    await screen.findByTestId('bg-image-upload-note');
+    expect(screen.getByTestId('bg-image-upload-note').textContent).toMatch(/slow every save|Large embeds/i);
+    expect(lastValue(spy).settings.panel.backgroundImage!.url.startsWith('data:')).toBe(true);
+  });
+
+  test('an unsupported type is refused even if the picker is bypassed', async () => {
+    const spy = jest.fn();
+    render(<Harness initial={withBackground()} onChangeSpy={spy} />);
+    const bad = new File(['<script>'], 'evil.html', { type: 'text/html' });
+    fireEvent.change(screen.getByTestId('bg-image-upload'), { target: { files: [bad] } });
+    await screen.findByTestId('bg-image-upload-note');
+    expect(screen.getByTestId('bg-image-upload-note').textContent).toMatch(/not a supported image type/i);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  test('an embedded source shows as read-only summary, not a wall of base64', () => {
+    const initial = withBackground();
+    initial.settings.panel.backgroundImage!.url = 'data:image/svg+xml;base64,PHN2Zy8+';
+    render(<Harness initial={initial} onChangeSpy={jest.fn()} />);
+    const field = document.querySelector('input[name="bgImageURL"]') as HTMLInputElement;
+    expect(field.value).toMatch(/^Embedded image \(SVG, /);
+    expect(field.readOnly).toBe(true);
+  });
+
+  test('a linked URL stays editable and is shown verbatim', () => {
+    const initial = withBackground();
+    initial.settings.panel.backgroundImage!.url = 'https://example.com/bg.png';
+    render(<Harness initial={initial} onChangeSpy={jest.fn()} />);
+    const field = document.querySelector('input[name="bgImageURL"]') as HTMLInputElement;
+    expect(field.value).toBe('https://example.com/bg.png');
+    expect(field.readOnly).toBe(false);
+  });
+});

--- a/src/forms/PanelForm.tsx
+++ b/src/forms/PanelForm.tsx
@@ -37,7 +37,7 @@ interface Props extends StandardEditorProps<Weathermap, Settings> {}
  * uppercase scheme is recognized the same as a freshly uploaded one — otherwise
  * the editor shows it as a wall of raw base64 in an editable field.
  */
-const isEmbeddedImage = (src: string | undefined) => sanitizeImageSource(src ?? '').startsWith('data:');
+const isEmbeddedImage = (src: string | undefined) => /^data:/i.test(sanitizeImageSource(src ?? ''));
 
 /** "SVG, 53 KB" for the read-only source field of an embedded image. */
 const embeddedImageLabel = (raw: string) => {
@@ -166,6 +166,9 @@ export const PanelForm = ({ value, onChange }: Props) => {
                 type={'text'}
                 name={'bgImageURL'}
                 onChange={(e) => {
+                  // Typing a URL is a newer choice than any read still in
+                  // flight — invalidate it so it cannot land on top.
+                  resetUploads();
                   let options = structuredClone(value);
                   if (options.settings.panel.backgroundImage) {
                     options.settings.panel.backgroundImage.url = sanitizeUrl(e.currentTarget.value);
@@ -189,6 +192,9 @@ export const PanelForm = ({ value, onChange }: Props) => {
                       return;
                     }
                     if (file.size > BG_IMAGE_MAX_BYTES) {
+                      // Picking this file supersedes any read still running,
+                      // even though this one is refused.
+                      uploadSeq.current += 1;
                       setBgUploadNote({
                         level: 'error',
                         text: `${file.name} is ${formatBytes(file.size)} — too large to embed (limit ${formatBytes(

--- a/src/forms/PanelForm.tsx
+++ b/src/forms/PanelForm.tsx
@@ -11,20 +11,44 @@ import {
   Slider,
   useStyles2,
   UnitPicker,
+  useTheme2,
 } from '@grafana/ui';
 import { GrafanaTheme2, StandardEditorProps } from '@grafana/data';
 import { Weathermap, ValueMappingMode } from 'types';
 import { v4 as uuidv4 } from 'uuid';
 import { FormDivider } from './FormDivider';
 import { css } from '@emotion/css';
-import { finiteOrFallback, sanitizeUrl } from 'utils';
+import {
+  finiteOrFallback,
+  sanitizeUrl,
+  sanitizeImageSource,
+  formatBytes,
+  BG_IMAGE_MAX_BYTES,
+  BG_IMAGE_WARN_BYTES,
+} from 'utils';
 
 interface Settings {}
 
 interface Props extends StandardEditorProps<Weathermap, Settings> {}
 
+/** An embedded background is a data: URI; a linked one is a URL. */
+const isEmbeddedImage = (src: string | undefined) => Boolean(src && src.startsWith('data:'));
+
+/** "SVG, 53 KB" for the read-only source field of an embedded image. */
+const embeddedImageLabel = (src: string) => {
+  const type = /^data:image\/([a-z0-9+.-]+);/i.exec(src)?.[1] ?? 'image';
+  // 4 base64 chars per 3 bytes, minus padding.
+  const b64 = src.slice(src.indexOf(',') + 1);
+  const bytes = Math.max(0, Math.floor((b64.length * 3) / 4) - (b64.endsWith('==') ? 2 : b64.endsWith('=') ? 1 : 0));
+  return `${type.replace('+xml', '').toUpperCase()}, ${formatBytes(bytes)}`;
+};
+
 export const PanelForm = ({ value, onChange }: Props) => {
   const styles = useStyles2(getStyles);
+  const theme = useTheme2();
+  const [bgUploadNote, setBgUploadNote] = React.useState<{ level: 'info' | 'warn' | 'error'; text: string } | null>(
+    null
+  );
 
   // Immutable panel-settings update (#225): clone the settings path so
   // onChange delivers new references instead of mutating props.value.
@@ -97,9 +121,22 @@ export const PanelForm = ({ value, onChange }: Props) => {
         </InlineField>
         {value.settings.panel.backgroundImage ? (
           <>
-            <InlineField grow label="Image Source" className={styles.inlineField} style={{ marginLeft: '24px' }}>
+            <InlineField
+              grow
+              label="Image Source"
+              className={styles.inlineField}
+              style={{ marginLeft: '24px' }}
+              tooltip={
+                'Link an image by URL, or upload one to embed it in the dashboard. Embedding makes the dashboard self-contained (it travels with exports and needs no image host) at the cost of dashboard size — prefer SVG, and keep files small.'
+              }
+            >
               <Input
-                value={value.settings.panel.backgroundImage.url}
+                value={
+                  isEmbeddedImage(value.settings.panel.backgroundImage.url)
+                    ? `Embedded image (${embeddedImageLabel(value.settings.panel.backgroundImage.url)})`
+                    : value.settings.panel.backgroundImage.url
+                }
+                readOnly={isEmbeddedImage(value.settings.panel.backgroundImage.url)}
                 placeholder={'https://example.com/background.jpg'}
                 type={'text'}
                 name={'bgImageURL'}
@@ -111,6 +148,78 @@ export const PanelForm = ({ value, onChange }: Props) => {
                   onChange(options);
                 }}
               ></Input>
+            </InlineField>
+            <InlineField grow label="Upload Image" className={styles.inlineField} style={{ marginLeft: '24px' }}>
+              <div>
+                <input
+                  type="file"
+                  name="bgImageUpload"
+                  data-testid="bg-image-upload"
+                  accept="image/png,image/jpeg,image/gif,image/webp,image/svg+xml"
+                  onChange={(e) => {
+                    const file = e.currentTarget.files?.[0];
+                    // Reset so re-picking the same file fires change again.
+                    e.currentTarget.value = '';
+                    if (!file) {
+                      return;
+                    }
+                    if (file.size > BG_IMAGE_MAX_BYTES) {
+                      setBgUploadNote({
+                        level: 'error',
+                        text: `${file.name} is ${formatBytes(file.size)} — too large to embed (limit ${formatBytes(
+                          BG_IMAGE_MAX_BYTES
+                        )}). Link it by URL instead, or use an SVG.`,
+                      });
+                      return;
+                    }
+                    const reader = new FileReader();
+                    reader.onerror = () =>
+                      setBgUploadNote({ level: 'error', text: `Could not read ${file.name}.` });
+                    reader.onload = () => {
+                      const dataUri = sanitizeImageSource(String(reader.result ?? ''));
+                      if (!dataUri) {
+                        setBgUploadNote({
+                          level: 'error',
+                          text: `${file.name} is not a supported image type (PNG, JPEG, GIF, WebP, SVG).`,
+                        });
+                        return;
+                      }
+                      let options = structuredClone(value);
+                      if (options.settings.panel.backgroundImage) {
+                        options.settings.panel.backgroundImage.url = dataUri;
+                      }
+                      onChange(options);
+                      setBgUploadNote(
+                        file.size > BG_IMAGE_WARN_BYTES
+                          ? {
+                              level: 'warn',
+                              text: `Embedded ${formatBytes(
+                                file.size
+                              )}. Large embeds are stored in the dashboard itself and slow every save — an SVG or a linked URL is usually better.`,
+                            }
+                          : { level: 'info', text: `Embedded ${file.name} (${formatBytes(file.size)}).` }
+                      );
+                    };
+                    reader.readAsDataURL(file);
+                  }}
+                />
+                {bgUploadNote ? (
+                  <div
+                    data-testid="bg-image-upload-note"
+                    className={css`
+                      margin-top: 4px;
+                      font-size: 11px;
+                      color: ${bgUploadNote.level === 'error'
+                        ? theme.colors.error.text
+                        : bgUploadNote.level === 'warn'
+                        ? theme.colors.warning.text
+                        : theme.colors.text.secondary};
+                    `}
+                  >
+                    {bgUploadNote.text}
+                  </div>
+                ) : null}
+              </div>
             </InlineField>
             <InlineField grow label="Image Fit" className={styles.inlineField} style={{ marginLeft: '24px' }}>
               <Select

--- a/src/forms/PanelForm.tsx
+++ b/src/forms/PanelForm.tsx
@@ -31,11 +31,17 @@ interface Settings {}
 
 interface Props extends StandardEditorProps<Weathermap, Settings> {}
 
-/** An embedded background is a data: URI; a linked one is a URL. */
-const isEmbeddedImage = (src: string | undefined) => Boolean(src && src.startsWith('data:'));
+/**
+ * An embedded background is a data: URI; a linked one is a URL. Classify the
+ * SANITIZED form so an imported dashboard whose source carries whitespace or an
+ * uppercase scheme is recognized the same as a freshly uploaded one — otherwise
+ * the editor shows it as a wall of raw base64 in an editable field.
+ */
+const isEmbeddedImage = (src: string | undefined) => sanitizeImageSource(src ?? '').startsWith('data:');
 
 /** "SVG, 53 KB" for the read-only source field of an embedded image. */
-const embeddedImageLabel = (src: string) => {
+const embeddedImageLabel = (raw: string) => {
+  const src = sanitizeImageSource(raw);
   const type = /^data:image\/([a-z0-9+.-]+);/i.exec(src)?.[1] ?? 'image';
   // 4 base64 chars per 3 bytes, minus padding.
   const b64 = src.slice(src.indexOf(',') + 1);
@@ -49,6 +55,21 @@ export const PanelForm = ({ value, onChange }: Props) => {
   const [bgUploadNote, setBgUploadNote] = React.useState<{ level: 'info' | 'warn' | 'error'; text: string } | null>(
     null
   );
+  // A FileReader read is async, so its onload must NOT close over the `value`
+  // of the render that started it: by the time it fires the user may have
+  // removed the background, edited the URL, or picked another file, and cloning
+  // that stale snapshot would silently undo those changes (or resurrect a
+  // deleted background). Read the latest value through a ref, and stamp each
+  // read so a superseded one discards itself.
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
+  const uploadSeq = React.useRef(0);
+  // Invalidate any in-flight read and drop its note — used when the background
+  // is added or removed, so a stale result can neither land nor be reported.
+  const resetUploads = () => {
+    uploadSeq.current += 1;
+    setBgUploadNote(null);
+  };
 
   // Immutable panel-settings update (#225): clone the settings path so
   // onChange delivers new references instead of mutating props.value.
@@ -94,12 +115,14 @@ export const PanelForm = ({ value, onChange }: Props) => {
               variant="destructive"
               size="md"
               icon="trash-alt"
+              data-testid="bg-image-remove"
               onClick={() => {
                 if (!confirm('Are you sure you want remove the background image?')) {
                   return;
                 }
                 let options = structuredClone(value);
                 options.settings.panel.backgroundImage = undefined;
+                resetUploads();
                 onChange(options);
               }}
               style={{ justifyContent: 'center' }}
@@ -112,9 +135,11 @@ export const PanelForm = ({ value, onChange }: Props) => {
                   url: '',
                   fit: 'contain',
                 };
+                resetUploads();
                 onChange(options);
               }}
               icon="plus"
+              data-testid="bg-image-add"
               style={{ justifyContent: 'center' }}
             ></Button>
           )}
@@ -172,10 +197,18 @@ export const PanelForm = ({ value, onChange }: Props) => {
                       });
                       return;
                     }
+                    const seq = ++uploadSeq.current;
+                    const superseded = () => seq !== uploadSeq.current;
                     const reader = new FileReader();
-                    reader.onerror = () =>
-                      setBgUploadNote({ level: 'error', text: `Could not read ${file.name}.` });
+                    reader.onerror = () => {
+                      if (!superseded()) {
+                        setBgUploadNote({ level: 'error', text: `Could not read ${file.name}.` });
+                      }
+                    };
                     reader.onload = () => {
+                      if (superseded()) {
+                        return;
+                      }
                       const dataUri = sanitizeImageSource(String(reader.result ?? ''));
                       if (!dataUri) {
                         setBgUploadNote({
@@ -184,7 +217,18 @@ export const PanelForm = ({ value, onChange }: Props) => {
                         });
                         return;
                       }
-                      let options = structuredClone(value);
+                      // Latest value, not the one captured when the read began.
+                      const latest = valueRef.current;
+                      if (!latest.settings.panel.backgroundImage) {
+                        // The background was removed while the file was being
+                        // read — do not resurrect it.
+                        setBgUploadNote({
+                          level: 'error',
+                          text: 'The background image was removed while the file was loading — add it again to upload.',
+                        });
+                        return;
+                      }
+                      let options = structuredClone(latest);
                       if (options.settings.panel.backgroundImage) {
                         options.settings.panel.backgroundImage.url = dataUri;
                       }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -29,6 +29,10 @@ import {
   removeVia,
   sampleAtTime,
   sanitizeUrl,
+  sanitizeImageSource,
+  formatBytes,
+  BG_IMAGE_MAX_BYTES,
+  BG_IMAGE_WARN_BYTES,
   valueAtTime,
   buildLegacyNameAliases,
   getLegacyDataFrameName,
@@ -1020,5 +1024,79 @@ describe('finitePosition (#339)', () => {
     const out = finitePosition(input);
     expect(out).not.toBe(input);
     expect(input).toEqual([10, 20]);
+
+// Embedded background images (#344). The security boundary matters most here:
+// sanitizeUrl also guards NAVIGATION targets, so data: URIs must be accepted
+// by the image helper WITHOUT ever becoming acceptable to navigate to.
+describe('sanitizeImageSource (#344)', () => {
+  const PNG = 'data:image/png;base64,iVBORw0KGgo=';
+  const SVG = 'data:image/svg+xml;base64,PHN2Zy8+';
+
+  test('accepts the image data URI types we support', () => {
+    for (const type of ['png', 'jpeg', 'jpg', 'gif', 'webp', 'svg+xml']) {
+      const uri = `data:image/${type};base64,PHN2Zy8+`;
+      expect(sanitizeImageSource(uri)).toBe(uri);
+    }
+  });
+
+  test('still accepts everything a linked source could be', () => {
+    expect(sanitizeImageSource('https://example.com/bg.png')).toBe('https://example.com/bg.png');
+    expect(sanitizeImageSource('http://localhost:8080/rack2.svg')).toBe('http://localhost:8080/rack2.svg');
+    expect(sanitizeImageSource('/public/img/bg.png')).toBe('/public/img/bg.png');
+    expect(sanitizeImageSource('  https://example.com/bg.png  ')).toBe('https://example.com/bg.png');
+  });
+
+  test('rejects non-image and script-bearing data URIs', () => {
+    expect(sanitizeImageSource('data:text/html;base64,PHNjcmlwdD4=')).toBe('');
+    expect(sanitizeImageSource('data:application/javascript;base64,YWxlcnQoMSk=')).toBe('');
+    expect(sanitizeImageSource('data:image/svg+xml,<svg onload=alert(1)>')).toBe(''); // not base64
+    expect(sanitizeImageSource('data:image/png,rawbytes')).toBe(''); // missing base64 marker
+    expect(sanitizeImageSource('data:image/tiff;base64,AAAA')).toBe(''); // unsupported type
+  });
+
+  test('rejects the schemes sanitizeUrl rejects', () => {
+    expect(sanitizeImageSource('javascript:alert(1)')).toBe('');
+    expect(sanitizeImageSource('java\nscript:alert(1)')).toBe('');
+    expect(sanitizeImageSource('//evil.example.com/bg.png')).toBe('');
+    expect(sanitizeImageSource('')).toBe('');
+    expect(sanitizeImageSource(null)).toBe('');
+    expect(sanitizeImageSource(undefined)).toBe('');
+  });
+
+  test('does NOT widen the shared navigation guard', () => {
+    // The whole reason this helper exists: a data: URI is fine as an image and
+    // must stay unusable as a link target.
+    expect(sanitizeUrl(PNG)).toBe('');
+    expect(sanitizeUrl(SVG)).toBe('');
+    expect(sanitizeImageSource(PNG)).toBe(PNG);
+    expect(sanitizeImageSource(SVG)).toBe(SVG);
+  });
+
+  test('strips whitespace inside a data URI rather than rejecting it', () => {
+    // Base64 wrapped across lines (some encoders do this) still resolves.
+    expect(sanitizeImageSource('data:image/png;base64,iVBO\n Rw0K Ggo=')).toBe('data:image/png;base64,iVBORw0KGgo=');
+  });
+});
+
+describe('background image size limits (#344)', () => {
+  test('warn threshold sits below the hard cap', () => {
+    expect(BG_IMAGE_WARN_BYTES).toBeLessThan(BG_IMAGE_MAX_BYTES);
+    expect(BG_IMAGE_WARN_BYTES).toBe(1024 * 1024);
+    expect(BG_IMAGE_MAX_BYTES).toBe(4 * 1024 * 1024);
+  });
+
+  test('formatBytes reads the way an editor message should', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(512)).toBe('512 B');
+    expect(formatBytes(5 * 1024)).toBe('5.0 KB');
+    expect(formatBytes(53 * 1024)).toBe('53 KB');
+    expect(formatBytes(1024 * 1024)).toBe('1.0 MB');
+    expect(formatBytes(4 * 1024 * 1024)).toBe('4.0 MB');
+  });
+
+  test('formatBytes never emits NaN for junk input', () => {
+    expect(formatBytes(NaN)).toBe('0 B');
+    expect(formatBytes(-5)).toBe('0 B');
+    expect(formatBytes(Infinity)).toBe('0 B');
   });
 });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1024,6 +1024,8 @@ describe('finitePosition (#339)', () => {
     const out = finitePosition(input);
     expect(out).not.toBe(input);
     expect(input).toEqual([10, 20]);
+  });
+});
 
 // Embedded background images (#344). The security boundary matters most here:
 // sanitizeUrl also guards NAVIGATION targets, so data: URIs must be accepted

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1072,6 +1072,14 @@ describe('sanitizeImageSource (#344)', () => {
     expect(sanitizeImageSource(SVG)).toBe(SVG);
   });
 
+  test('rejects a truncated base64 payload at the sanitizer, not at load time', () => {
+    // Canonical base64 is whole 4-char groups; without a length check a
+    // truncated payload passed here and only surfaced later as a broken image.
+    expect(sanitizeImageSource('data:image/png;base64,iVBORw0KGg')).toBe(''); // 10 chars
+    expect(sanitizeImageSource('data:image/png;base64,iVBORw0KGgo')).toBe(''); // 11 chars
+    expect(sanitizeImageSource('data:image/png;base64,iVBORw0KGgo=')).toBe('data:image/png;base64,iVBORw0KGgo='); // 12
+  });
+
   test('strips whitespace inside a data URI rather than rejecting it', () => {
     // Base64 wrapped across lines (some encoders do this) still resolves.
     expect(sanitizeImageSource('data:image/png;base64,iVBO\n Rw0K Ggo=')).toBe('data:image/png;base64,iVBORw0KGgo=');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -912,9 +912,14 @@ export function sanitizeImageSource(raw: string | undefined | null): string {
   const trimmed = raw.trim();
   // Match a base64 image data URI and nothing else — no `data:text/html`, no
   // percent-encoded payloads, no missing base64 marker.
-  const dataMatch = /^data:image\/([a-z0-9+.-]+);base64,([a-z0-9+/]+={0,2})$/i.exec(trimmed.replace(/\s+/g, ''));
+  const normalized = trimmed.replace(/\s+/g, '');
+  const dataMatch = /^data:image\/([a-z0-9+.-]+);base64,([a-z0-9+/]+={0,2})$/i.exec(normalized);
   if (dataMatch) {
-    return ALLOWED_IMAGE_DATA_TYPES.includes(dataMatch[1].toLowerCase()) ? trimmed.replace(/\s+/g, '') : '';
+    // Canonical base64 is a whole number of 4-char groups. Without this a
+    // truncated payload passes the sanitizer and only fails later as a broken
+    // image, which contradicts what this helper promises its callers.
+    const validLength = dataMatch[2].length % 4 === 0;
+    return validLength && ALLOWED_IMAGE_DATA_TYPES.includes(dataMatch[1].toLowerCase()) ? normalized : '';
   }
   return sanitizeUrl(trimmed);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -850,6 +850,76 @@ export function isSafeUrl(raw: string | undefined | null): boolean {
 }
 
 /**
+ * Image MIME types accepted as an embedded `data:` background (#344).
+ *
+ * SVG is included on purpose. A `data:image/svg+xml` source is NOT safe to
+ * navigate to — the document could script — but both places this is used load
+ * it as an IMAGE (a CSS `background-image` and an SVG `<image href>`), and
+ * browsers render images in a non-scripting mode where external references and
+ * scripts are inert. SVG is also the format worth encouraging here: vector
+ * rack elevations and floor plans embed in tens of KB where a screenshot of the
+ * same thing costs megabytes.
+ */
+const ALLOWED_IMAGE_DATA_TYPES = ['png', 'jpeg', 'jpg', 'gif', 'webp', 'svg+xml'];
+
+/**
+ * Size limits for an embedded background (#344), in bytes of the ORIGINAL
+ * file. Base64 inflates by ~33% and the result lives in the dashboard JSON,
+ * which Grafana stores in its database and re-serializes on every save — so an
+ * oversized embed does not just bloat the export, it makes saving slow in a way
+ * that is hard to attribute to the image.
+ *
+ * WARN is advisory (the upload still happens, with a visible note); MAX is
+ * refused outright. A vector floor plan or rack elevation lands far under both
+ * — the bundled demo rack art is ~53 KB — so anything approaching these is a
+ * screenshot that would be better linked by URL or converted to SVG.
+ */
+export const BG_IMAGE_WARN_BYTES = 1024 * 1024; // 1 MB
+export const BG_IMAGE_MAX_BYTES = 4 * 1024 * 1024; // 4 MB
+
+/** Human-readable byte size for editor messages ("1.4 MB", "512 KB"). */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) {
+    return '0 B';
+  }
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(bytes < 10 * 1024 ? 1 : 0)} KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Sanitize a background-image source (#344). Accepts everything `sanitizeUrl`
+ * does, PLUS a `data:image/...;base64,` URI so a map can embed its background
+ * instead of depending on an external host staying reachable.
+ *
+ * Deliberately separate from `sanitizeUrl`: that one also guards NAVIGATION
+ * targets (node and link dashboard links), and a `data:` URI that is harmless
+ * as an image is a real hazard as a navigation target. Widening the shared
+ * helper would silently make every dashboard link accept them too — so this
+ * stays image-only and is used exactly where a background is drawn.
+ *
+ * @param raw the stored background source
+ * @returns the trimmed source when safe, otherwise an empty string
+ */
+export function sanitizeImageSource(raw: string | undefined | null): string {
+  if (raw == null) {
+    return '';
+  }
+  const trimmed = raw.trim();
+  // Match a base64 image data URI and nothing else — no `data:text/html`, no
+  // percent-encoded payloads, no missing base64 marker.
+  const dataMatch = /^data:image\/([a-z0-9+.-]+);base64,([a-z0-9+/]+={0,2})$/i.exec(trimmed.replace(/\s+/g, ''));
+  if (dataMatch) {
+    return ALLOWED_IMAGE_DATA_TYPES.includes(dataMatch[1].toLowerCase()) ? trimmed.replace(/\s+/g, '') : '';
+  }
+  return sanitizeUrl(trimmed);
+}
+
+/**
  * Sanitize a user-provided URL. Returns the cleaned value when it is safe to
  * use, or an empty string when it is not. This is applied both when a value is
  * entered/saved in the editor and again at the point of use (navigation or

--- a/website/docs/guide/panel-options.md
+++ b/website/docs/guide/panel-options.md
@@ -19,8 +19,41 @@ Panel-level options apply to the whole weathermap. Open the panel options sideba
     Only relative Grafana paths and `http`/`https` URLs are accepted. `data:`, `file:`, `javascript:` and other schemes are **rejected** by the plugin's URL sanitization — pasting a base64 data URL will not work.
 
 - **Color** — the canvas background color.
-- **Image** — set a background image by URL (floor plan, geographic map, building outline, network zones). Choose an **Image Fit** (contain / cover / auto).
+- **Image** — set a background image (floor plan, geographic map, building outline, rack elevation). Choose an **Image Fit** (contain / cover / auto). You can either **link** it by URL or **upload** it to embed it in the dashboard — see [Linked vs embedded](#linked-vs-embedded-background-images) below.
 - **Move With Map** — when enabled, the background image is drawn *inside* the map canvas so it **pans and zooms together** with the nodes and links. When off (default), the image stays fixed like a wallpaper.
+
+### Linked vs embedded background images
+
+There are two ways to give the panel a background, and the trade-off between them is worth understanding before you pick one.
+
+| | **Linked** (Image Source URL) | **Embedded** (Upload Image) |
+|---|---|---|
+| Where the image lives | On a web server you control | Inside the dashboard JSON |
+| Dashboard size | Unchanged | Grows by ~1.33× the file size |
+| Sharing / export | Recipient must be able to reach the URL | Travels with the dashboard, works anywhere |
+| Changing the image | Replace it on the server; every dashboard using it updates | Re-upload per dashboard |
+| Breaks when… | The host moves, a port changes, or the viewer's network can't reach it | Never — there is nothing external to reach |
+
+**Link** when the image is large, shared across several dashboards, or updated independently. **Embed** when you want the dashboard to be self-contained — exports, imports, and air-gapped installs all keep their background with no image hosting at all.
+
+Both accept **PNG, JPEG, GIF, WebP, and SVG**.
+
+#### Size limits for embedded images
+
+An embedded image is stored as text inside the dashboard, which Grafana keeps in its database and re-serialises on **every save**. An oversized embed doesn't just bloat exports — it makes saving noticeably slower, in a way that's hard to trace back to the image. So:
+
+| Size of the original file | What happens |
+|---|---|
+| Up to **1 MB** | Embedded silently — the normal case |
+| **1 MB – 4 MB** | Embedded, with a warning suggesting SVG or a linked URL |
+| Over **4 MB** | **Refused.** Link it by URL instead, or convert it to SVG |
+
+Base64 encoding adds about 33%, so a 1 MB file becomes roughly 1.33 MB of dashboard JSON.
+
+!!! tip "Prefer SVG"
+    Vector art is dramatically smaller for exactly the kind of image this panel wants. The rack elevation used in the demo dashboards is a detailed multi-device drawing and it embeds in **53 KB** — a screenshot of the same rack would cost megabytes and look worse when zoomed. If your source is a photo or screenshot, consider linking it rather than embedding.
+
+Whichever you choose, if the image can't be loaded the panel tells you: while **editing**, a broken or rejected background shows a notice naming the problem, rather than silently drawing your nodes on an empty canvas. The notice is edit-mode only, so a dashboard on a wall display is never interrupted by it.
 
 ---
 

--- a/website/docs/guide/panel-options.md
+++ b/website/docs/guide/panel-options.md
@@ -6,17 +6,19 @@ Panel-level options apply to the whole weathermap. Open the panel options sideba
 
 ## Background
 
-!!! tip "Where do I host my floor plan / map image?"
-    The **Image** field takes a URL — the plugin does not upload files. Your options:
+!!! tip "Where do I put my floor plan / map image?"
+    Either **embed it in the dashboard** with **Upload Image** — nothing to host, and it travels with exports — or **link it** and host it yourself:
 
     1. **Any `http://` or `https://` URL** your dashboard viewers' browsers can reach (an internal web server, a wiki attachment, an S3/object-storage link, Wikimedia Commons, ...). Prefer `https` where you have it — but plain `http` is accepted, which matters for lab and air-gapped intranets.
     2. **Grafana's own `public/` folder** — copy the file onto the Grafana server, e.g. `/usr/share/grafana/public/img/floorplan.png`, then use the relative URL `public/img/floorplan.png`. Works fully air-gapped and survives viewer networks that can't reach external hosts.
     3. **A provisioned sidecar** — the demo dashboards serve their floor-plan and world-map images from the `testing/` stack's exporter container on `:8080`; any tiny static file server works the same way.
 
-    SVG or PNG both work; prefer SVG for crisp zooming with **Move With Map**.
+    Uploading is the simplest choice for a one-off image; linking is better for large files or art shared across several dashboards. See [Linked vs embedded](#linked-vs-embedded-background-images).
 
-!!! warning "Image URLs are validated"
-    Only relative Grafana paths and `http`/`https` URLs are accepted. `data:`, `file:`, `javascript:` and other schemes are **rejected** by the plugin's URL sanitization — pasting a base64 data URL will not work.
+!!! warning "Sources are validated"
+    The **Image Source** field accepts only relative Grafana paths and `http`/`https` URLs. `data:`, `file:`, `javascript:` and other schemes are **rejected** — pasting a base64 data URL into that box will not work.
+
+    To embed an image, use **Upload Image** instead. That is deliberate rather than an inconsistency: the upload path is where the type and [size limits](#size-limits-for-embedded-images) are enforced, so pasting cannot be used to slip an oversized or unsupported image past them.
 
 - **Color** — the canvas background color.
 - **Image** — set a background image (floor plan, geographic map, building outline, rack elevation). Choose an **Image Fit** (contain / cover / auto). You can either **link** it by URL or **upload** it to embed it in the dashboard — see [Linked vs embedded](#linked-vs-embedded-background-images) below.


### PR DESCRIPTION
Closes #344. Implements both parts: embed-by-upload, and the companion fix that makes a broken background visible.

## Why

A background could only be a URL, so every dashboard depended on an external host staying reachable at the same address. For this panel that hurts more than most: with a rack elevation or floor plan, the background **is** the frame the nodes are positioned against — losing it doesn't degrade the map, it makes it unreadable. And nothing on screen said why. That is exactly what happened this week when port 8080 was occupied and the demo rack maps rendered their nodes on an empty canvas.

## The design

Upload embeds the image as a `data:` URI in the **same `backgroundImage.url` field**.

- **No schema change, no migration, no new options section.** The field accepts one more form of source; `fit` and `attachToCanvas` keep working identically for both. Existing maps are untouched.
- A **linked** URL stays editable and shown verbatim. An **embedded** one shows a read-only `Embedded image (SVG, 53 KB)` summary instead of a wall of base64.

## Security — the part worth reviewing closely

`sanitizeUrl` also guards **navigation** targets (node and link dashboard links), where a `data:` URI is a genuine hazard. It is deliberately **not** widened. Instead `sanitizeImageSource` accepts `data:image/(png|jpeg|jpg|gif|webp|svg+xml)` with a strict base64 payload, and is used **only** where a background is drawn.

SVG is included on purpose: both render sites load it as an *image* (a CSS `background-image` and an SVG `<image href>`), and browsers render images in a non-scripting mode where scripts and external references are inert. It's also the format worth encouraging — vector art is what this panel wants.

Guards, all tested:

- `sanitizeUrl` still rejects everything `sanitizeImageSource` accepts (explicit test — this is the boundary that must not erode).
- Rejected: `data:text/html`, `data:application/javascript`, non-base64 payloads like `data:image/svg+xml,<svg onload=alert(1)>`, unsupported types, `javascript:`, protocol-relative.
- **Re-sanitized at render**, so a hand-edited dashboard carrying a hostile source never reaches the DOM — not just blocked in the editor.

**Grafana compatibility:** verified against a real Grafana instance — an embedded 53 KB rack elevation renders the full map with **zero network requests** and **no CSP violations**. Grafana's own `defaults.ini` CSP template permits it explicitly: `img-src * data:`. Nothing leaves the browser; `FileReader` is entirely client-side, so there's no upload endpoint and no server-side file handling.

## Size limits

Base64 inflates ~33%, and the result lives in dashboard JSON that Grafana re-serialises on **every save** — an oversized embed makes saving slow in a way that's hard to attribute to the image.

| Original file | Behaviour |
|---|---|
| ≤ 1 MB | Embedded silently |
| 1–4 MB | Embedded, with a warning pointing at SVG or a linked URL |
| > 4 MB | Refused |

For scale, the demo rack elevation embeds in **53 KB**.

## Companion fix

A background that 404s, is refused, or is rejected by the sanitizer now raises an in-panel notice naming the cause — reusing the existing notice banner (#69). **Edit mode only**, so a transient failure never puts a banner on a wall display.

## Docs

`panel-options.md` gains a linked-vs-embedded trade-off table (size, sharing, updating, what breaks each), the size thresholds, and why SVG is worth preferring.

## Verification

`npm run lint` · `npm run typecheck` · `CI=true npx jest` (257 passed, 15 suites) · `npm run build` · `mkdocs build --strict` — all green. 19 new tests across the sanitizer boundary, both render paths, the hostile-input cases, the upload size guards, and the edit-mode-only notice.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add background image upload with embedding and edit‑mode notices for load failures. Keeps dashboards self‑contained and safer without changing the schema.

- New Features
  - Upload embeds the file as a `data:image/...;base64` in `backgroundImage.url`. Linked URLs stay editable; embedded sources show a read‑only summary like "Embedded image (SVG, 53 KB)".
  - Supports PNG, JPEG, GIF, WebP, and SVG. Size limits: ≤1 MB embeds silently; 1–4 MB embeds with a warning; >4 MB is refused. `fit` and `attachToCanvas` work for both.
  - Added `sanitizeImageSource` for backgrounds; `sanitizeUrl` (used for navigation) is unchanged. Rendering uses one memoized, re‑sanitized source for both CSS and canvas paths to block hostile edits.

- Bug Fixes
  - Broken or rejected backgrounds now show a cause in edit mode only, with no flash in view mode; the status resets when the source changes.
  - Hardened upload and sanitizer: cancel stale FileReader writes (also when typing a URL or when a refused file is picked), report if the background was removed mid‑read, reject truncated base64 and unsupported `data:` URIs, and classify embedded sources via the sanitized form with a case‑insensitive `data:` check.
  - Clear upload notes on add/remove and reuse the sanitized source to avoid repeated work on large embeds.

<sup>Written for commit ebe6d982cb3affb9de73264f28559911796ecfa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

