### PR TITLE
release: v1.6.9 — drawable polyline links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.6.9](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.6.9) (2026-08-06)
+
+### Features
+
+* **links can be drawn as polylines** ([#332](https://github.com/allamiro/grafana-network-weathermap-ng/issues/332)): a link was always a straight line, so on a dense map the only way to stop links crossing each other was to move the devices. Each link now takes an optional list of **waypoints** and bends through them as ONE logical link — not split into segments the way a VIA is — keeping its own A/Z queries, bandwidths, port labels and tooltip. Everything follows the drawn path by arc length: both directional halves, the arrowheads (which rotate with the segment they sit on), value labels, the arrow meeting point, port labels, and traffic-animation dots, which travel around the bends. Add a bend by **right-clicking a link** in edit mode, then drag its handle; **Corner Radius** rounds each bend into a smooth curve. An empty waypoint list is exactly the old straight link, so existing maps are untouched and no migration is needed ([#334](https://github.com/allamiro/grafana-network-weathermap-ng/pull/334))
+* **Link Offset now works on bent links** ([#336](https://github.com/allamiro/grafana-network-weathermap-ng/issues/336)): parallel-link spreading used to be ignored the moment a link had waypoints, so a bundle sharing a route could not be separated. The whole polyline is now translated along its A→Z axis. That choice is deliberate rather than convenient — offsetting each segment instead would fold the path in on itself wherever the offset exceeds the corner radius (an 18 px radius with an 18 px offset self-intersects, with no safe side to pick), and would stretch the path so arrows, labels and animation drift apart across a bundle. A translation cannot self-intersect and preserves length exactly, so every member of a bundle stays in step. Waypoints are stored unshifted, so changing the offset never rewrites saved coordinates ([#338](https://github.com/allamiro/grafana-network-weathermap-ng/pull/338))
+* **gradient link colouring follows the drawn path** ([#336](https://github.com/allamiro/grafana-network-weathermap-ng/issues/336)): gradients shaded along the straight A→Z axis, so on a bent link the colour ramp did not match the line you see — a route bowing off its axis squashed most of its range into the ends. Colours are now placed by distance *along the path*. One exception, by nature rather than oversight: a segment running perpendicular to the A→Z axis has no room on the gradient axis and renders a single flat colour there
+
+### Fixed
+
+* **double-clicking a link to add a VIA now works where the value label sits** ([#336](https://github.com/allamiro/grafana-network-weathermap-ng/issues/336)): value labels are drawn on top of the link and swallow its pointer events, so a double-click aimed at the middle of a link — the spot most people go for — landed on the label and did nothing at all, while right-click on the same pixel worked. Both gestures now behave identically anywhere on a link
+
+### Documentation
+
+* the Links guide gains a step-by-step for bending a link, with screenshots of the editor and the canvas drag handles, guidance on spacing bends relative to the corner radius, and a worked example of a parallel bundle routed around an obstruction
+
+### Testing
+
+* a Playwright suite covering the canvas gestures runs in CI against Grafana 11.0.0 and latest: right-click creation, cursor-locked dragging (including at the panel's bottom edge, while zoomed, and released outside the panel), removal, Link Offset translating the path rigidly, a no-creep drag round-trip, and waypoint persistence across a dashboard save and reload
+* two demo dashboards — `WAN Demo — Polyline Links` and `WAN Demo — Polyline Links + Link Offset`
+
 ## [1.6.8](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.6.8) (2026-08-05)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamirsuliman-weathermap-panel",
-      "version": "1.6.8",
+      "version": "1.6.9",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "postinstall": "patch-package",


### PR DESCRIPTION
Version bump + changelog for **v1.6.9**. Merge, then tag `v1.6.9`.

## What ships

| Area | Change |
|---|---|
| **Feature** | Links can be drawn as **polylines** through per-link waypoints, as one logical link (#332/#334) |
| **Feature** | **Link Offset now works on bent links** — the whole path translates, so a parallel bundle stays in step (#336/#338) |
| **Feature** | **Gradient colouring follows the drawn path** rather than the straight A→Z axis (#336) |
| **Fix** | Double-click to add a VIA now works where the **value label** sits — previously silently dead at the most natural click spot |

## Pre-tag verification

```
npm audit --audit-level=high   0 high, 0 critical
OSV  fast-uri@3.1.5            CLEAN
OSV  brace-expansion@5.0.9     CLEAN
npm ci                         accepts the lockfile
npm run build                  dist/plugin.json stamps 1.6.9
node scripts/verify-dist.js    dist verification passed
CI=true npx jest               377 passed, 17 suites
E2E (Grafana 11.0.0 / latest)  both pass on #334 and #338
lint / typecheck               clean
```

`package.json` and both lockfile root `version` fields are in sync at 1.6.9.

## On the hands-on gate

#334's remaining gate was a human "does dragging feel right" check. That was run as an automated acceptance pass in Chromium instead, and **it earned its keep** — it found the VIA/label bug above, which is exactly what a manual tester would have hit first.

```
handle tracks the cursor 1:1     max error 0.20px over 4 legs
no jump after release            delta 0.0000 panel units
frame time during drag           avg 8.3ms, p95 8.5ms over 98 frames
cursor-locked while zoomed       error 0.20px
released outside the panel       commits, moved 420px
right-click add / remove         work
keyboard nudge + Delete          work
regressions: VIA, node drag      both intact
uncaught page errors             none
```

12/12. Two initial failures were run down rather than accepted: one was my own test sequencing, the other was the real VIA bug. A flaky wheel-zoom test was also fixed (fixed sleep → polling) and re-run 3× clean.

What this cannot certify is subjective feel. The mechanical behaviour is exact and responsive.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.6.9 introduces drawable polyline links for clearer routing and improves visual accuracy for offsets and gradients. It also includes a small interaction fix.

- **New Features**
  - Draw links as polylines using per-link waypoints; right‑click to add and drag to bend, with optional corner radius.
  - Link Offset now translates the whole bent path to keep parallel bundles aligned.
  - Gradient coloring follows the drawn path instead of the straight A→Z axis.

- **Bug Fixes**
  - Double‑click to add a VIA works when clicking on the value label.

<sup>Written for commit b35dc679c744133da2277545ac1ffcffb7e67d60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

