### PR TITLE
release: v1.6.11 — recognized provenance attestation + patched Go toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.6.11](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.6.11) (2026-08-17)
+
+### Chores
+
+* **the release pipeline now produces a build-provenance attestation the catalog recognizes** ([#305](https://github.com/allamiro/grafana-network-weathermap-ng/pull/305)): the 1.6.10 submission came back with `no-provenance-attestation` — "this plugin was built without build verification" — even though the workflow already ran `actions/attest-build-provenance`. The validator checks for an attestation in the specific shape Grafana's own tooling emits, so a hand-rolled step does not count no matter how correct the SLSA statement is. Building through `grafana/plugin-actions/build-plugin` produces it in the expected form. Tests, the `verify-dist.js` packaging check and the community-signature assertion all still gate the release — `build-plugin` runs none of them itself, so they now sit in a `test` job the release job depends on, and the packaged zip is still rejected if it carries no community `MANIFEST.txt`. Two consequences worth knowing: the checksum published alongside the zip is now **SHA1** rather than MD5, and the GitHub release is created as a **draft** to be published after review
+* **exporter Go toolchain raised to 1.26.6** ([#298](https://github.com/allamiro/grafana-network-weathermap-ng/issues/298)): the catalog's `govulncheck` source scan reported three reachable stdlib advisories — GO-2026-5972 / CVE-2026-33818 (`encoding/asn1` recursion depth), GO-2026-6089 / CVE-2026-56853 (`net/http` not applying `ReadHeaderTimeout` to the unencrypted HTTP/2 check) and GO-2026-6090 / CVE-2026-56862 (`crypto/tls` post-handshake message limits), all fixed in 1.25.13 and 1.26.6. The `go` directive moves only to **1.25.13**, the patched release on the line it was already on, rather than to 1.26.6: the validator's runner uses `GOTOOLCHAIN=local`, and a directive above its own version turns the scan from a warning into a hard failure, which is exactly what happened when this was last set to 1.26.5. The `toolchain` directive carries the 1.26.6 recommendation. None of this reaches a Grafana instance — the module is the simulated-WAN Prometheus exporter behind the demo dashboards and is not part of the panel
+
 ## [1.6.10](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.6.10) (2026-08-17)
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.6.10",
+  "version": "1.6.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamirsuliman-weathermap-panel",
-      "version": "1.6.10",
+      "version": "1.6.11",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.6.10",
+  "version": "1.6.11",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "postinstall": "patch-package",

--- a/testing/exporter/go.mod
+++ b/testing/exporter/go.mod
@@ -1,8 +1,8 @@
 module github.com/allamiro/wm-prometheus
 
-go 1.25.12
+go 1.25.13
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/aquilax/go-perlin v1.1.0


### PR DESCRIPTION
Addresses both warnings from the **1.6.10** Grafana catalog validation report. No panel behaviour changes.

## `no-provenance-attestation`

> No provenance attestation. This plugin was built without build verification

The workflow already ran `actions/attest-build-provenance`, so the SLSA statement existed — but the validator only recognizes an attestation produced by Grafana's own tooling. Merging #305 moves the release to `grafana/plugin-actions/build-plugin@build-plugin/v1.2.0` with `attestation: true`.

`build-plugin` runs no tests of its own, so the existing gates were preserved rather than dropped:

- `npm ci`, `npm run test:ci`, `npm run build` and `scripts/verify-dist.js` now run in a `test` job that `release` depends on
- the packaged zip is still rejected if it lacks a community `MANIFEST.txt`
- `CHANGELOG.md` still supplies the release notes

**Two behaviour changes to be aware of:** the published checksum is now **SHA1** instead of MD5, and the GitHub release is created as a **draft** that must be published after review.

## `govulncheck-issue-found`

> govulncheck source scan reports 3 reachable vulnerabilities — update Go toolchain to 1.26.6 or later

| Advisory | CVE | Package |
|---|---|---|
| GO-2026-5972 | CVE-2026-33818 | `encoding/asn1` — recursion depth |
| GO-2026-6089 | CVE-2026-56853 | `net/http` — `ReadHeaderTimeout` on the unencrypted HTTP/2 check |
| GO-2026-6090 | CVE-2026-56862 | `crypto/tls` — post-handshake message limits |

All three are stdlib, fixed in **1.25.13** and **1.26.6**.

```diff
-go 1.25.12
-toolchain go1.26.5
+go 1.25.13
+toolchain go1.26.6
```

The `go` directive deliberately moves only to **1.25.13**, not 1.26.6. Per #298, the validator's runner uses `GOTOOLCHAIN=local`, and a `go` directive above its own version turns the scan from a warning into a *hard failure* — exactly what happened when this was last set to 1.26.5. 1.25.13 is the patched release on the line it already used, so it stays loadable by an older runner while clearing all three advisories. The `toolchain` directive carries Grafana's 1.26.6 recommendation.

Worth setting expectations: #298 also established that govulncheck evaluates the stdlib of *the toolchain running the scan*, not the directive, so this warning can persist if Grafana's own runner is on a vulnerable patch. It is a Warning, not a Failure.

The module is the simulated-WAN Prometheus exporter behind the demo dashboards — it is not part of the shipped panel and never enters the zip.

## Verification

- `npm run build` — compiles clean
- `node scripts/verify-dist.js` — passes
- `dist/plugin.json` → version `1.6.11`
- `go1.25.13` and `go1.26.6` both confirmed as published Go releases

`npm run test:ci` cannot run on the dev host (FIPS mode blocks MD5, which Jest's cache-key function requires). CI covers it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes v1.6.11 with a Grafana‑recognized build provenance and patches the demo exporter’s Go toolchain to clear govulncheck warnings. No panel behavior changes.

**Notes for review and rollout**
- Build now uses `grafana/plugin-actions/build-plugin@build-plugin/v1.2.0` with `attestation: true`; tests and `scripts/verify-dist.js` run in a `test` job that gates `release`, and the community `MANIFEST.txt` check remains.
- Behavior changes: checksum output is now SHA1 (was MD5), and the GitHub release is created as a draft. Action: publish the draft after validation.
- `testing/exporter` updates to `go 1.25.13` and `toolchain go1.26.6` to address GO-2026-5972/6089/6090; the `go` directive stays on 1.25.13 to avoid validator hard‑fail with `GOTOOLCHAIN=local`. The exporter is demo-only and not shipped in the plugin ZIP.
- Bumps version to 1.6.11 in `package.json`, `package-lock.json`, and updates `CHANGELOG.md`.

<sup>Written for commit 70c874db946dae40500bd3e0ae4e47a9154e6122. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

