### PR TITLE
docs: add a dedicated migration guide for knightss27 imports (#331)

### DIFF
--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -5,7 +5,7 @@ New to the plugin? See the **[Tutorial → Getting Started](guide/getting-starte
 ## Installation & versions
 
 - **Q: Is this the same plugin as `knightss27-weathermap-panel`?**
-    - This is a continuation fork. The original plugin was archived in 2023. This fork (`tamirsuliman-weathermap-panel`, display name **Network Weathermap NG**) is modernized and actively maintained. Config exported from the original plugin is compatible.
+    - This is a continuation fork. The original plugin was archived in 2023. This fork (`tamirsuliman-weathermap-panel`, display name **Network Weathermap NG**) is modernized and actively maintained. Config exported from the original plugin is read directly — see the [migration guide](guide/migrating.md) for the step-by-step, including the panel-type change that must be made in the JSON rather than the UI.
 
 - **Q: What is the minimum Grafana version?**
     - Grafana **11.0.0**. The plugin uses `@grafana/*` SDK v11 APIs. API compatibility is verified against Grafana 11.x and 12.x in CI.
@@ -112,7 +112,7 @@ New to the plugin? See the **[Tutorial → Getting Started](guide/getting-starte
 
 - **Q: I exported my config from the original `knightss27-weathermap-panel`. Will it import here?**
     - Yes — the JSON config format is backward-compatible. Use **Export / Import** in the panel editor, or change the panel's `"type"` to `tamirsuliman-weathermap-panel` in the dashboard JSON before importing. Don't switch plugins through the panel-type picker in the UI — Grafana resets the panel options on a UI type switch and the whole map is lost.
-    - Link query bindings (A/Z side and bandwidth queries) are stored by their query display name, which this plugin computes slightly differently than the original in some setups (multiple queries returning a same-named column, table-style results). Since v1.6.7 unambiguous old-style names are re-bound automatically as soon as the panel receives data; if a binding stays empty after import (it can be ambiguous — e.g. two queries whose results are indistinguishable by name), re-select it once in the link editor and re-save.
+    - Link query bindings (A/Z side and bandwidth queries, link and node status queries, and tooltip metrics) are stored by their query display name, which this plugin computes slightly differently than the original in some setups (multiple queries returning a same-named column, table-style results). Since v1.6.7 unambiguous old-style names are re-bound automatically as soon as the panel receives data; if a binding stays empty after import (it can be ambiguous — e.g. two queries whose results are indistinguishable by name), re-select it once in the link editor and re-save. Full walkthrough: [migration guide](guide/migrating.md).
 
 ---
 

--- a/website/docs/guide/migrating.md
+++ b/website/docs/guide/migrating.md
@@ -1,0 +1,130 @@
+# Migrating from `knightss27-weathermap-panel`
+
+Network Weathermap NG is a continuation of the original
+[knightss27/grafana-network-weathermap](https://github.com/knightss27/grafana-network-weathermap),
+archived in 2023. Maps built with the original plugin move across without being redrawn —
+nodes, links, colours, scales, and layout are all read from the same saved structure.
+
+This page is the complete migration path, including the one step people most often get
+wrong.
+
+---
+
+## The one rule: never switch plugins from the panel-type picker
+
+!!! danger "Changing the visualization type in the UI destroys the map"
+    Grafana resets a panel's options when you change its visualization type from the
+    picker. Weathermap keeps your entire map — every node, link, and setting — inside
+    those options, so switching this way discards all of it. There is no undo once the
+    dashboard is saved.
+
+    Edit the dashboard JSON instead, as described below.
+
+---
+
+## 1. Export the dashboard
+
+From the dashboard, use **Dashboard settings → JSON Model** (or **Share → Export**) and
+save the JSON.
+
+!!! tip "Work on a copy"
+    Import the migrated JSON under a new name/UID first and confirm it renders before
+    retiring the original dashboard.
+
+---
+
+## 2. Change the panel type in the JSON
+
+Find each weathermap panel and change its `type`:
+
+```json
+{
+  "type": "tamirsuliman-weathermap-panel",
+  "options": {
+    "weathermap": { "nodes": [], "links": [] }
+  }
+}
+```
+
+| Old value | New value |
+|---|---|
+| `knightss27-weathermap-panel` | `tamirsuliman-weathermap-panel` |
+
+Leave `options.weathermap` exactly as it is — that object is the map, and this plugin
+reads the original format directly.
+
+---
+
+## 3. Import
+
+Use **Dashboards → New → Import** and paste the edited JSON. Nodes, links, positioning,
+colour scales, and visual settings all come across.
+
+---
+
+## 4. Check your link queries
+
+This is the only part that may need attention, and since **v1.6.7** it usually resolves
+itself.
+
+**Why it happens.** Weathermap doesn't store a query's `refId` — it stores the query's
+**display name**, the label you pick from the dropdown in the link editor. NG computes
+that display name slightly differently from the original plugin in some setups, most
+commonly when several queries return a same-named column (very typical with the Infinity
+data source, where every query returns a field called `Value`). NG disambiguates those
+with the query's `refId`/labels; the original didn't. The saved string then matches
+nothing, and the dropdown looks empty — but nothing was deleted, and the underlying
+queries are untouched.
+
+**What NG does about it.** On the first data load after import, the panel re-binds
+old-style names automatically. The rewrite is deliberately conservative — it only acts on
+bindings that currently resolve to **nothing**, only when a legacy name maps to exactly
+**one** current series and doesn't collide with a live name, and only once every query has
+loaded without error. Working bindings and template-variable queries are never touched.
+
+Automatic re-binding covers every place a query name is stored:
+
+| Location | Fields |
+|---|---|
+| Link sides | `sides.A` / `sides.Z` — query and bandwidth query |
+| Link status | `statusQuery` |
+| Link tooltips | `tooltipMetrics[].queryA` / `.queryZ` |
+| Node status | `statusQuery` |
+| Node tooltips | `tooltipMetrics[].query` |
+
+**When it can't decide.** If two of your queries produce genuinely indistinguishable
+names, NG leaves those dropdowns empty rather than guessing. Open the link editor,
+re-select the query, and save once — the name is then stored in NG's format and stays
+stable.
+
+!!! tip "Many links to fix by hand?"
+    Open one link editor to see what NG now calls each query, then find-and-replace the
+    old name with the new one throughout the dashboard JSON. The mapping is identical for
+    every link using that query.
+
+---
+
+## What to expect afterwards
+
+| Area | Result |
+|---|---|
+| Nodes, links, layout, colours, scales | Carried over unchanged |
+| Link query bindings | Automatic since v1.6.7; ambiguous cases need one manual re-select |
+| Minimum Grafana version | **11.0.0+** — see the [FAQ](../faq.md) |
+| Plugin signature | Releases from the Grafana catalog are signed |
+
+Features added since the fork — traffic animation, BGP neighbour status, polyline links —
+are all opt-in and default to off, so a migrated map looks the same as it did before until
+you turn them on.
+
+---
+
+## Still stuck?
+
+[Open an issue](https://github.com/allamiro/grafana-network-weathermap-ng/issues) with a
+sanitized copy of your dashboard JSON (redact any internal URLs and credentials). Real
+exported dashboards become regression fixtures, so a report with one attached tends to get
+fixed and stay fixed.
+
+See also: [Getting Started](getting-started.md) · [Links](links.md) ·
+[Data Sources](datasources.md) · [FAQ](../faq.md)

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
   - Home: index.md
   - Tutorial:
       - Getting Started: guide/getting-started.md
+      - Migrating from knightss27: guide/migrating.md
       - Nodes (Devices): guide/nodes.md
       - Links: guide/links.md
       - Panel Options: guide/panel-options.md


### PR DESCRIPTION
Migrating from the original `knightss27-weathermap-panel` was documented only as an FAQ bullet. That left the two things users actually get wrong hard to find, both of which showed up in #331:

- The panel `type` must be changed in the dashboard JSON. Switching visualization type from the panel-type picker makes Grafana reset the panel options — which is where the entire map lives — so the map is lost.
- Empty link-query dropdowns after an import mean a query **display-name mismatch**, not deleted queries.

## Changes

- New `website/docs/guide/migrating.md` — export, panel-type change, import, and query re-binding, with the picker warning called out as a `!!! danger` admonition.
- Added to the Tutorial nav directly after Getting Started.
- Both FAQ entries cross-link to it.

## Accuracy

The description of the v1.6.7 automatic re-binding is written against the implementation, not the release note. It rewrites only bindings that currently resolve to nothing, only when a legacy name maps to exactly one current series without colliding with a live name, and only once every query has loaded without error.

The guide also documents that re-binding covers link and node `statusQuery` and tooltip metrics — the FAQ previously listed only the A/Z side and bandwidth queries, which understated the coverage.

## Verification

- `mkdocs build --strict` — clean, no broken links
- `npm run lint` — clean
- `npm run typecheck` — clean
- `CI=true npx jest` — 377 passed, 17 suites
- `npm run build` — compiled successfully

Docs-only; no runtime code touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated migration guide for importing dashboards from `knightss27-weathermap-panel`, with clear steps and a warning not to change the panel type via the UI. Documents v1.6.7 automatic query re-binding and links the guide from the Tutorial nav and related FAQ entries.

<sup>Written for commit 5f85ee42e5f13510b428cdb5c72ea0b350aa66d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

