### PR TITLE
release: v1.6.10 — clear three high advisories from the lockfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.6.10](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.6.10) (2026-08-17)
+
+### Security
+
+* **three high-severity advisories cleared from the lockfile.** None of the three reach a Grafana instance — `nanoid` arrives through `postcss`, and both `js-yaml` lines through `eslint` and `jest`, so all of them are build- and test-time tooling that the webpack bundle never includes; the shipped `module.js` contains no code from any of them. They are pinned anyway because the marketplace review reads the lockfile, and the equivalent dev-only findings in **brace-expansion** and **fast-uri** are what blocked the 1.6.5 submission. Pinned: **nanoid** 3.3.18 (GHSA-2v37-7h3g-55p8 / CVE-2026-67213 — custom generators can loop indefinitely when `size` is zero), and **js-yaml** 3.15.1 and 4.3.1 (GHSA-5p4m-2wfm-xmqj — quadratic CPU consumption resolving `!!omap`, where the CVE-2026-59870 fix was never backported to either line). `npm audit` now reports **0 high and 0 critical** findings
+* **dompurify** raised to 3.4.13 (GHSA-55q2-fjhq-7xh7 — an `IN_PLACE` hook removal leaves a detached subtree executable, causing XSS). It reaches the plugin only as a transitive dependency of `@grafana/data`, which Grafana supplies at runtime rather than bundling, so this pin hardens the dependency graph the reviewer inspects rather than the panel itself ([#354](https://github.com/allamiro/grafana-network-weathermap-ng/pull/354))
+* four moderate advisories remain, all in `react-router` by way of `@grafana/ui`. They are externalized at runtime for the same reason as `dompurify` and cannot be resolved without a breaking `@grafana/ui` upgrade, so they are carried forward unchanged
+
+### Notes
+
+* no panel behaviour changes in this release — 1.6.10 is 1.6.9 with a clean lockfile. Maps, dashboards and saved options are untouched
+
 ## [1.6.9](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.6.9) (2026-08-06)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamirsuliman-weathermap-panel",
-      "version": "1.6.9",
+      "version": "1.6.10",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1464,9 +1464,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6416,9 +6416,10 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -10520,9 +10521,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -11232,9 +11233,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "postinstall": "patch-package",
@@ -97,7 +97,7 @@
   "packageManager": "npm@9.6.6",
   "overrides": {
     "serialize-javascript": "7.0.5",
-    "dompurify": "^3.4.12",
+    "dompurify": "^3.4.13",
     "js-cookie": "3.0.8",
     "form-data": "4.0.6",
     "@grafana/ui": {
@@ -108,6 +108,9 @@
     "websocket-driver": "0.7.5",
     "protobufjs": "^7.6.5",
     "fast-uri": "^3.1.5",
+    "nanoid": "^3.3.18",
+    "js-yaml@3": "3.15.1",
+    "js-yaml@4": "4.3.1",
     "brace-expansion": "5.0.9"
   }
 }


### PR DESCRIPTION
Security-only release. **No panel behaviour changes** — 1.6.10 is 1.6.9 with a clean lockfile.

## Why now

1.6.9 is tagged, released and signed, so these cannot go into it. The Grafana catalog is still on **1.6.7**, and the 1.6.9 submission is being held for this PR: the marketplace review reads the lockfile, and the equivalent dev-only `brace-expansion` / `fast-uri` findings are what blocked the 1.6.5 submission. Submitting 1.6.9 with three open high advisories risked another bounce.

## Changes

| Package | Pinned to | Advisory | Reaches the bundle? |
|---|---|---|---|
| `nanoid` | 3.3.18 | GHSA-2v37-7h3g-55p8 / CVE-2026-67213 | No — via `postcss` |
| `js-yaml` (3.x) | 3.15.1 | GHSA-5p4m-2wfm-xmqj | No — via `jest` |
| `js-yaml` (4.x) | 4.3.1 | GHSA-5p4m-2wfm-xmqj | No — via `eslint` |
| `dompurify` | 3.4.13 | GHSA-55q2-fjhq-7xh7 | No — via `@grafana/data` (externalized) |

Verified empirically against the built bundle rather than inferred: `dist/module.js` contains **zero** occurrences of `nanoid`, `js-yaml`, `dompurify` or `react-router`. The webpack config externalizes `@grafana/data`, `@grafana/ui`, `@grafana/runtime`, `react` and `react-dom`, so Grafana supplies those at runtime.

## Result

`npm audit`: **3 high → 0 high, 0 critical**.

Four moderates remain, all `react-router` by way of `@grafana/ui`. Externalized for the same reason as `dompurify`, and not resolvable without a breaking `@grafana/ui` upgrade, so they are carried forward unchanged.

## Verification

- `npm ci` — lockfile installable and in sync
- `npm run build` — compiles clean
- `node scripts/verify-dist.js` — passes
- `dist/plugin.json` → version `1.6.10`

`npm run test:ci` could not be run locally: this host is in FIPS mode, which blocks MD4/MD5 in Node, and Jest's cache-key function requires it. CI covers it.

## Supersedes

Closes #354 — the dompurify 3.4.12 → 3.4.13 bump is folded into this release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Security-only release that clears three high advisories from the lockfile to unblock Grafana Marketplace review. No panel behavior changes; 1.6.10 is 1.6.9 with a clean lockfile.

**Reviewer notes**
- Pin transitive dev-time deps: `nanoid@3.3.18` (via `postcss`), `js-yaml@3.15.1` (via `jest`), `js-yaml@4.3.1` (via `eslint`); override `dompurify@3.4.13` (via `@grafana/data`, externalized).
- None of the above reach the bundle; `@grafana/*`, `react`, and `react-dom` are externalized at runtime. `dist/module.js` contains no `nanoid`, `js-yaml`, or `dompurify`.
- `npm audit`: 3 high → 0 high and 0 critical. Four moderates remain in `react-router` via `@grafana/ui` (externalized), left as-is.
- Bump package version to `1.6.10`; update `CHANGELOG.md`. No migrations or config changes required.

<sup>Written for commit 13576d91f01980cae10091e6334bc8ac3edda004. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

