### PR TITLE
release: v1.6.12 — Grafana plugin review fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.6.12](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.6.12) (2026-08-17)
+
+### Fixed
+
+* **link animations can no longer collide with another plugin's**: the flow and blink animations were emitted as raw `<style>` tags declaring `@keyframes link-flow-forward` and `@keyframes link-blink`. Animation names are global to the page, not scoped to the element that uses them, so any other panel on the same dashboard declaring an animation by either of those names would silently redefine ours — or have ours redefine theirs — with the winner decided by mount order. Both are now built with Emotion's `keyframes()` helper, which hashes the rule body into a unique `animation-<hash>` name, so a collision is impossible regardless of what else is on the dashboard. The animations themselves are unchanged
+* **the export anchor is rendered by React instead of being spliced into the document**: SVG and JSON export created an `<a>`, appended it to `document.body`, clicked it and removed it. That mutates the document outside the component's own subtree, and an unmount or a throw between the append and the remove would leave the node stranded in the DOM. The anchor is now part of the form's JSX and is driven through a `useRef`, so React owns its lifetime and it disappears with the component
+
+### Chores
+
+* **panel styling uses Grafana's theme tokens instead of literal values**: the data-notice banner, both hover tooltips, the animation and status legends, and the colour scale carried hard-coded pixel sizes, `z-index: 9999` / `10000`, and in one case a literal `rgba(204, 204, 220, 0.25)` border that could not follow a light/dark switch at all. These now read from `theme.spacing()`, `theme.shape.radius.default`, `theme.typography.bodySmall.fontSize`, `theme.zIndex` and `theme.colors`. The notice maps to `theme.zIndex.tooltip` and the hover tooltips to `theme.zIndex.portal`, preserving the stacking order the old 9999/10000 pair produced. Two `z-index: 2` values are deliberately left as-is: they stack an element directly above the map SVG rather than acting as an overlay layer, and no theme token expresses that. One visual nuance worth noting — `theme.shape.radius.default` is 2px where the literals were 4px, so those corners are slightly less rounded, which is the point of deferring to the theme
+
 ## [1.6.11](https://github.com/allamiro/grafana-network-weathermap-ng/releases/tag/v1.6.11) (2026-08-17)
 
 ### Chores

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.6.11",
+  "version": "1.6.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tamirsuliman-weathermap-panel",
-      "version": "1.6.11",
+      "version": "1.6.12",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tamirsuliman-weathermap-panel",
-  "version": "1.6.11",
+  "version": "1.6.12",
   "description": "A modernized, actively maintained network weathermap plugin for Grafana. Continuation of the original knightss27-weathermap-panel.",
   "scripts": {
     "postinstall": "patch-package",

--- a/src/WeathermapPanel.tsx
+++ b/src/WeathermapPanel.tsx
@@ -25,7 +25,7 @@ import {
   NodeTooltipMetric,
   Threshold,
 } from 'types';
-import { css, cx } from '@emotion/css';
+import { css, cx, keyframes } from '@emotion/css';
 import {
   Button,
   LegendDisplayMode,
@@ -78,6 +78,26 @@ import {
 } from 'utils';
 import MapNode from './components/MapNode';
 import ColorScale from 'components/ColorScale';
+
+// Link animations used to be emitted as raw <style> tags holding global
+// `@keyframes link-flow-forward` / `link-blink` rules. A global animation name
+// is shared by every stylesheet on the page, so a second plugin defining an
+// animation of the same name on the same dashboard would silently redefine
+// ours (or we would redefine theirs), depending on which mounted last.
+//
+// Emotion's keyframes() hashes the rule body into a unique name
+// (`animation-<hash>`) and inserts the @keyframes into its own stylesheet as
+// soon as this module loads, so the name below can be used directly in the
+// inline `animation` shorthand and cannot collide with anything.
+const linkFlowForwardAnimation = keyframes`
+  from { stroke-dashoffset: 15; }
+  to { stroke-dashoffset: 0; }
+`;
+
+const linkBlinkAnimation = keyframes`
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.15; }
+`;
 
 // Calculate node position, width, etc.
 function generateDrawnNode(d: Node, i: number, wm: Weathermap): DrawnNode {
@@ -1237,15 +1257,20 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
             data-testid="weathermap-data-notice"
             className={css`
               position: absolute;
-              top: 8px;
+              top: ${theme.spacing(1)};
               left: 50%;
               transform: translateX(-50%);
               max-width: 90%;
-              z-index: 9999;
+              /*
+                Was a literal 9999. theme.zIndex.tooltip keeps the notice above
+                the map while staying below the hover tooltips (portal), which
+                is the same order the old 9999 / 10000 pair produced.
+              */
+              z-index: ${theme.zIndex.tooltip};
               pointer-events: none;
-              padding: 6px 12px;
-              border-radius: 4px;
-              font-size: 12px;
+              padding: ${theme.spacing(0.75, 1.5)};
+              border-radius: ${theme.shape.radius.default};
+              font-size: ${theme.typography.bodySmall.fontSize};
               text-align: center;
               box-shadow: ${theme.shadows.z1};
               background-color: ${dataNotice.level === 'error'
@@ -1275,11 +1300,11 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
               background-color: ${wm.settings.tooltip.backgroundColor};
               color: ${wm.settings.tooltip.textColor} !important;
               font-size: ${wm.settings.tooltip.fontSize} !important;
-              z-index: 10000;
+              z-index: ${theme.zIndex.portal};
               display: ${hoveredLink ? 'flex' : 'none'};
               flex-direction: column;
               padding: ${wm.settings.tooltip.fontSize}px;
-              border-radius: 4px;
+              border-radius: ${theme.shape.radius.default};
               border: 1px solid
                 ${getScaleColor(
                   hoveredLink.link.sides[hoveredLink.side].currentValue,
@@ -1479,11 +1504,11 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
               background-color: ${wm.settings.tooltip.backgroundColor};
               color: ${wm.settings.tooltip.textColor} !important;
               font-size: ${wm.settings.tooltip.fontSize} !important;
-              z-index: 10000;
+              z-index: ${theme.zIndex.portal};
               display: flex;
               flex-direction: column;
               padding: ${wm.settings.tooltip.fontSize}px;
-              border-radius: 4px;
+              border-radius: ${theme.shape.radius.default};
               border: 1px solid ${theme.colors.border.medium};
             `}
           >
@@ -1530,12 +1555,14 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
               position: absolute;
               bottom: 1%;
               left: 1%;
+              /* Local stacking above the map SVG only — not an overlay layer,
+                 so no theme.zIndex token applies. */
               z-index: 2;
-              padding: 6px 10px;
-              border-radius: 4px;
+              padding: ${theme.spacing(0.75, 1.25)};
+              border-radius: ${theme.shape.radius.default};
               background-color: ${theme.colors.background.secondary};
               border: 1px solid ${theme.colors.border.weak};
-              font-size: 12px;
+              font-size: ${theme.typography.bodySmall.fontSize};
               pointer-events: none;
               color: ${theme.colors.text.primary};
             `}
@@ -1582,12 +1609,14 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
               position: absolute;
               top: ${wm.settings.statusLegend.position.y}%;
               left: ${wm.settings.statusLegend.position.x}%;
+              /* Local stacking above the map SVG only — not an overlay layer,
+                 so no theme.zIndex token applies. */
               z-index: 2;
-              padding: 6px 10px;
-              border-radius: 4px;
+              padding: ${theme.spacing(0.75, 1.25)};
+              border-radius: ${theme.shape.radius.default};
               background-color: ${theme.colors.background.secondary};
               border: 1px solid ${theme.colors.border.weak};
-              font-size: 12px;
+              font-size: ${theme.typography.bodySmall.fontSize};
               pointer-events: none;
             `}
             data-testid="status-legend"
@@ -1694,22 +1723,6 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                   opacity={1}
                 />
               </pattern>
-            )}
-            {wm.settings.link.flowAnimation?.enabled && (
-              <style>{`
-                @keyframes link-flow-forward {
-                  from { stroke-dashoffset: 15; }
-                  to { stroke-dashoffset: 0; }
-                }
-              `}</style>
-            )}
-            {links.some((d) => d.isDown && d.statusBlink) && (
-              <style>{`
-                @keyframes link-blink {
-                  0%, 100% { opacity: 1; }
-                  50% { opacity: 0.15; }
-                }
-              `}</style>
             )}
             {wm.settings.link.gradientColor &&
               resolvedLinks.map((d) => {
@@ -1886,11 +1899,11 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                       style={{
                         ...(d.sides.A.dashboardLink.length > 0 ? { cursor: 'pointer' } : {}),
                         ...(d.isDown && d.statusBlink
-                          ? { animation: 'link-blink 1s ease-in-out infinite' }
+                          ? { animation: `${linkBlinkAnimation} 1s ease-in-out infinite` }
                           : wm.settings.link.flowAnimation?.enabled
                           ? {
                               strokeDasharray: '10 5',
-                              animation: `link-flow-forward ${wm.settings.link.flowAnimation.speed}s linear infinite`,
+                              animation: `${linkFlowForwardAnimation} ${wm.settings.link.flowAnimation.speed}s linear infinite`,
                             }
                           : {}),
                       }}
@@ -1964,11 +1977,11 @@ export const WeathermapPanel: React.FC<PanelProps<SimpleOptions>> = (props: Pane
                           style={{
                             ...(d.sides.Z.dashboardLink.length > 0 ? { cursor: 'pointer' } : {}),
                             ...(d.isDown && d.statusBlink
-                              ? { animation: 'link-blink 1s ease-in-out infinite' }
+                              ? { animation: `${linkBlinkAnimation} 1s ease-in-out infinite` }
                               : wm.settings.link.flowAnimation?.enabled
                               ? {
                                   strokeDasharray: '10 5',
-                                  animation: `link-flow-forward ${wm.settings.link.flowAnimation.speed}s linear infinite`,
+                                  animation: `${linkFlowForwardAnimation} ${wm.settings.link.flowAnimation.speed}s linear infinite`,
                                 }
                               : {}),
                           }}

--- a/src/components/ColorScale.tsx
+++ b/src/components/ColorScale.tsx
@@ -1,5 +1,5 @@
 import { useStyles2, useTheme2 } from '@grafana/ui';
-import { getValueFormat } from '@grafana/data';
+import { getValueFormat, GrafanaTheme2 } from '@grafana/data';
 import { css, cx } from '@emotion/css';
 import React from 'react';
 import { Threshold, WeathermapSettings } from 'types';
@@ -75,8 +75,8 @@ const ColorScale: React.FC<ColorScaleProps> = (props: ColorScaleProps) => {
           settings.scale.backgroundColor
             ? css`
                 background: ${settings.scale.backgroundColor};
-                border: 1px solid rgba(204, 204, 220, 0.25);
-                border-radius: 4px;
+                border: 1px solid ${theme.colors.border.weak};
+                border-radius: ${theme.shape.radius.default};
               `
             : css``
         )}
@@ -145,27 +145,35 @@ const ColorScale: React.FC<ColorScaleProps> = (props: ColorScaleProps) => {
   }
 };
 
-const getStyles = () => {
+const getStyles = (theme: GrafanaTheme2) => {
   return {
     colorScaleContainer: css`
       position: relative;
-      padding: 10px;
+      padding: ${theme.spacing(1.25)};
       display: flex;
       flex-direction: column;
-      color: black;
+      /*
+        Inherited only: the title and every threshold label set their own color
+        (an explicit fontColor, or automatic contrast against the panel
+        background). This is the fallback for anything that does not, and is a
+        theme token rather than a literal so it follows light/dark switching.
+      */
+      color: ${theme.colors.text.primary};
+      /* Local stacking above the map SVG — not an overlay layer, so no
+         theme.zIndex token applies. */
       z-index: 2;
       width: fit-content;
     `,
     colorBoxTitle: css`
       font-weight: bold;
-      padding: 5px 0px;
+      padding: ${theme.spacing(0.625, 0)};
     `,
     colorScaleItem: css`
       display: flex;
       align-items: center;
     `,
     colorBox: css`
-      margin-right: 5px;
+      margin-right: ${theme.spacing(0.625)};
     `,
     colorLabel: css`
       line-height: normal;

--- a/src/forms/ExportForm.test.tsx
+++ b/src/forms/ExportForm.test.tsx
@@ -27,6 +27,30 @@ test('SVG export does not crash when the SVG element is missing', async () => {
   expect(createObjectURL).not.toHaveBeenCalled();
 });
 
+test('the download anchor is owned by React and no stray node is left in the document', async () => {
+  const value = getData(theme);
+  const props = { value, onChange: jest.fn() } as unknown as StandardEditorProps<Weathermap>;
+  const { container, unmount } = render(<ExportForm {...props} />);
+
+  // The anchor is part of the component's own subtree rather than something
+  // appended to document.body behind React's back.
+  const anchors = container.querySelectorAll('a');
+  expect(anchors).toHaveLength(1);
+
+  const anchorCountBefore = document.querySelectorAll('a').length;
+  fireEvent.click(screen.getByText('Export JSON'));
+  await new Promise((r) => setTimeout(r, 0));
+
+  // Exporting reuses that one anchor: it neither appends nor leaks a node.
+  expect(document.querySelectorAll('a')).toHaveLength(anchorCountBefore);
+  expect(anchors[0].getAttribute('download')).toContain('network-weathermap-');
+
+  // And unmounting takes the anchor with it, which an imperatively appended
+  // node would not have done.
+  unmount();
+  expect(document.querySelectorAll('a')).toHaveLength(anchorCountBefore - 1);
+});
+
 describe('SVG export URL handling (#203)', () => {
   const setupSvg = (value: Weathermap, hrefs: string[]) => {
     const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');

--- a/src/forms/ExportForm.tsx
+++ b/src/forms/ExportForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { InlineFieldRow, Button, useStyles2 } from '@grafana/ui';
 import { GrafanaTheme2, StandardEditorProps } from '@grafana/data';
 import { Weathermap } from 'types';
@@ -11,15 +11,21 @@ interface Props extends StandardEditorProps<Weathermap, Settings> {}
 export const ExportForm = ({ value, onChange }: Props) => {
   const styles = useStyles2(getStyles);
 
-  const generateDownloadLink = (href: string, download: string) => {
-    let downloadLink = document.createElement('a');
-    downloadLink.href = href;
-    downloadLink.download = download;
-    downloadLink.target = '_blank';
+  // The download anchor is part of this component's own JSX (below) and is
+  // driven through a ref. It used to be created, appended to document.body,
+  // clicked and removed imperatively — that reaches outside the component's
+  // subtree and mutates the document behind React's back, so an unmount or an
+  // exception between append and remove would strand the node in the DOM.
+  const downloadRef = useRef<HTMLAnchorElement>(null);
 
-    document.body.appendChild(downloadLink);
-    downloadLink.click();
-    document.body.removeChild(downloadLink);
+  const generateDownloadLink = (href: string, download: string) => {
+    const anchor = downloadRef.current;
+    if (!anchor) {
+      return;
+    }
+    anchor.href = href;
+    anchor.download = download;
+    anchor.click();
   };
 
   const handleSVGExport = async () => {
@@ -89,6 +95,12 @@ export const ExportForm = ({ value, onChange }: Props) => {
             Export JSON
           </Button>
         </InlineFieldRow>
+        {/*
+          Hidden, but rendered and owned by React. href/download are set on it
+          immediately before the programmatic click; a display:none anchor still
+          activates via HTMLElement.click().
+        */}
+        <a ref={downloadRef} className={styles.downloadAnchor} target="_blank" rel="noreferrer" aria-hidden="true" />
       </React.Fragment>
     );
   } else {
@@ -104,6 +116,9 @@ const getStyles = (theme: GrafanaTheme2) => {
     `,
     exportJSONButton: css`
       margin: ${theme.spacing(1)} 0;
+    `,
+    downloadAnchor: css`
+      display: none;
     `,
   };
 };


### PR DESCRIPTION
Addresses all three issues raised in the Grafana plugin review of **v1.6.11**.

## 1. Unscoped global `@keyframes`

> `link-flow-forward` / `link-blink` are injected via raw `<style>` tags, which can collide with a same-named animation from another plugin on the same dashboard page.

Animation names are global to the page, not scoped to the element using them, so whichever plugin mounted last would win. Both animations now use Emotion's `keyframes()` helper:

```js
const linkFlowForwardAnimation = keyframes`
  from { stroke-dashoffset: 15; }
  to { stroke-dashoffset: 0; }
`;
```

`keyframes()` hashes the rule body into a unique `animation-<hash>` name and inserts the `@keyframes` into Emotion's own stylesheet at module load, so the returned name works directly in the existing inline `animation` shorthand — no change to how the animation is applied, and a collision is now impossible. The two raw `<style>` tags are gone.

Verified in the built bundle: `link-flow-forward` and `link-blink` no longer appear anywhere in `dist/module.js`, and `keyframes` resolves from the Grafana-provided external `@emotion/css`.

## 2. DOM access outside component lifecycle

> `generateDownloadLink()` creates and appends an element to `document.body` imperatively instead of through React.

The anchor is now rendered in the component's own JSX and driven via `useRef`:

```jsx
<a ref={downloadRef} className={styles.downloadAnchor} target="_blank" rel="noreferrer" aria-hidden="true" />
```

`generateDownloadLink()` sets `href`/`download` on the ref and clicks it. A `display: none` anchor still activates via `HTMLElement.click()`. React now owns the node's lifetime, so an unmount or a throw can no longer strand it in the DOM.

Covered by a new test: the anchor is in the component subtree, exporting neither appends nor leaks a node, and unmounting removes it.

## 3. Hardcoded CSS values

> Several components (e.g. the notice banner) use literal pixel/z-index values instead of Grafana's theme tokens.

Converted across the data-notice banner, both hover tooltips, the animation legend, the status legend and the colour scale:

| Was | Now |
|---|---|
| `top: 8px`, `padding: 6px 12px`, `padding: 6px 10px`, `padding: 10px`, `5px` | `theme.spacing(...)` |
| `border-radius: 4px` | `theme.shape.radius.default` |
| `font-size: 12px` | `theme.typography.bodySmall.fontSize` |
| `z-index: 9999` (notice) | `theme.zIndex.tooltip` |
| `z-index: 10000` (tooltips) | `theme.zIndex.portal` |
| `border: 1px solid rgba(204, 204, 220, 0.25)` | `theme.colors.border.weak` |
| `color: black` | `theme.colors.text.primary` |

The `rgba()` border and `color: black` were the two that could not follow a light/dark switch at all.

**Two deliberate non-changes**, called out so they don't read as misses:

- Two `z-index: 2` values are kept. They stack an element directly above the map SVG rather than acting as an overlay layer, and no `theme.zIndex` token expresses "just above my sibling" — the smallest is `activePanel: 999`. Comments explain this inline.
- `theme.shape.radius.default` is **2px** where the literals were 4px, so those corners are slightly less rounded. That is the intended consequence of deferring to the theme.

Stacking order is preserved: the notice sits below the hover tooltips, exactly as the old 9999/10000 pair did.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm run build` — compiles; `node scripts/verify-dist.js` passes
- Confirmed the old global animation names are absent from the built bundle

`npm run test:ci` cannot run on the dev host (FIPS mode blocks MD5, which Jest's cache-key function requires). CI covers it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three v1.6.11 review issues: scopes link animations to prevent cross-plugin collisions, renders the export download anchor within React to avoid unsafe DOM mutation, and replaces hardcoded CSS with Grafana theme tokens. Old vs new behavior: global `@keyframes` names are now hashed via `keyframes()` from `@emotion/css`; the export anchor was imperatively appended to `document.body` and is now a hidden JSX element triggered via a ref; literal sizes/z-indexes now read from theme tokens, preserving stacking order, with corners slightly less rounded (2px).

**What to review**
- Animations: raw `<style>` tags removed; `link-blink` and flow now use `keyframes()`; verify `dist` no longer contains `link-flow-forward`/`link-blink` and animations behave unchanged (WeathermapPanel).
- Export: anchor moved into JSX with a `ref`; exporting sets `href`/`download` and clicks it; test asserts no stray nodes and unmount cleans up (`ExportForm` and `ExportForm.test.tsx`).
- Styling: data notice, tooltips, legends, and color scale use `theme.spacing`, `theme.shape.radius.default`, `theme.typography.bodySmall.fontSize`, `theme.colors`, and `theme.zIndex`; notice maps to `theme.zIndex.tooltip`, tooltips to `theme.zIndex.portal`; two `z-index: 2` values intentionally kept for local stacking; expect 2px corner radius where 4px was used before.

<sup>Written for commit 8e91901b1f33903fbb1d4ab37c0051d289c63375. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/allamiro/grafana-network-weathermap-ng/pull/357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

